### PR TITLE
Stop the cargo-release install being cached away

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -43,13 +43,22 @@ jobs:
           fetch-depth: 0
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          # this job installs cargo-release into CARGO_HOME/bin, which this
+          # action caches by default. restoring that cache made the install
+          # below a no-op without the binary actually being there.
+          cache-bin: false
 
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-binstall,git-cliff
 
       - name: Install cargo-release
-        run: cargo binstall --no-confirm cargo-release
+        run: |
+          cargo binstall --no-confirm cargo-release
+          # binstall can exit zero without installing anything, so fail here
+          # rather than several steps later with a confusing error
+          cargo release --version
 
       # the release workflow runs these again, but failing here means nothing is
       # created at all, rather than a pull request that has to be closed again


### PR DESCRIPTION
Fixes the **Prepare release** failure on [run 30627085504](https://github.com/aywrite/arche/actions/runs/30627085504).

```
Run cargo release patch --execute --no-confirm --no-tag
error: no such command: `release`
```

## Why it worked twice and then stopped

The `Install cargo-release` step reported **success, in one second**, and the binary was not there afterwards. The difference between this run and the two that worked is the cache:

| run | rust-cache step | outcome |
|---|---|---|
| 1 | 1s (cold) | `cargo release` ran fine |
| 2 | 2s | ran fine |
| 3 | 4s (restored) | `no such command: release` |

`Swatinem/rust-cache` has a `cache-bin` input which **defaults to `true`** and caches `${CARGO_HOME}/bin`. The first runs populated that cache. Once it existed and was being restored, `cargo binstall` stopped doing the install and exited zero anyway, leaving nothing on `PATH`.

So this was latent from the start and could only appear on the third run — the first two had nothing to restore.

## The fix

Two changes, one addressing the cause and one the symptom:

- `cache-bin: false` on the rust-cache step in this job, so the cache stops managing the directory the job installs into. The registry and target caching, which is where the time actually goes, is unaffected.
- `cargo release --version` immediately after the install. `binstall` exiting zero without installing is the failure mode here, so the job should fail at the install step rather than three steps later with an error that points at the wrong thing.

I did not add `--force` to binstall: it is not in the documented flags, and I would rather not pin behaviour on a flag I could not confirm exists.

## Nothing was left behind

The run failed at the bump, before anything was pushed. No `release/*` branch, no tag, and `Cargo.toml` on master is untouched.

## Verification

`cache-bin`'s existence and its `true` default are confirmed from the action's own `action.yml`, not assumed. The real proof is the next run of the workflow, since the failure only reproduces with a warm cache — which is now exactly the state it will run in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSBdRtPp2XNa7FugJLaizW)_