### PR TITLE
Open a pull request to release rather than pushing to master

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,8 +1,8 @@
 name: Prepare release
 
-# Cuts a release from the actions tab. Bumps the version, writes the changelog,
-# tags, and hands over to the release workflow, which is everything that
-# otherwise has to be done by hand on a laptop.
+# Starts a release from the actions tab. Bumps the version and writes the
+# changelog, then opens a pull request with the result. Merging that pull
+# request is what tags and releases it, see tag-release.yml.
 
 on:
   workflow_dispatch:
@@ -20,8 +20,7 @@ on:
 
 permissions:
   contents: write
-  # needed to start the release workflow at the end
-  actions: write
+  pull-requests: write
 
 # releases are not something to run two of at once
 concurrency:
@@ -52,8 +51,8 @@ jobs:
       - name: Install cargo-release
         run: cargo binstall --no-confirm cargo-release
 
-      # the release workflow runs these again, but failing here means no tag is
-      # created at all, rather than one that has to be deleted afterwards
+      # the release workflow runs these again, but failing here means nothing is
+      # created at all, rather than a pull request that has to be closed again
       - name: Run the tests
         run: cargo test --workspace --locked --release
 
@@ -62,41 +61,54 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
 
+      # no tag here, tag-release.yml makes it once this lands, so that it points
+      # at the commit that is on master rather than one on a branch
       - name: Bump the version and write the changelog
-        run: cargo release ${{ inputs.level }} --execute --no-confirm
+        run: cargo release ${{ inputs.level }} --execute --no-confirm --no-tag
 
-      - name: Read the tag that was created
-        id: tag
+      - name: Read the new version
+        id: version
         run: |
-          tag=$(git tag --points-at HEAD)
-          if [ -z "$tag" ]; then
-            echo "::error::cargo-release did not create a tag"
-            exit 1
-          fi
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          version=$(python3 -c "import tomllib; print(tomllib.load(open('Cargo.toml','rb'))['workspace']['package']['version'])")
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "branch=release/v${version}" >> "$GITHUB_OUTPUT"
 
-      # release.toml sets push = false so that a release can be inspected before
-      # it goes anywhere, which is still what happens locally
-      - name: Push the release commit and tag
+      # master only takes changes through a pull request, so the release commit
+      # goes through one like anything else
+      - name: Push the release branch
         run: |
-          git push origin HEAD:master
-          git push origin "${{ steps.tag.outputs.tag }}"
+          git switch -c "${{ steps.version.outputs.branch }}"
+          git push -u origin "${{ steps.version.outputs.branch }}"
 
-      # a tag pushed with GITHUB_TOKEN does not trigger the tag filter on the
-      # release workflow, github suppresses that to avoid workflows setting each
-      # other off. workflow_dispatch is the documented exception, so start it
-      # explicitly, at the new tag.
-      - name: Start the release workflow
+      - name: Open the pull request
+        id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run release.yml --ref "${{ steps.tag.outputs.tag }}"
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          cat > body.md <<EOF
+          Prepares \`v${VERSION}\`, bumped by \`cargo release ${{ inputs.level }}\`.
+
+          The version and the changelog are the whole diff. Merging this tags
+          \`v${VERSION}\` and starts the release, which builds the binaries and
+          plays the sanity check match against the previous release.
+
+          Close it without merging to call the release off, nothing has been
+          tagged or published yet.
+          EOF
+          url=$(gh pr create \
+            --base master \
+            --head "${{ steps.version.outputs.branch }}" \
+            --title "chore(release): prepare for ${VERSION}" \
+            --body-file body.md)
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
 
       - name: Summary
         run: |
           {
-            echo "### Released ${{ steps.tag.outputs.tag }}"
+            echo "### Release pull request for v${{ steps.version.outputs.version }}"
             echo
-            echo "The release workflow is building the binaries and playing the"
-            echo "sanity check match, which takes a while. It will add the result"
-            echo "to the release notes when it finishes."
+            echo "${{ steps.pr.outputs.url }}"
+            echo
+            echo "Merging it tags the release and starts the build."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,74 @@
+name: Tag release
+
+# Tags master whenever the version in Cargo.toml is one that has not been
+# released yet, which in practice means when a release pull request from
+# prepare-release.yml has just been merged.
+#
+# This deliberately looks at the version rather than the commit message. The
+# message of the merged commit depends on whether the pull request was merged,
+# squashed or rebased, whereas the version is the thing being released.
+
+on:
+  push:
+    branches: [ "master" ]
+
+permissions:
+  contents: write
+  # needed to start the release workflow
+  actions: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Work out whether there is anything to tag
+        id: version
+        run: |
+          version=$(python3 -c "import tomllib; print(tomllib.load(open('Cargo.toml','rb'))['workspace']['package']['version'])")
+          tag="v${version}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "::notice::${tag} is already tagged, nothing to do"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push the tag
+        if: steps.version.outputs.needed == 'true'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          git tag -a "$TAG" -m "chore: Release $TAG"
+          git push origin "$TAG"
+
+      # a tag pushed with GITHUB_TOKEN does not trigger the tag filter on the
+      # release workflow, github suppresses that to avoid workflows setting each
+      # other off. workflow_dispatch is the documented exception, so start it
+      # explicitly, at the new tag.
+      - name: Start the release workflow
+        if: steps.version.outputs.needed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run release.yml --ref "${{ steps.version.outputs.tag }}"
+
+      - name: Summary
+        if: steps.version.outputs.needed == 'true'
+        run: |
+          {
+            echo "### Tagged ${{ steps.version.outputs.tag }}"
+            echo
+            echo "The release workflow is building the binaries and playing the"
+            echo "sanity check match, which takes a while. It will add the result"
+            echo "to the release notes when it finishes."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -109,15 +109,33 @@ declared once in `[workspace.package]` in the root `Cargo.toml`.
 ### From the actions tab
 
 Run the **Prepare release** workflow from `master` and pick how much to bump the
-version by. It runs the tests, bumps the version, writes the changelog, commits,
-tags, pushes, and then starts the release workflow, which is the whole procedure
-below without needing anything installed locally.
+version by. It runs the tests, bumps the version, writes the changelog and opens
+a pull request with the result. `rc` gives a release candidate, `0.3.7` becomes
+`0.3.8-rc.1`.
 
-The one thing to know is that a tag pushed by a workflow does not set off
-another workflow. Github suppresses that so workflows cannot trigger each other
-in a loop, and `workflow_dispatch` is the documented exception, which is why the
-prepare workflow starts the release workflow explicitly rather than leaving it
-to the tag filter.
+Merging that pull request tags the release and starts the build. Closing it
+without merging calls the release off, nothing is tagged or published until it
+lands.
+
+Two things are worth knowing about why it is shaped this way:
+
+- `master` only takes changes through a pull request, so a workflow cannot push
+  the release commit to it directly. The release commit goes through a pull
+  request like anything else.
+- A tag pushed by a workflow does not set off another workflow. Github
+  suppresses that so workflows cannot trigger each other in a loop, and
+  `workflow_dispatch` is the documented exception, which is why the tag workflow
+  starts the release workflow explicitly rather than leaving it to the tag
+  filter.
+
+**Tag release** decides whether to tag by comparing the version in `Cargo.toml`
+against the existing tags, rather than by looking at the commit message, because
+the message of a merged pull request depends on whether it was merged, squashed
+or rebased.
+
+Github requires a maintainer to approve the first workflow run on a pull request
+opened by a workflow, so the checks on a release pull request may need the
+**Approve and run** button before they start.
 
 The release workflow can also be run from the actions tab on its own, against an
 existing tag, if a release needs redoing.


### PR DESCRIPTION
Fixes the failure from the first real run of **Prepare release** ([run 30617714932](https://github.com/aywrite/arche/actions/runs/30617714932)).

## What went wrong

The workflow pushed the version bump straight to `master`:

```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - Changes must be made through a pull request.
 ! [remote rejected] HEAD -> master (protected branch hook declined)
```

Everything up to that point worked — tests, bump, changelog, tag creation, all in 68 seconds. Because the branch push is first, the tag push never ran and the release dispatch correctly skipped, so nothing was left behind: `master` is untouched and no `v0.3.8` tag exists.

Branch protection is not visible anywhere in the repo, which is why this only surfaced on a live run against the real remote.

## The fix

Split the flow in two, so the release commit goes through a pull request like any other change and the protection stays exactly as it is.

**`prepare-release.yml`** now runs `cargo release <level> --execute --no-confirm --no-tag`, pushes a `release/vX.Y.Z` branch and opens a pull request. No tag, nothing published. Closing the pull request calls the release off.

**`tag-release.yml`** (new) runs on push to `master`. If the version in `Cargo.toml` has no matching tag, it creates and pushes one, then dispatches the release workflow at it.

## Why the tag job checks the version, not the commit message

The obvious implementation is to match `chore(release): prepare for ...` on the head commit. That breaks depending on merge strategy — a merge commit reads `Merge pull request #N from ...`, and only a rebase merge preserves the original message.

Comparing the version in `Cargo.toml` against existing tags is strategy-agnostic and idempotent: it does nothing on every ordinary push, fires exactly once when a release lands, and is safe to re-run.

The `workflow_dispatch` trick is unchanged and still necessary — a tag pushed with `GITHUB_TOKEN` does not set off `on: push: tags`, so the release workflow is started explicitly at the new tag.

## Verified

`cargo release rc` against a throwaway clone bumps `0.3.7` to `0.3.8-rc.1` and tags `v0.3.8-rc.1`, matching the existing `v0.3.6-rc.5` convention. `--no-tag` confirmed present in cargo-release 1.1.3, and the `tomllib` version read returns `0.3.7` against the current manifest. Both workflow files parse.

## Worth knowing

GitHub requires a maintainer to approve the first workflow run on a pull request opened by a workflow, so the checks on a release pull request may need the **Approve and run** button. Documented in `docs/DEVELOPMENT.md` rather than worked around.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSBdRtPp2XNa7FugJLaizW)_