### PR TITLE
Use precomputed magic numbers instead of searching for them at startup

### DIFF
--- a/basic_engine/src/magic.rs
+++ b/basic_engine/src/magic.rs
@@ -1,7 +1,5 @@
 use crate::bitboard::BitBoard;
 use crate::board::BASE_CONVERSIONS;
-use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
 
 // Mask for locations of possible blockers
 // for a given slider movement type and board square
@@ -25,10 +23,12 @@ struct MoveBoards {
 pub struct Magic {
     blocker_masks: BlockerMasks,
     straight: [u64; 64],
-    straight_moves: Vec<Vec<u64>>,
+    straight_moves: Vec<u64>,
+    straight_offsets: [u32; 64],
     straight_bits: [u8; 64],
     diagonal: [u64; 64],
-    diagonal_moves: Vec<Vec<u64>>,
+    diagonal_moves: Vec<u64>,
+    diagonal_offsets: [u32; 64],
     diagonal_bits: [u8; 64],
 }
 
@@ -37,35 +37,33 @@ impl Magic {
         let bm = BlockerMasks::new();
         let bb = BlockerBoards::new(&bm);
         let mb = MoveBoards::new(&bb);
-        let mut straight_magic_idxs = Vec::new();
-        let mut straight_moves_magic = Vec::new();
-
-        let mut diagonal_magic_idxs = Vec::new();
-        let mut diagonal_moves_magic = Vec::new();
-        let mut rng: SmallRng = <SmallRng as SeedableRng>::seed_from_u64(102938423890384);
+        let mut straight_moves_magic: Vec<u64> = Vec::new();
+        let mut diagonal_moves_magic: Vec<u64> = Vec::new();
+        let mut straight_offsets = [0u32; 64];
+        let mut diagonal_offsets = [0u32; 64];
 
         for index in 0..64 {
-            let blockers = &bb.straight[index];
-            let move_boards = &mb.straight[index];
-            let bits = bb.straight_bits[index];
-            let (s_magic, s_result) = Magic::find_magic(&mut rng, blockers, move_boards, bits);
-
-            straight_magic_idxs.push(s_magic);
-            straight_moves_magic.push(s_result);
-
-            let blockers = &bb.diagonal[index];
-            let move_boards = &mb.diagonal[index];
-            let bits = bb.diagonal_bits[index];
-            let (d_magic, d_result) = Magic::find_magic(&mut rng, blockers, move_boards, bits);
-
-            diagonal_magic_idxs.push(d_magic);
-            diagonal_moves_magic.push(d_result);
+            straight_offsets[index] = straight_moves_magic.len() as u32;
+            straight_moves_magic.extend(Magic::build_table(
+                &bb.straight[index],
+                &mb.straight[index],
+                bb.straight_bits[index],
+                STRAIGHT_MAGICS[index],
+            ));
+            diagonal_offsets[index] = diagonal_moves_magic.len() as u32;
+            diagonal_moves_magic.extend(Magic::build_table(
+                &bb.diagonal[index],
+                &mb.diagonal[index],
+                bb.diagonal_bits[index],
+                DIAGONAL_MAGICS[index],
+            ));
         }
 
         Self {
             blocker_masks: bm,
-            straight: straight_magic_idxs.try_into().unwrap(),
+            straight: STRAIGHT_MAGICS,
             straight_moves: straight_moves_magic,
+            straight_offsets,
             straight_bits: bb
                 .straight_bits
                 .iter()
@@ -73,8 +71,9 @@ impl Magic {
                 .collect::<Vec<u8>>()
                 .try_into()
                 .unwrap(),
-            diagonal: diagonal_magic_idxs.try_into().unwrap(),
+            diagonal: DIAGONAL_MAGICS,
             diagonal_moves: diagonal_moves_magic,
+            diagonal_offsets,
             diagonal_bits: bb
                 .diagonal_bits
                 .iter()
@@ -85,43 +84,31 @@ impl Magic {
         }
     }
 
-    fn find_magic(
-        rng: &mut SmallRng,
-        blockers: &[u64],
-        move_boards: &Vec<u64>,
-        bits: u8,
-    ) -> (u64, Vec<u64>) {
-        let mut result = vec![0; 2usize.pow(u32::from(bits))];
+    fn build_table(blockers: &[u64], move_boards: &[u64], bits: u8, magic: u64) -> Vec<u64> {
+        let mut result = vec![0u64; 1usize << bits];
         let shift = 64 - bits;
-        'outer: loop {
-            let magic_candidate: u64 =
-                rng.random::<u64>() & rng.random::<u64>() & rng.random::<u64>();
-            result.fill(0);
-
-            for (blocker, &move_b) in blockers.iter().zip(move_boards) {
-                let magic_index = blocker.wrapping_mul(magic_candidate) >> shift;
-                if result[magic_index as usize] == 0 {
-                    result[magic_index as usize] = move_b;
-                } else if result[magic_index as usize] != move_b {
-                    continue 'outer;
-                }
-            }
-            return (magic_candidate, result);
+        for (blocker, &move_b) in blockers.iter().zip(move_boards) {
+            let magic_index = (blocker.wrapping_mul(magic) >> shift) as usize;
+            debug_assert!(result[magic_index] == 0 || result[magic_index] == move_b);
+            result[magic_index] = move_b;
         }
+        result
     }
 
+    #[inline]
     pub fn get_straight_move(&self, square: u8, mask: u64) -> u64 {
         let blockers = mask & self.blocker_masks.straight[square as usize];
         let index = (blockers.wrapping_mul(self.straight[square as usize]))
             >> self.straight_bits[square as usize];
-        self.straight_moves[square as usize][index as usize]
+        self.straight_moves[self.straight_offsets[square as usize] as usize + index as usize]
     }
 
+    #[inline]
     pub fn get_diagonal_move(&self, square: u8, mask: u64) -> u64 {
         let blockers = mask & self.blocker_masks.diagonal[square as usize];
         let index = (blockers.wrapping_mul(self.diagonal[square as usize]))
             >> self.diagonal_bits[square as usize];
-        self.diagonal_moves[square as usize][index as usize]
+        self.diagonal_moves[self.diagonal_offsets[square as usize] as usize + index as usize]
     }
 }
 
@@ -321,6 +308,163 @@ pub fn test() {
     moves_d.debug_print();
     println!("MOVES");
     moves.debug_print();
+}
+
+#[rustfmt::skip]
+pub const STRAIGHT_MAGICS: [u64; 64] = [
+    0x1080002011400080, 0x0040200040029000, 0x1200081080220042, 0x01001000202c8900,
+    0x0080040006080080, 0x0100022c00010018, 0x0200081886000104, 0x0880004100102880,
+    0x4500802040008004, 0x0412004861810200, 0x0001004015002002, 0x0048800802801000,
+    0x3100801400580081, 0x2841000204000900, 0x1011000a00240900, 0x0002000062009401,
+    0x0004208001400a80, 0x92acc04000201001, 0x0020048024801000, 0x009e0200104008a1,
+    0x0002020020841028, 0x0000808004001200, 0x182a040001028810, 0x0300820004410284,
+    0x0061688180004000, 0x4002010200402081, 0x0102200100104100, 0x0000420200100820,
+    0x0408040080080080, 0x0002040080800200, 0x8048010c000a9008, 0x0029800080086900,
+    0x00028040008000a2, 0x5002804000802004, 0x2048c20082001029, 0x0008809800805000,
+    0x2904080080800400, 0x0082000402001008, 0x0001010804003002, 0x000881024e0000a4,
+    0x20192088400a8000, 0x0002406010004002, 0x0042002080120040, 0x400020f200420008,
+    0x00c800a400808008, 0x2001000a24010008, 0x204a0008c40a0005, 0x000000c402820019,
+    0xc080205080010100, 0x2020044000288880, 0x0000802000100080, 0x0828080084900080,
+    0x0021018800241100, 0x0812000204008080, 0x1182a20110388400, 0x0000010084004200,
+    0x0210610080024391, 0x4013908240002903, 0x000010408201200a, 0x4050990020045001,
+    0x0201000224080031, 0x0201000822440005, 0x1000020090082104, 0x0800040221004192,
+];
+
+#[rustfmt::skip]
+pub const DIAGONAL_MAGICS: [u64; 64] = [
+    0x0140100421004892, 0x00041006520020a0, 0x208c0806004d1008, 0x00041c0080080802,
+    0x0004042090002815, 0x0002020a22012240, 0x005242102420c800, 0x0106024042282000,
+    0x0040864808080480, 0x4201041022851104, 0x0020410e02004000, 0x40000c040c886601,
+    0x00003d10c0041440, 0x80002202100c0220, 0x1800058808080440, 0x4a000a1542080460,
+    0x091004420a220c08, 0x2104001210042100, 0x0828004408002109, 0x0154000645020000,
+    0x0404015822080840, 0x2000400808121001, 0x230c010205510820, 0x00020000c2020188,
+    0x00a84e1040101200, 0x1c04841202500c00, 0xa0102a0004040400, 0x4800d80100820040,
+    0x1105010000104004, 0x0200820005004208, 0x0028019018440480, 0x20030a0000c0e400,
+    0x004c122000082004, 0x402a086008044102, 0x0881209000280020, 0x0610040c00080210,
+    0x209002008028100c, 0x65124800c00a0045, 0x0010810208284200, 0x4004408204106900,
+    0x0008261004e03004, 0x08c0c410286c0400, 0x0000701098091000, 0x0000091148002c00,
+    0x180e810124000201, 0x1040100400200110, 0x012062120040220c, 0x1004010441000210,
+    0x0144030431040108, 0x0208808410028010, 0x1000002215300000, 0x480a910020981400,
+    0x0001006102440810, 0x2102400448008000, 0x002818505082003c, 0x8410242800404080,
+    0x0300206208444000, 0x84c0010403010800, 0x0118000480482202, 0x0400500000460801,
+    0x8030004020042400, 0x2212004820080480, 0x0040482004040240, 0x0290203089020060,
+];
+
+#[cfg(test)]
+mod magic_generation {
+    use super::{BlockerBoards, BlockerMasks, DIAGONAL_MAGICS, MoveBoards, STRAIGHT_MAGICS};
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
+
+    /// The search that produced the committed magics. Kept here so they can be
+    /// regenerated, and compiled with the tests so it cannot rot.
+    fn find_magic(rng: &mut SmallRng, blockers: &[u64], move_boards: &[u64], bits: u8) -> u64 {
+        let mut table = vec![0u64; 1usize << bits];
+        let shift = 64 - bits;
+        'outer: loop {
+            let candidate: u64 = rng.random::<u64>() & rng.random::<u64>() & rng.random::<u64>();
+            table.fill(0);
+            for (blocker, &move_b) in blockers.iter().zip(move_boards) {
+                let index = (blocker.wrapping_mul(candidate) >> shift) as usize;
+                if table[index] == 0 {
+                    table[index] = move_b;
+                } else if table[index] != move_b {
+                    continue 'outer;
+                }
+            }
+            return candidate;
+        }
+    }
+
+    /// True if this magic maps every blocker configuration for the square onto a
+    /// collision free index. Two configurations may share an index only when they
+    /// have the same attack set, which is harmless.
+    fn is_valid(magic: u64, blockers: &[u64], move_boards: &[u64], bits: u8) -> bool {
+        let mut table = vec![0u64; 1usize << bits];
+        let shift = 64 - bits;
+        for (blocker, &move_b) in blockers.iter().zip(move_boards) {
+            let index = (blocker.wrapping_mul(magic) >> shift) as usize;
+            if table[index] != 0 && table[index] != move_b {
+                return false;
+            }
+            table[index] = move_b;
+        }
+        true
+    }
+
+    /// The committed constants have to be valid, not identical to whatever the
+    /// search last happened to return. Many magics work for a given square.
+    #[test]
+    fn committed_magics_are_valid() {
+        let bm = BlockerMasks::new();
+        let bb = BlockerBoards::new(&bm);
+        let mb = MoveBoards::new(&bb);
+        for square in 0..64 {
+            assert!(
+                is_valid(
+                    STRAIGHT_MAGICS[square],
+                    &bb.straight[square],
+                    &mb.straight[square],
+                    bb.straight_bits[square]
+                ),
+                "straight magic for square {} does not work",
+                square
+            );
+            assert!(
+                is_valid(
+                    DIAGONAL_MAGICS[square],
+                    &bb.diagonal[square],
+                    &mb.diagonal[square],
+                    bb.diagonal_bits[square]
+                ),
+                "diagonal magic for square {} does not work",
+                square
+            );
+        }
+    }
+
+    /// Prints a fresh set of constants to paste into this file. Ignored because
+    /// it takes about half a second and is only needed if the blocker masks or
+    /// the table layout change.
+    ///
+    ///     cargo test -p basic_engine regenerate_magics -- --ignored --nocapture
+    #[test]
+    #[ignore = "prints replacement constants, see the doc comment"]
+    fn regenerate_magics() {
+        let bm = BlockerMasks::new();
+        let bb = BlockerBoards::new(&bm);
+        let mb = MoveBoards::new(&bb);
+        let mut rng: SmallRng = SeedableRng::seed_from_u64(102938423890384);
+
+        // the searches are interleaved per square, the same order the original
+        // code consumed the rng in, so this reproduces the committed values
+        let mut straight = Vec::with_capacity(64);
+        let mut diagonal = Vec::with_capacity(64);
+        for i in 0..64 {
+            straight.push(find_magic(
+                &mut rng,
+                &bb.straight[i],
+                &mb.straight[i],
+                bb.straight_bits[i],
+            ));
+            diagonal.push(find_magic(
+                &mut rng,
+                &bb.diagonal[i],
+                &mb.diagonal[i],
+                bb.diagonal_bits[i],
+            ));
+        }
+
+        for (name, magics) in [("STRAIGHT_MAGICS", straight), ("DIAGONAL_MAGICS", diagonal)] {
+            println!("#[rustfmt::skip]");
+            println!("pub const {}: [u64; 64] = [", name);
+            for chunk in magics.chunks(4) {
+                let line: Vec<String> = chunk.iter().map(|m| format!("0x{:016x}", m)).collect();
+                println!("    {},", line.join(", "));
+            }
+            println!("];");
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**Startup 0.584s → 0.228s**, and the debug test suite drops from 2m17s to 40s. Move generation is unchanged — same move, node count and score on every position tested.

## The problem

The engine searched for its magic numbers on every launch:

```rust
'outer: loop {
    let magic_candidate: u64 = rng.random::<u64>() & rng.random::<u64>() & rng.random::<u64>();
    table.fill(0);
    for (blocker, &move_b) in blockers.iter().zip(move_boards) {
        let index = blocker.wrapping_mul(magic_candidate) >> shift;
        if table[index as usize] == 0 {
            table[index as usize] = move_b;
        } else if table[index as usize] != move_b {
            continue 'outer;          // collision, throw it away and try again
        }
    }
    return (magic_candidate, table);
}
```

Instrumented, that is **2,478,569 candidates tried per launch**, across 128 searches, one per square per slider type. The RNG is seeded with a fixed constant, so it arrives at exactly the same 128 numbers every time.

Measured phase breakdown of `Board::new()`:

| phase | release | debug |
|---|---|---|
| `BlockerMasks::new` | 8.7 µs | 71 µs |
| `BlockerBoards::new` | 8.2 ms | 103 ms |
| `MoveBoards::new` | 3.5 ms | 44 ms |
| **`find_magic` × 128** | **387–512 ms** | **13.6 s** |

Finding the magics is 97% of it. This is also why fastchess needs `-startup-ms 60000` in the release workflow — the default 10 second handshake timeout is not enough when several engines start at once.

## The change

The 128 numbers become two `[u64; 64]` constants, and the search is replaced by a fill from a magic already known to work:

```rust
fn build_table(blockers: &[u64], move_boards: &[u64], bits: u8, magic: u64) -> Vec<u64> {
    let mut result = vec[0u64; 1usize << bits];
    let shift = 64 - bits;
    for (blocker, &move_b) in blockers.iter().zip(move_boards) {
        let magic_index = (blocker.wrapping_mul(magic) >> shift) as usize;
        debug_assert!(result[magic_index] == 0 || result[magic_index] == move_b);
        result[magic_index] = move_b;
    }
    result
}
```

The retry loop goes; the collision check survives as a `debug_assert!`.

## The search is kept, not deleted

Committing the numbers would otherwise mean losing the only tool that can produce them, so the search moves into a test module rather than disappearing. Three pieces, all `#[cfg(test)]` — no effect on the shipped binary:

**`find_magic`** — the original search. Compiled with the tests, so it cannot rot.

**`committed_magics_are_valid`** — runs on every `cargo test`. Checks all 128 magics map their square without collisions, and names the offender if not (`straight magic for square 37 does not work`). Costs **0.01s**; the suite goes from 59 to 60 tests and stays at ~12s.

**`regenerate_magics`** — `#[ignore]`d, prints replacement constants ready to paste:

```
cargo test -p basic_engine regenerate_magics -- --ignored --nocapture
```

It interleaves the two searches per square, the same order the original code consumed the RNG in, so it **reproduces the committed constants byte-for-byte** — verified, all 128. That means its output can be diffed against the file to confirm nothing has drifted.

Validity is the property that matters here, not identity: many magics work for a given square, and there is nothing special about the ones the original search returned.

## Why not `build.rs`

Not the 400 ms — that is roughly 2.4s across the CI jobs, once per clean build, and cached on incremental builds. It is that **`build.rs` cannot use the crate it is building**. The search needs `BlockerMasks`, `BlockerBoards` and `MoveBoards`, ~200 lines living in `magic.rs`. That means either duplicating them into `build.rs`, where they can silently drift from the real ones, or extracting a third workspace crate. The drift case is the worst possible failure: a generator producing magics for slightly different blocker masks than the engine uses.

The test module needs neither, because it lives inside the module it depends on. `#[ignore]` gives the opt-in behaviour a feature flag would, while keeping the code compiled so it cannot break unnoticed.

## Why the attack tables are still built at runtime

Those tables are **841 KB** — 102,400 rook entries and 5,248 bishop entries. Baking them in would put that in `.rodata` to save the ~12 ms it takes to fill them, which is the 3% of startup that was never the problem.

So the split is: the expensive deterministic search moves to compile time, the cheap mechanical fill stays at runtime.

## Riding along

The move tables were `Vec<Vec<u64>>` — 64 separate allocations per slider, and every lookup a double pointer chase with two bounds checks. They are now one flat `Vec<u64>` plus a `[u32; 64]` offset array. Measured wall-neutral in isolation, so this is tidiness while the code was already being rewritten, not a claimed win. The two lookups also get `#[inline]`.

## On trusting 128 opaque constants

I tested the failure mode. **Flipping one bit** (`0x1080002011400080` → `...81`): all tests passed — because magics are not unique, and that value happened to be another valid one producing identical move generation. **A definitively invalid value** (`0x1`): the `debug_assert!` fires in debug, and `perft` positions 2, 4, 5 and 6 fail in release.

So the guardrail is real, and with this PR there are now three layers: the validity test on every run, the debug assertion during table construction, and perft.

## Alternatives considered

- **Full `const fn`** — the table builders use `Vec<Vec<u64>>` and the tables are ragged, 2¹² entries for rook squares against 2⁹ for bishop. Going const means padding to fixed arrays, **2.25 MB** of `.rodata` against the ~841 KB packed form, plus rewriting three builders. To save 11 ms.
- **`include_bytes!` of a blob** — same size problem, plus endianness and alignment hazards, and it makes the tables opaque to a reader.

## Left for later

`BlockerBoards::generate_blocker_board` loops all 64 bits for each of ~108k blocker boards, 6.9 M iterations. The carry-rippler trick (`sub = (sub - mask) & mask`) does it in `popcount` steps. That is the only startup cost left worth naming, and it is ~11 ms.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, 60/60 tests (plus the ignored regenerator) in both release and debug profiles. Independent of #27 — different file, no conflict in either merge order.