### PR TITLE
Use depth and key when replacing hash table entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,10 @@ The program does not accept posix style arguments it will immediately start in U
   - fail low (alpha) nodes are never stored in the transposition table, only exact and beta nodes
   - transposition table scores don't account for repetition or fifty move history, make_move_str
     clears the key for played moves as a workaround
-  - hash table replacement doesn't compare entry depth and protects exact entries even when the
-    stored key is for a different position
-  - the replacement strategy change in 0b858f8 uses game ply rather than depth despite its title,
-    and dropped the same key guard added by the earlier collision fixes (51657b2, 6b2aac6)
+  - hash table size is only configurable from code, there is no UCI Hash option, so every engine
+    allocates the 500MB default
   - history array is fixed at 375 plies and ply is initialised to twice the full move number, so
     very long games can overflow it
-  - each engine instance allocates a 500MB hash table up front (including in tests)
-  - quiescence stand pat raises alpha on score >= alpha instead of score > alpha
-  - pv_line panics if the root entry has been evicted from the hash table
   - en passant is hashed for every double pawn push, even when no capture is possible, which
     slightly reduces transposition hits
 - perft command from uci

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -8,6 +8,7 @@ use std::time;
 
 const CHECKMATE_SCORE: i64 = 800_000;
 const MAX_DEPTH: u8 = 20;
+const DEFAULT_TABLE_BYTES: usize = 500 * 1024 * 1024;
 // Any score this close to CHECKMATE_SCORE is a forced mate. Regular evals are
 // bounded by material values which are orders of magnitude smaller.
 const CHECKMATE_THRESHOLD: i64 = CHECKMATE_SCORE - 1000;
@@ -155,6 +156,20 @@ pub struct AlphaBeta {
 }
 
 impl AlphaBeta {
+    pub fn with_table_bytes(board: Board, bytes: usize) -> Self {
+        Self {
+            board,
+            nodes: 0,
+            score: 0,
+            moves: HashTable::with_capacity_bytes(bytes),
+            search_depth: 0,
+            selective_depth: 0,
+            start_time: time::Instant::now(),
+            search_duration: None,
+            should_stop: false,
+        }
+    }
+
     fn eval(&self) -> i64 {
         self.board.eval()
     }
@@ -437,19 +452,21 @@ impl HashTable {
 
     fn set(&mut self, key: u64, pv: Pv) {
         let index = (key % self.capacity as u64) as usize;
-        if let Some((old_pv, _)) = self.table[index] {
-            // if new is exact and old isn't replace
-            if matches!(pv.node, Node::Exact) {
-                self.table[index] = Some((pv, key));
-                return;
-            } else if !matches!(old_pv.node, Node::Exact) {
-                self.table[index] = Some((pv, key));
-                return;
-            } else if (pv.ply as isize - old_pv.ply as isize) > (MAX_DEPTH as isize + 3) {
-                self.table[index] = Some((pv, key));
-                return;
+        if let Some((old_pv, old_key)) = self.table[index] {
+            // entries left over from an earlier point in the game are always replaced
+            let stale = (pv.ply as isize - old_pv.ply as isize) > (MAX_DEPTH as isize + 3);
+            if !stale {
+                if pv.depth < old_pv.depth {
+                    return;
+                }
+                if pv.depth == old_pv.depth
+                    && old_key == key
+                    && matches!(old_pv.node, Node::Exact)
+                    && !matches!(pv.node, Node::Exact)
+                {
+                    return;
+                }
             }
-            return;
         }
         self.table[index] = Some((pv, key));
     }
@@ -604,6 +621,24 @@ mod test_search {
     }
 
     #[test]
+    fn test_small_table_matches_large_table() {
+        // a table small enough to force constant collisions must not change the result
+        let fen = "r1b2rk1/ppp1qppp/4pn2/6N1/Qn1P4/2NBP3/PP3PPP/R3K2R w KQ - 9 12";
+        let mut big = <AlphaBeta as Engine>::new(Board::from_fen(fen).unwrap());
+        let expected = big.search(5).unwrap();
+        let mut small = AlphaBeta::with_table_bytes(Board::from_fen(fen).unwrap(), 8 * 1024);
+        let result = small.search(5).unwrap();
+        assert_eq!(result.score, expected.score);
+    }
+
+    #[test]
+    fn test_pv_line_without_cache_entry() {
+        let game = Board::new();
+        let e = <AlphaBeta as Engine>::new(game);
+        assert_eq!(format!("{}", e.pv_line()), "");
+    }
+
+    #[test]
     fn test_stopped_search_does_not_poison_cache() {
         let fen = "r1b2rk1/ppp1qppp/4pn2/6N1/Qn1P4/2NBP3/PP3PPP/R3K2R w KQ - 9 12";
         let game = Board::from_fen(fen).unwrap();
@@ -661,10 +696,7 @@ mod test_hash_table {
         assert!(matches!(table.get(1).unwrap().node, Node::Exact));
     }
 
-    // TODO known issue (see README): replacement never compares depth so a shallower exact entry
-    // replaces a deeper one for the same position
     #[test]
-    #[ignore = "known issue: replacement strategy does not compare entry depth"]
     fn test_deeper_exact_entry_survives_shallower_exact_entry() {
         let mut table = HashTable::with_capacity(1);
         table.set(1, new_pv(Node::Exact, 8, 1));
@@ -672,31 +704,43 @@ mod test_hash_table {
         assert_eq!(table.get(1).unwrap().depth, 8);
     }
 
-    // TODO known issue (see README): an exact entry blocks non-exact stores even when the stored
-    // key is for a different position, so colliding positions can never enter the table
     #[test]
-    #[ignore = "known issue: exact entries block stores for other positions in the same slot"]
-    fn test_exact_entry_does_not_block_other_positions() {
+    fn test_deeper_entry_replaces_exact_entry_for_another_position() {
+        let mut table = HashTable::with_capacity(1);
+        table.set(1, new_pv(Node::Exact, 1, 1));
+        table.set(2, new_pv(Node::Beta, 8, 1));
+        assert!(table.get(2).is_some());
+        assert!(table.get(1).is_none());
+    }
+
+    #[test]
+    fn test_shallower_entry_does_not_evict_deeper_entry_for_another_position() {
+        let mut table = HashTable::with_capacity(1);
+        table.set(1, new_pv(Node::Beta, 8, 1));
+        table.set(2, new_pv(Node::Exact, 1, 1));
+        assert_eq!(table.get(1).unwrap().depth, 8);
+    }
+
+    #[test]
+    fn test_quiescence_entry_does_not_evict_searched_entry() {
+        let mut table = HashTable::with_capacity(1);
+        table.set(1, new_pv(Node::Exact, 5, 1));
+        table.set(2, new_pv(Node::Ordering, 0, 1));
+        assert_eq!(table.get(1).unwrap().depth, 5);
+    }
+
+    #[test]
+    fn test_stale_entry_is_replaced_regardless_of_depth() {
         let mut table = HashTable::with_capacity(1);
         table.set(1, new_pv(Node::Exact, 8, 1));
-        table.set(2, new_pv(Node::Beta, 1, 1));
+        table.set(2, new_pv(Node::Beta, 1, 100));
         assert!(table.get(2).is_some());
     }
 }
 
 impl Engine for AlphaBeta {
     fn new(board: Board) -> Self {
-        Self {
-            board,
-            nodes: 0,
-            score: 0,
-            moves: HashTable::with_capacity_bytes(500 * 1024 * 1024),
-            search_depth: 0,
-            selective_depth: 0,
-            start_time: time::Instant::now(),
-            search_duration: None,
-            should_stop: false,
-        }
+        AlphaBeta::with_table_bytes(board, DEFAULT_TABLE_BYTES)
     }
 
     fn perft(&mut self) {
@@ -764,16 +808,15 @@ impl Engine for AlphaBeta {
     }
 
     fn pv_line(&self) -> PvLine {
-        let mut pv_line = Vec::new();
-        let mut pv = self.moves.get(self.board.key).unwrap();
-        pv_line.push(pv.play);
-        while let Some(next) = self.moves.get(pv.next_key) {
-            pv_line.push(next.play);
-            pv = next;
-            if pv_line.len() >= 16 {
+        let mut line = Vec::new();
+        let mut key = self.board.key;
+        while let Some(pv) = self.moves.get(key) {
+            line.push(pv.play);
+            key = pv.next_key;
+            if line.len() >= 16 {
                 break; // TODO resolve hash colisions to prevent errors here
             }
         }
-        PvLine { line: pv_line }
+        PvLine { line }
     }
 }


### PR DESCRIPTION
Follow up to #11, clearing the remaining hash table issues from the README list.

## Replacement strategy

The strategy added in 0b858f8 never compared entry depth despite its title, and dropped the same key guard added by the earlier collision fixes (51657b2, 6b2aac6). Two consequences:

- a shallow exact entry replaced a deeper exact entry for the same position, throwing away the more expensive search
- an exact entry blocked every non-exact store for **any other position** sharing its slot until it aged out, so a depth 1 exact entry could keep a depth 9 entry out of the table indefinitely

Replacement is now depth preferred: the old entry is kept only when it searched deeper, with the existing ply based aging applied first so entries from earlier in the game are still discarded. The two tests that were added as ignored in #11 now pass and are enabled, along with tests for depth preference across positions, quiescence entries not evicting searched entries, and aged out entries being replaced regardless of depth.

## Other fixes

- `pv_line` no longer panics when the root entry has been evicted from the table
- hash table size is configurable via `AlphaBeta::with_table_bytes`, which allows testing a search against a table small enough to collide constantly (`test_small_table_matches_large_table` runs a depth 5 search through an 8KB table and gets the same score as the 500MB default)

## Measurements

Depth 7, total nodes across all iterations, compared against master:

| position | nodes before | nodes after | |
|---|---|---|---|
| initial | 629,766 | 626,454 | -0.5% |
| kiwipete | 4,186,998 | 4,187,263 | +0.0% |
| position 3 | 298,273 | 234,033 | -21.5% |
| position 4 | 4,418,913 | 4,365,419 | -1.2% |
| regression | 1,744,411 | 1,612,283 | -7.6% |
| **total** | **11,278,361** | **11,025,452** | **-2.2%** |

Scores and best moves are identical throughout, so this is ordering and cutoff efficiency only. The gain is modest because a 500MB table holds ~9.4M entries and these searches barely collide, so replacement rarely fires — it matters most in long games and when the table is under pressure, which is what the small table test now covers.

## Not addressed

Still open from the README list: fail low (alpha) nodes are never stored, transposition scores don't account for repetition or fifty move history, there is no UCI Hash option, the history array can overflow in very long games, and en passant is hashed on every double push.

Also worth noting: the README previously listed the quiescence stand pat `>=` as an issue. It isn't one — `alpha = score` when `score == alpha` is a no-op, so the entry has been removed rather than "fixed".