### PR TITLE
Point the sanity check at a fastchess tag that exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,13 +95,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: tools
-          key: match-tools-fastchess-1.8.2-8moves-v3
+          key: match-tools-fastchess-1.8.2-alpha-8moves-v3
 
       - name: Build the match tools
         if: steps.previous.outputs.tag != '' && steps.tools.outputs.cache-hit != 'true'
         run: |
           mkdir -p tools
-          git clone --depth 1 --branch v1.8.2 \
+          # every fastchess release is tagged -alpha, there is no plain v1.8.2
+          git clone --depth 1 --branch v1.8.2-alpha \
             https://github.com/Disservin/fastchess.git /tmp/fastchess
           make -C /tmp/fastchess -j"$(nproc)"
           cp /tmp/fastchess/fastchess tools/


### PR DESCRIPTION
Fixes the `sanity-check` failure on the v0.3.8-rc.1 release ([run 30621301463](https://github.com/aywrite/arche/actions/runs/30621301463)).

## What failed

```
Cloning into '/tmp/fastchess'...
fatal: Remote branch v1.8.2 not found in upstream origin
```

The clone was pinned to `v1.8.2`. That tag does not exist — every fastchess release is tagged with an `-alpha` suffix, so the newest is `v1.8.2-alpha`:

```
v1.8.0-alpha
v1.8.1-alpha
v1.8.2-alpha
```

The job died on the clone, before building either engine or playing a single game. v0.3.8-rc.1 was the first release where this job has ever run, since it was added after v0.3.7 was tagged, which is why a wrong pin sat unnoticed.

## Impact on the release

Limited to the missing Elo line. The other five jobs all passed — `test`, `create-release`, and `upload-assets` on ubuntu, macos and windows — so **v0.3.8-rc.1 is released and its binaries are attached**. Only the `Sanity Check: ...` line is absent from the notes.

## The fix

Pin to `v1.8.2-alpha`, with a comment so it does not get "corrected" back to a plain version later, and bump the cache key to match so the corrected build is not masked by the old cache entry.

Verified by actually running the clone rather than reading the tag list: it resolves, checks out `v1.8.2-alpha`, and the `Makefile` the next step needs is present.

## Note on backfilling the rc

This cannot retroactively add the Elo line to v0.3.8-rc.1. Re-running `release.yml` against that tag would use the workflow file as it exists *at the tag*, which still has the broken pin. The fix applies from the next release onward. If you want the number for the rc specifically, the match can be run locally with the recipe in `docs/DEVELOPMENT.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSBdRtPp2XNa7FugJLaizW)_