### PR TITLE
Write the changelog from the last full release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,53 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.3.8-rc.2] - 2026-07-31
-
-### Bug Fixes
-
-- Point the sanity check at a fastchess tag that exists
-- Stop the cargo-release install being cached away
-
-## [0.3.8-rc.1] - 2026-07-31
-
-### Bug Fixes
-
-- Report the engine author with an id line
-- Search the root position even when it has repeated
-- Stop long games from running past the end of the history
-
-### Documentation
-
-- Document building, strength and the development workflow
-
-### Features
-
-- Bundle the engine and an opening book into a lichess-bot image
-
-### Miscellaneous Tasks
-
-- Update workflow actions, cache builds and check formatting
-- Modernise the pre-commit hooks
-- Build and publish the lichess-bot docker image
-- Remove the iai benchmark
-- Replace the disabled benchmark workflow
-- Group the dependabot updates
-
-### Performance
-
-- Stop the search benchmark timing a 500MB memset
-
-### Styling
-
-- Fix the clippy warnings across the workspace
-
-### Ci
-
-- Add a short match against the previous release
-- Add clippy, debug and msrv jobs to the test workflow
-- Add a workflow to cut a release from the actions tab
-- Open a pull request to release rather than pushing to master
-
 ## [0.3.7] - 2026-07-26
 
 ### Bug Fixes

--- a/release.toml
+++ b/release.toml
@@ -1,7 +1,5 @@
 allow-branch = ["master"]
 publish = false
 push = false
-pre-release-hook = [
-"git-cliff", "--unreleased", "--tag", "{{version}}", "--prepend", "CHANGELOG.md"
-]
+pre-release-hook = ["./scripts/changelog.sh", "{{version}}"]
 pre-release-commit-message="chore(release): prepare for {{version}}"

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Writes the changelog section for a release. Run by cargo-release as a
+# pre-release hook, with the version being released as the only argument.
+set -euo pipefail
+
+version="${1:?usage: changelog.sh <version>}"
+
+# Release candidates do not get a section of their own. Their commits belong to
+# the release they lead up to, and are written out when that release is cut.
+case "$version" in
+  *-*)
+    echo "changelog: skipping pre-release $version"
+    exit 0
+    ;;
+esac
+
+# Everything since the last full release rather than since the last tag, so that
+# a release preceded by candidates still lists all of its changes. git-cliff has
+# --ignore-tags, but it does not affect the range --unreleased picks.
+previous=$(git tag --list 'v[0-9]*' --sort=-v:refname | grep -v -- '-' | head -1)
+
+if [ -n "$previous" ]; then
+  echo "changelog: ${version}, covering ${previous}..HEAD"
+  git-cliff --tag "$version" "${previous}..HEAD" --prepend CHANGELOG.md
+else
+  echo "changelog: ${version}, no previous release, covering everything"
+  git-cliff --tag "$version" --prepend CHANGELOG.md
+fi


### PR DESCRIPTION
Fixes the empty `0.3.8` changelog section on #23, properly rather than by hand.

## The problem

The hook ran `git-cliff --unreleased`, which means *everything since the last tag*. When a release is preceded by candidates the last tag is the final candidate, so the release section came out empty:

```
## [0.3.8] - 2026-07-31

## [0.3.8-rc.2] - 2026-07-31
### Bug Fixes
- Point the sanity check at a fastchess tag that exists
```

`create-gh-release-action` extracts the section matching the tag, so the v0.3.8 release notes would have been blank while its actual changes sat under the candidate headings.

## Why the obvious fix doesn't work

`cliff.toml` already sets `ignore_tags = "(beta|rc|alpha)"`, which looks like it should fold candidates into the following release. It doesn't help here — I tested it:

```
$ git-cliff --unreleased --tag 0.3.8 --ignore-tags '(alpha|beta|rc)'
## [0.3.8] - 2026-07-31
<!-- generated by git-cliff -->      <- still empty
```

`--ignore-tags` affects grouping, not the range `--unreleased` picks. The range has to be worked out explicitly.

## The fix

`scripts/changelog.sh`, called by cargo-release with the version:

- **Candidates get no section.** Their commits belong to the release they lead up to.
- **A release is generated from the last full release**, `git tag ... | grep -v -- '-' | head -1`, so it lists everything it contains regardless of how many candidates preceded it.

`release.toml` becomes `pre-release-hook = ["./scripts/changelog.sh", "{{version}}"]`.

Also drops the two `0.3.8-rc.*` sections already committed, since the next release now covers that ground — otherwise the corrected section would sit above stale duplicates.

## Verified end to end

Ran real `cargo release` invocations against throwaway clones of this branch.

**Promotion** (`cargo release patch` from `0.3.8-rc.2`):
```
Upgrading workspace to version 0.3.8
changelog: 0.3.8, covering v0.3.7..HEAD
```
produces a complete section — 6 bug fixes, the docs entry, the lichess-bot feature, 6 misc tasks — with the `chore(release):` commits correctly skipped by the existing parser rule, and tags `v0.3.8`.

**Candidate** (`cargo release rc`):
```
Upgrading workspace to version 0.3.8-rc.3
changelog: skipping pre-release 0.3.8-rc.3
```
`CHANGELOG.md` md5 identical before and after, and `v0.3.8-rc.3` still tagged.

## After this merges

#23 should be closed rather than merged — its changelog diff is the broken one. Re-running **Prepare release** with `patch` then produces the same correct result verified above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSBdRtPp2XNa7FugJLaizW)_