### PR TITLE
Make the tests catch search changes, and the benchmark job trustworthy

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,20 @@
 name: Benchmark
 
+# Measures the pull request against the commit it would land on top of, both on
+# this runner, in this job, minutes apart.
+#
+# The previous version of this job compared against timings cached from a run on
+# master, which had been recorded on a different runner. Github's runners vary
+# enough that this reported changes which were not there, and the response at
+# the time was to raise the alert threshold to 150% and stop it failing the
+# build, which hid the false alarms rather than removing them. Measuring both
+# sides here costs twice the time and gives an answer worth reading.
+#
+# It still does not gate a merge. Even on one runner criterion calls single
+# digit differences significant, so this reports and the node count test in
+# basic_engine is what actually holds search behaviour still.
+
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 
@@ -11,57 +23,65 @@ env:
 
 permissions:
   contents: read
-  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
+        with:
+          # both sides get built, so both need their history
+          fetch-depth: 0
+
       - uses: Swatinem/rust-cache@v2
 
-      # --output-format bencher prints the libtest format that
-      # github-action-benchmark parses.
-      - name: Run benchmarks
+      - name: Work out what to compare
+        shell: bash
+        run: |
+          # github checks out a merge of the pull request into its base, so the
+          # first parent is the base and the merge is what would land
+          {
+            echo "BASE_SHA=$(git rev-parse HEAD^1)"
+            echo "HEAD_SHA=$(git rev-parse HEAD)"
+          } >> "$GITHUB_ENV"
+
+      - name: Measure the base
+        shell: bash
+        run: |
+          git checkout --detach "$BASE_SHA"
+          cargo bench -p basic_engine --bench benchmark -- --noplot --save-baseline pr-base
+
+      - name: Measure the pull request
         # Naming the shell is what turns on pipefail, without it a failing
         # cargo bench is hidden by tee.
         shell: bash
         run: |
+          git checkout --detach "$HEAD_SHA"
+          # lenient, because a pull request that adds a benchmark has nothing to
+          # compare it against and the strict flag makes that a panic
           cargo bench -p basic_engine --bench benchmark -- \
-            --output-format bencher --noplot | tee benchmark-output.txt
+            --noplot --baseline-lenient pr-base --noise-threshold 0.1 \
+            | tee benchmark-output.txt
 
-      # Only master writes the baseline. Caches saved on the default branch are
-      # the ones pull requests are allowed to read.
-      - name: Restore the master baseline
-        uses: actions/cache/restore@v6
-        with:
-          path: ./cache
-          key: benchmark-master-${{ github.run_id }}
-          restore-keys: benchmark-master-
+      - name: Summarise
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Benchmark against \`${BASE_SHA:0:8}\`"
+            echo
+            python3 scripts/benchmark_summary.py < benchmark-output.txt
+          } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Compare against the baseline
-        uses: benchmark-action/github-action-benchmark@v1
+      - name: Keep the measurements
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          name: basic_engine
-          tool: cargo
-          output-file-path: benchmark-output.txt
-          external-data-json-path: ./cache/benchmark-data.json
-          # These run on shared runners, so only report large changes and never
-          # fail the build on what is usually just a noisy neighbour.
-          alert-threshold: "150%"
-          fail-on-alert: false
-          # Only pull requests get comments. On a push the action falls back to
-          # commenting on the commit, which would need contents: write, and a
-          # fork's token is read only however this job is permissioned.
-          comment-always: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
-          comment-on-alert: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
-          summary-always: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Save the master baseline
-        if: github.event_name == 'push'
-        uses: actions/cache/save@v6
-        with:
-          path: ./cache
-          key: benchmark-master-${{ github.run_id }}
+          name: benchmark-output
+          path: benchmark-output.txt
+          if-no-files-found: warn

--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -1606,3 +1606,171 @@ mod test_fen {
         );
     }
 }
+
+#[cfg(test)]
+mod perft_edge_cases {
+    use super::Board;
+    use super::Game;
+    use pretty_assertions::assert_eq;
+
+    /// Positions that the six standard perft positions do not reach: the two
+    /// en passant pins, en passant giving check, castling into or through an
+    /// attack, promoting out of check, and stalemate. Each entry was checked
+    /// against python-chess rather than transcribed, since a published table is
+    /// only worth as much as the copy of it.
+    const CASES: [(&str, u8, u64, &str); 23] = [
+        (
+            "3k4/3p4/8/K1P4r/8/8/8/8 b - - 0 1",
+            6,
+            1_134_888,
+            "en passant capture is pinned along the rank",
+        ),
+        (
+            "8/8/4k3/8/2p5/8/B2P2K1/8 w - - 0 1",
+            6,
+            1_015_133,
+            "en passant capture is pinned along the diagonal",
+        ),
+        (
+            "8/8/1k6/2b5/2pP4/8/5K2/8 b - d3 0 1",
+            6,
+            1_440_467,
+            "en passant capture gives check",
+        ),
+        (
+            "5k2/8/8/8/8/8/8/4K2R w K - 0 1",
+            6,
+            661_072,
+            "castling short gives check",
+        ),
+        (
+            "3k4/8/8/8/8/8/8/R3K3 w Q - 0 1",
+            6,
+            803_711,
+            "castling long gives check",
+        ),
+        (
+            "r3k2r/1b4bq/8/8/8/8/7B/R3K2R w KQkq - 0 1",
+            4,
+            1_274_206,
+            "castling rights are given up correctly",
+        ),
+        (
+            "r3k2r/8/3Q4/8/8/5q2/8/R3K2R b KQkq - 0 1",
+            4,
+            1_720_476,
+            "castling is prevented by attacked squares",
+        ),
+        (
+            "2K2r2/4P3/8/8/8/8/8/3k4 w - - 0 1",
+            6,
+            3_821_001,
+            "promoting gets out of check",
+        ),
+        (
+            "8/8/1P2K3/8/2n5/1q6/8/5k2 b - - 0 1",
+            5,
+            1_004_658,
+            "discovered check",
+        ),
+        (
+            "4k3/1P6/8/8/8/8/K7/8 w - - 0 1",
+            6,
+            217_342,
+            "promoting gives check",
+        ),
+        (
+            "8/P1k5/K7/8/8/8/8/8 w - - 0 1",
+            6,
+            92_683,
+            "underpromoting gives check",
+        ),
+        (
+            "K1k5/8/P7/8/8/8/8/8 w - - 0 1",
+            6,
+            2_217,
+            "stalemating ourselves",
+        ),
+        (
+            "8/k1P5/8/1K6/8/8/8/8 w - - 0 1",
+            7,
+            567_584,
+            "stalemate and checkmate",
+        ),
+        (
+            "8/8/2k5/5q2/5n2/8/5K2/8 b - - 0 1",
+            4,
+            23_527,
+            "stalemate and checkmate again",
+        ),
+        (
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            5,
+            4_865_609,
+            "the start, deeper than the other suite goes",
+        ),
+        (
+            "n1n5/PPPk4/8/8/8/8/4Kppp/5N1N w - - 0 1",
+            5,
+            3_605_103,
+            "promotions of every piece for both sides",
+        ),
+        (
+            "8/8/8/3k4/8/3K4/8/8 w - - 0 1",
+            1,
+            5,
+            "the kings may not stand next to each other",
+        ),
+        (
+            "r6r/1b2k1bq/8/8/7B/8/8/R3K2R b KQ - 3 2",
+            1,
+            8,
+            "moving into check is not legal",
+        ),
+        (
+            "8/8/8/2k5/2pP4/8/B7/4K3 b - d3 0 3",
+            1,
+            8,
+            "en passant would expose the king",
+        ),
+        (
+            "r1bqkbnr/pppppppp/n7/8/8/P7/1PPPPPPP/RNBQKBNR w KQkq - 2 2",
+            1,
+            19,
+            "a quiet position, move count only",
+        ),
+        (
+            "r3k2r/p1pp1pb1/bn2Qnp1/2qPN3/1p2P3/2N5/PPPBBPPP/R3K2R b KQkq - 3 2",
+            1,
+            5,
+            "only check evasions are legal",
+        ),
+        (
+            "2kr3r/p1ppqpb1/bn2Qnp1/3PN3/1p2P3/2N5/PPPBBPPP/R3K2R b KQ - 3 2",
+            1,
+            44,
+            "not in check despite the queen",
+        ),
+        (
+            "rnb2k1r/pp1Pbppp/2p5/q7/2B5/8/PPPQNnPP/RNB1K2R w KQ - 3 9",
+            1,
+            39,
+            "castling with a knight on f2",
+        ),
+    ];
+
+    #[test]
+    fn test_perft_edge_cases() {
+        for (fen, depth, expected, description) in CASES {
+            let mut board = Board::from_fen(fen).unwrap();
+            assert_eq!(
+                board.perft(depth),
+                expected,
+                "{} ({} at depth {})",
+                description,
+                fen,
+                depth
+            );
+        }
+    }
+}

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -877,3 +877,84 @@ impl Engine for AlphaBeta {
         PvLine { line }
     }
 }
+
+#[cfg(test)]
+mod test_node_counts {
+    use super::AlphaBeta;
+    use super::Board;
+    use super::Engine;
+    use super::Game;
+    use pretty_assertions::assert_eq;
+
+    /// Pinned, because how often the transposition table collides decides how
+    /// much of the tree is searched again.
+    const TABLE_BYTES: usize = 1 << 20;
+
+    /// Positions chosen to reach different parts of the search: a quiet
+    /// opening, a tactical middlegame, a pawn endgame, a position full of
+    /// captures, and one with castling and promotions available.
+    const POSITIONS: [(&str, &str, u8); 5] = [
+        (
+            "opening",
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            6,
+        ),
+        (
+            "kiwipete",
+            "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+            5,
+        ),
+        (
+            "pawn endgame",
+            "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+            7,
+        ),
+        (
+            "promotions",
+            "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
+            5,
+        ),
+        (
+            "middlegame",
+            "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10",
+            5,
+        ),
+    ];
+
+    /// Widens the way the engine does when it plays, so the table is warm from
+    /// the previous iteration the way it is in a real search, and totals what
+    /// each iteration visited.
+    fn nodes(fen: &str, depth: u8) -> u64 {
+        let mut engine = AlphaBeta::with_table_bytes(Board::from_fen(fen).unwrap(), TABLE_BYTES);
+        (1..=depth)
+            .map(|d| engine.search(d).map_or(0, |result| result.nodes))
+            .sum()
+    }
+
+    /// The search is deterministic, so how many nodes it visits is an exact
+    /// figure rather than a timing, and it says the same thing on any machine.
+    /// It moves whenever move ordering, quiescence, the transposition table or
+    /// any pruning changes, including the many such changes that leave the move
+    /// finally played untouched, which is what makes it worth pinning.
+    ///
+    /// A deliberate change to the search is expected to move these. Update them
+    /// in the same commit: the diff is then a statement of how much less, or
+    /// more, of the tree the engine now looks at.
+    #[test]
+    fn test_node_counts_have_not_moved() {
+        let counted: Vec<(&str, u64)> = POSITIONS
+            .iter()
+            .map(|(name, fen, depth)| (*name, nodes(fen, *depth)))
+            .collect();
+        assert_eq!(
+            counted,
+            vec![
+                ("opening", 142_845),
+                ("kiwipete", 218_114),
+                ("pawn endgame", 261_194),
+                ("promotions", 121_129),
+                ("middlegame", 207_819),
+            ]
+        );
+    }
+}

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -539,13 +539,23 @@ mod test_search {
     use pretty_assertions::assert_eq;
     use std::time;
 
+    /// The default table is half a gigabyte, which is the right size to play
+    /// with and the wrong size to test with: one per test dominated both the
+    /// memory and the run time of the suite. This is still far larger than
+    /// anything here searches deeply enough to fill.
+    const TABLE_BYTES: usize = 16 * 1024 * 1024;
+
+    fn engine(board: Board) -> AlphaBeta {
+        AlphaBeta::with_table_bytes(board, TABLE_BYTES)
+    }
+
     #[test]
     fn test_regression_bad_cache() {
         // This is a losing position but running a search on a previous position then the losing
         // position seems to cause hash/cache collisions in some cases.
         let game =
             Board::from_fen("r4rk1/pppb1ppp/4pn2/6N1/3P4/2qBP3/P4PPP/3R1R1K w - - 2 16").unwrap();
-        let mut e = <AlphaBeta as Engine>::new(game);
+        let mut e = engine(game);
         let result = e.search(7).unwrap();
         assert!(
             result.score < -800,
@@ -556,7 +566,7 @@ mod test_search {
         let game =
             Board::from_fen("r1b2rk1/ppp1qppp/4pn2/6N1/Qn1P4/2NBP3/PP3PPP/R3K2R w KQ - 9 12")
                 .unwrap();
-        let mut e = <AlphaBeta as Engine>::new(game);
+        let mut e = engine(game);
         e.search(7).unwrap();
         let _ = e.parse_fen("r4rk1/pppb1ppp/4pn2/6N1/3P4/2qBP3/P4PPP/3R1R1K w - - 2 16");
         let result = e.search(7).unwrap();
@@ -567,7 +577,7 @@ mod test_search {
     fn test_checkmate_in_2_white() {
         let game =
             Board::from_fen("2rr3k/pp3pp1/1nnqbN1p/3pN3/2pP4/2P3Q1/PPB4P/R4RK1 w - - 0 0").unwrap();
-        let mut e = <AlphaBeta as Engine>::new(game);
+        let mut e = engine(game);
         let result = e.search(4).unwrap();
         assert_eq!(result.checkmate_in(), Some(2));
         assert_eq!(format!("{}", result.best_move), "g3g6");
@@ -577,7 +587,7 @@ mod test_search {
     fn test_checkmate_in_2_white_warm_cache() {
         let game =
             Board::from_fen("2rr3k/pp3pp1/1nnqbN1p/3pN3/2pP4/2P3Q1/PPB4P/R4RK1 w - - 0 0").unwrap();
-        let mut e = <AlphaBeta as Engine>::new(game);
+        let mut e = engine(game);
         let result = e.search(4).unwrap();
         assert_eq!(result.checkmate_in(), Some(2));
         // searching again deeper with a warm cache reuses mate scores stored
@@ -591,7 +601,7 @@ mod test_search {
     fn test_checkmate_in_1_black() {
         let game =
             Board::from_fen("2rr3k/pp3pp1/1nnqbNQp/3pN3/2pP4/2P5/PPB4P/R4RK1 b - - 1 1").unwrap();
-        let mut e = <AlphaBeta as Engine>::new(game);
+        let mut e = engine(game);
         let result = e.search(4).unwrap();
         assert_eq!(result.checkmate_in(), Some(-1));
     }
@@ -600,7 +610,7 @@ mod test_search {
     fn test_fifty_move_rule_play_for_draw() {
         // white is down material in this position so should play for fifty move draw
         let game = Board::from_fen("5k2/1p3p1p/p3pK1P/P1P1P3/4bP2/2B5/8/8 w - - 99 112").unwrap();
-        let mut e = <AlphaBeta as Engine>::new(game);
+        let mut e = engine(game);
         let result = e.search(3).unwrap();
         assert_eq!(result.score, 0);
     }
@@ -609,7 +619,7 @@ mod test_search {
     fn test_fifty_move_rule_no_legal_moves() {
         // The fifty move rules has been triggered - there should not be any legal moves
         let game = Board::from_fen("5k2/1p3p1p/p3pK1P/P1P1P3/4bP2/2B5/8/8 w - - 100 112").unwrap();
-        let mut e = <AlphaBeta as Engine>::new(game);
+        let mut e = engine(game);
         let result = e.search(3);
         assert!(result.is_none());
     }
@@ -623,14 +633,14 @@ mod test_search {
             "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 10 10",
             "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1",
         ];
-        let mut warm = <AlphaBeta as Engine>::new(Board::new());
+        let mut warm = engine(Board::new());
         for fen in fens {
             warm.parse_fen(fen).unwrap();
             warm.search(5).unwrap();
         }
         for fen in fens {
             let game = Board::from_fen(fen).unwrap();
-            let mut cold = <AlphaBeta as Engine>::new(game);
+            let mut cold = engine(game);
             let expected = cold.search(5).unwrap();
             warm.parse_fen(fen).unwrap();
             let result = warm.search(5).unwrap();
@@ -648,7 +658,7 @@ mod test_search {
     fn test_small_table_matches_large_table() {
         // a table small enough to force constant collisions must not change the result
         let fen = "r1b2rk1/ppp1qppp/4pn2/6N1/Qn1P4/2NBP3/PP3PPP/R3K2R w KQ - 9 12";
-        let mut big = <AlphaBeta as Engine>::new(Board::from_fen(fen).unwrap());
+        let mut big = engine(Board::from_fen(fen).unwrap());
         let expected = big.search(5).unwrap();
         let mut small = AlphaBeta::with_table_bytes(Board::from_fen(fen).unwrap(), 8 * 1024);
         let result = small.search(5).unwrap();
@@ -661,7 +671,7 @@ mod test_search {
             "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 b - - 3 19",
         )
         .unwrap();
-        let mut e = <AlphaBeta as Engine>::new(game);
+        let mut e = engine(game);
         for m in [
             "a8b8", "a1b1", "b8a8", "b1a1", "a8b8", "a1b1", "b8a8", "b1a1",
         ] {
@@ -674,7 +684,7 @@ mod test_search {
     #[test]
     fn test_new_game_forgets_the_previous_game() {
         let fen = "r1b2rk1/ppp1qppp/4pn2/6N1/Qn1P4/2NBP3/PP3PPP/R3K2R w KQ - 9 12";
-        let mut e = <AlphaBeta as Engine>::new(Board::from_fen(fen).unwrap());
+        let mut e = engine(Board::from_fen(fen).unwrap());
         e.search(4).unwrap();
         assert!(e.moves.get(e.board.key).is_some(), "nothing was stored");
         assert_ne!(format!("{}", e.pv_line()), "");
@@ -687,7 +697,7 @@ mod test_search {
     #[test]
     fn test_pv_line_without_cache_entry() {
         let game = Board::new();
-        let e = <AlphaBeta as Engine>::new(game);
+        let e = engine(game);
         assert_eq!(format!("{}", e.pv_line()), "");
     }
 
@@ -695,13 +705,13 @@ mod test_search {
     fn test_stopped_search_does_not_poison_cache() {
         let fen = "r1b2rk1/ppp1qppp/4pn2/6N1/Qn1P4/2NBP3/PP3PPP/R3K2R w KQ - 9 12";
         let game = Board::from_fen(fen).unwrap();
-        let mut cold = <AlphaBeta as Engine>::new(game);
+        let mut cold = engine(game);
         let expected = cold.search(6).unwrap();
 
         // a search with no time budget stops immediately, it must not leave partial results in
         // the hash table which change the outcome of the next search
         let game = Board::from_fen(fen).unwrap();
-        let mut e = <AlphaBeta as Engine>::new(game);
+        let mut e = engine(game);
         e.configure(time::Instant::now(), Some(time::Duration::ZERO));
         e.search(6);
         assert!(e.should_stop());

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -108,9 +108,17 @@ sequence is to benchmark master, apply a change, and benchmark again. Wall clock
 numbers move around on a loaded machine, so treat anything under about ten
 percent as noise.
 
-The benchmark workflow runs the same benchmarks on every pull request and
-compares them against the last run on master. It only reports, it will not fail
-a build, for the same reason.
+The benchmark workflow runs the same benchmarks on every pull request, once for
+the commit the pull request would land on and once for the pull request itself,
+both on the same runner. It writes the comparison to the job summary. It only
+reports and will not fail a build, for the same reason: even measured back to
+back on one machine, criterion calls single digit differences significant.
+
+What does hold search behaviour still is `test_node_counts_have_not_moved` in
+`basic_engine/src/engine.rs`. The number of nodes a search visits is exact
+rather than timed, so it says the same thing on any machine. A deliberate change
+to the search is expected to move it, and the numbers are updated in the same
+commit so the diff shows how much more, or less, of the tree is being looked at.
 
 ## Playing a match against a previous version
 

--- a/scripts/benchmark_summary.py
+++ b/scripts/benchmark_summary.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Turns a criterion comparison into a markdown table.
+
+Reads the output of `cargo bench -- --baseline <name>` and writes the change
+for each benchmark, worst first. Criterion prints its verdict per benchmark but
+buries it in several hundred lines of sampling chatter, and the interesting
+part of a comparison is the handful of entries that moved.
+"""
+
+import re
+import sys
+
+# criterion prints the benchmark id on a line of its own, then indents the
+# measurements underneath it
+ID = re.compile(r"^(\S.*?)\s*$")
+TIME = re.compile(r"^\s+time:\s+\[\S+ \S+ (\S+ \S+) \S+ \S+\]")
+CHANGE = re.compile(r"^\s+change:\s+\[\S+ (\S+) \S+\]")
+VERDICT = re.compile(
+    r"^\s+(Performance has regressed|Performance has improved"
+    r"|No change in performance detected|Change within noise threshold)"
+)
+
+SKIP = ("Benchmarking", "Found", "Warning", "Gnuplot", "gnuplot")
+
+LABEL = {
+    "Performance has regressed": "slower",
+    "Performance has improved": "faster",
+    "No change in performance detected": "no change",
+    "Change within noise threshold": "noise",
+}
+
+
+def parse(lines):
+    """Yields (benchmark, time, percent change, verdict) in file order.
+
+    A benchmark the baseline does not have prints no change and no verdict, so
+    entries are flushed when the next one starts rather than when a verdict
+    arrives. A benchmark added by the branch being measured is worth listing.
+    """
+    name = time = change = verdict = None
+
+    def flush():
+        if name is not None and time is not None:
+            return (name, time, change, verdict or "new")
+        return None
+
+    for line in lines:
+        if match := TIME.match(line):
+            time = match.group(1)
+        elif match := CHANGE.match(line):
+            # criterion writes a minus sign, not a hyphen
+            change = match.group(1).replace("−", "-")
+        elif match := VERDICT.match(line):
+            verdict = match.group(1)
+        elif not line.startswith(SKIP) and (match := ID.match(line)):
+            if record := flush():
+                yield record
+            name, time, change, verdict = match.group(1), None, None, None
+    if record := flush():
+        yield record
+
+
+def percent(change):
+    try:
+        return abs(float(change.rstrip("%")))
+    except (AttributeError, ValueError):
+        return 0.0
+
+
+def main():
+    results = list(parse(sys.stdin))
+    if not results:
+        print("No benchmark comparison was produced.")
+        return 1
+
+    moved = [r for r in results if r[3] == "Performance has regressed"]
+    print("Both sides were measured on the same runner in the same job, minutes")
+    print("apart. Criterion still calls small differences significant on a shared")
+    print("runner, so treat single digit changes as noise.\n")
+    if moved:
+        print(f"{len(moved)} of {len(results)} benchmarks are slower.\n")
+    else:
+        print(f"None of the {len(results)} benchmarks are slower.\n")
+
+    print("| benchmark | time | change | |")
+    print("| --- | --- | --- | --- |")
+    for name, time, change, verdict in sorted(
+        results, key=lambda r: percent(r[2]), reverse=True
+    ):
+        label = LABEL.get(verdict, verdict)
+        print(f"| `{name}` | {time or ''} | {change or 'no baseline'} | {label} |")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Four commits from a review of the test and benchmark apparatus. Independent of #30.

## Pin how many nodes the search visits

The suite did not notice when the search changed shape. All of these left it green:

| deliberate break | before | now |
|---|---|---|
| quiescence removed | passes | fails |
| hash index → `key % 16` (a 9M entry table using 16 slots) | passes | fails |
| check extension removed | passes | fails |
| principal variation dropped from move ordering | ran 25 min, killed | fails in <1s |

The search is deterministic — I confirmed each position returns an identical count across runs before pinning anything — so the node count for a given position, depth and table size is an exact figure rather than a timing. It says the same thing on every machine, which is exactly what the benchmark job cannot do.

Five positions, widened the way the engine widens when it plays so the table is warm from the previous iteration. 0.13s.

A deliberate search change is expected to move these. Updating them in the same commit makes the diff a statement of how much more, or less, of the tree the engine looks at.

## Perft positions that catch the awkward cases

Deleting the king clause from `square_attacked`, so the engine no longer believes a king guards the squares around it, **changes none of the six existing perft counts** — verified. It was caught only incidentally, by a fifty move rule test.

Adds the published edge case suite: both en passant pins, en passant giving check, castling into and through an attack, promoting out of check, promoting to give check, stalemating ourselves, and a bare king position where the only thing counted is whether the kings may stand adjacent. That last one fails at depth 1 with the king clause removed.

**On the expected counts.** These were first drafted from recall, and recall got four of them wrong. Rather than trust the rest, every one of the 23 was checked against `python-chess` — an independent move generator — and all 23 agree. 22.2M nodes, 1.3s in release.

## Stop every test allocating half a gigabyte

Fifteen test engines each took the playing default of a 500MB table. A test that asserts the principal variation is empty paid for half a gigabyte to do it, and the suite spent more time in the kernel faulting in memory than searching.

| | release | debug | peak RSS |
|---|---|---|---|
| before | 8.09s | 45.03s | 2800 MiB |
| 4MB | 5.77s | **51.91s** | 31 MiB |
| **16MB** | **5.35s** | **43.86s** | 75 MiB |

4MB was the obvious choice and it makes debug 15% *slower* — a smaller table collides more, and the extra searching costs more in debug than the allocation saves. 16MB improves both. System time falls from 6.6s to 0.02s.

## Measure both sides of a pull request on one runner

The benchmark job compared against timings restored from a cache written by a run on master, on whichever runner picked that run up. Runners vary by more than the changes being looked for — this is what reported a move generation benchmark 60% slower from a change that did not touch it. The response at the time was to raise the alert threshold to 150% and stop it failing the build, which hid the false alarms without removing them, and hid real regressions under the same threshold.

Now it measures the base and the pull request in the same job on the same runner, minutes apart, and lets criterion do the comparison. Twice the benchmarking time, and the whole class of problem goes away.

It reports rather than gates, and that is deliberate: comparing *identical code* on a busy machine, criterion still called three of four benchmarks "regressed". The node count test above is what holds search behaviour still; this says how long things take. `--noise-threshold 0.1` keeps the verdicts sensible.

Uses `--baseline-lenient` rather than `--baseline`: criterion **panics** if a benchmark is missing from the baseline, so the strict form would break any PR that adds one. Also adds the concurrency group the other workflows have — without it every push started another half hour of benchmarking alongside the last, making the runner busier and the measurements worse.

`scripts/benchmark_summary.py` turns criterion's several hundred lines of sampling chatter into a table in the job summary, worst first.

## Checks

`cargo fmt --check`, clippy `-D warnings`, ruff check and format on the new script, and the full suite in release and debug: 26 + 63, 1 ignored.

Not addressed here, from the same review: the two reachable panics from parsed FENs, asserting UCI output, an independent PSQT recompute, stalemate and promotion-`Display` tests, and `[profile.test] opt-level = 3`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSBdRtPp2XNa7FugJLaizW)_