### PR TITLE
Keep the piece square sum incrementally

### DIFF
--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -269,6 +269,7 @@ pub struct Board {
     pub white_value: u32,
     pub black_value: u32,
     // piece square table score, kept up to date incrementally
+    psqt: isize,
 
     //history: Vec<PlayState>,
     history: [Option<PlayState>; MAX_GAME_SIZE],
@@ -567,25 +568,12 @@ impl Board {
     }
 
     #[inline]
-    fn piece_value(&self, index: u8) -> isize {
-        match self.get_piece_and_color_index(index) {
-            Some((p, Color::White)) => PVT.get_value(index as usize, p, Color::White),
-            Some((p, Color::Black)) => -PVT.get_value(index as usize, p, Color::Black),
-            None => 0,
-        }
-    }
-
     pub fn eval(&self) -> i64 {
         // TODO should this return white value & black value as separate numbers instead?
         // TODO should this return i32 or isize instead
         let eval = i64::from(self.white_value) - i64::from(self.black_value);
 
-        let mut score = 0i64;
-        let mut occupied = self.black | self.white;
-        while occupied != 0 {
-            score += self.piece_value(pop_lsb(&mut occupied)) as i64;
-        }
-        let eval = eval + score;
+        let eval = eval + self.psqt as i64;
 
         match self.active_color {
             Color::White => eval,
@@ -891,6 +879,10 @@ impl Board {
         debug_assert!(!self.white.is_bit_set(index));
         let zorb: &Zorbrist = &ZORB;
         self.key ^= zorb.get_piece_key(index, piece, color);
+        self.psqt += match color {
+            Color::White => PVT.get_value(index as usize, piece, Color::White),
+            Color::Black => -PVT.get_value(index as usize, piece, Color::Black),
+        };
         match piece {
             Piece::Pawn => self.pawns.set_bit(index),
             Piece::Knight => self.knights.set_bit(index),
@@ -921,6 +913,10 @@ impl Board {
         debug_assert!((self.black | self.white).is_bit_set(index));
         let zorb: &Zorbrist = &ZORB;
         self.key ^= zorb.get_piece_key(index, piece, color);
+        self.psqt -= match color {
+            Color::White => PVT.get_value(index as usize, piece, Color::White),
+            Color::Black => -PVT.get_value(index as usize, piece, Color::Black),
+        };
         match piece {
             Piece::Pawn => self.pawns.clear_bit(index),
             Piece::Knight => self.knights.clear_bit(index),
@@ -1110,6 +1106,7 @@ impl Game for Board {
                 .map_err(|e| e.to_string())?,
             white_value: 0,
             black_value: 0,
+            psqt: 0,
 
             history: EMPTY_HISTORY,
             key: 2340980257093, // TODO start with random number?


### PR DESCRIPTION
One commit, one file, +11/−14. **1.39× on search**, with byte-identical results — same move, node count and score on every position tested.

## The problem

`eval` was recomputing the positional term from scratch at every node:

```rust
let eval = white_value - black_value;      // material: already a running total

let mut score = 0i64;
let mut occupied = self.black | self.white;
while occupied != 0 {
    score += self.piece_value(pop_lsb(&mut occupied)) as i64;   // ~32 iterations
}
let eval = eval + score;
```

The material half was already incremental. The piece-square half was the one term left recomputing itself. Worse, it has to *discover* what is standing on each square: `piece_value` calls `get_piece_and_color_index`, which tests up to six bitboards. That is roughly 200 bitboard tests plus 32 table lookups per node, for a number that changes by a few points between one node and the next.

It was about a third of all search instructions.

## The change

The sum becomes board state, updated where pieces actually move — three lines below the Zobrist key update and immediately beside the material update that was already there:

```rust
self.psqt += match color {
    Color::White =>  PVT.get_value(index as usize, piece, Color::White),
    Color::Black => -PVT.get_value(index as usize, piece, Color::Black),
};
```

with the mirror `-=` in `clear_piece_index`. `eval` collapses to `(white_value - black_value) + self.psqt`, and `piece_value` is deleted.

White adds and black subtracts, so `psqt` is white-relative exactly like `white_value - black_value`. The existing `match self.active_color` at the end of `eval` is untouched.

## Why it cannot drift

`set_piece_index` and `clear_piece_index` are the only places a piece ever appears on or leaves a square — `self.pawns.set_bit(...)` occurs at exactly one line in the file, and `clear_bit` at exactly one. Every move type routes through them: a quiet move is clear-then-set, a capture is two clears and a set, castling moves two pieces, promotion clears a pawn and sets a queen, en passant clears a pawn on a square the moving piece never touches.

That is the same invariant the position key already depends on — `self.key ^= zorb.get_piece_key(...)` is the line directly above. `undo_move` needs no new code, since it replays the same calls in reverse.

## Verification

Beyond the argument: I added a temporary `debug_assert_eq!` in `eval` comparing `self.psqt` against a from-scratch recomputation, and ran the suite in debug. That fires on **every eval call**, including perft to depth 6 — millions of make/undo cycles covering castling, promotion, en passant and captures. It never diverged, so the assertion was removed.

| position | master | branch | gain |
|---|---|---|---|
| initial | 0.107 | 0.095 | 1.13× |
| kiwipete | 1.053 | 0.683 | 1.54× |
| position 3 | 0.077 | 0.053 | 1.45× |
| position 4 | 1.039 | 0.801 | 1.30× |
| **total** | **2.276** | **1.633** | **1.39×** |

Depth 7, seconds, startup subtracted, min of 4 interleaved runs.

## The trade-off

Make and undo now do a table lookup per piece placement, so **perft gets about 10% slower** — it pays the maintenance and never calls `eval`. Right trade for the engine, but it will show as a regression on the `perft_3` benchmark in CI.

Worth noting for later: this term is a pure function of piece placement, which is what makes it exactly incremental. Mobility and king safety depend on blockers and cannot be maintained this way — they will have to be computed per eval whenever that work lands. Keeping this one incremental does not conflict with that.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, 59/59 tests in both release and debug profiles.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSBdRtPp2XNa7FugJLaizW)_