### PR TITLE
Turn the piece square tables the right way up

### DIFF
--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -1254,6 +1254,59 @@ mod evaluate {
         "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10"
     );
     test_fen!(position_3, "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1");
+
+    /// The assertions above hold whichever way up the piece square tables are,
+    /// because both colours read them the same way and the symmetry survives.
+    /// These say which way is up.
+    #[test]
+    fn test_a_pawn_is_worth_more_the_closer_it_is_to_promoting() {
+        let advanced = Board::from_fen("4k3/4P3/8/8/8/8/8/4K3 w - - 0 1").unwrap();
+        let home = Board::from_fen("4k3/8/8/8/8/8/4P3/4K3 w - - 0 1").unwrap();
+        assert!(
+            advanced.eval() > home.eval(),
+            "a pawn on e7 scored {} and one on e2 scored {}",
+            advanced.eval(),
+            home.eval()
+        );
+    }
+
+    #[test]
+    fn test_a_pawn_is_worth_more_the_closer_it_is_to_promoting_for_black_too() {
+        let advanced = Board::from_fen("4k3/8/8/8/8/8/4p3/4K3 b - - 0 1").unwrap();
+        let home = Board::from_fen("4k3/4p3/8/8/8/8/8/4K3 b - - 0 1").unwrap();
+        assert!(
+            advanced.eval() > home.eval(),
+            "a pawn on e2 scored {} and one on e7 scored {}",
+            advanced.eval(),
+            home.eval()
+        );
+    }
+
+    /// A position and its reflection, colours swapped, have to score the same
+    /// for whoever is to move. This does not catch the tables being upside down,
+    /// since that happens to both colours at once, but it does catch one colour
+    /// being changed without the other.
+    #[test]
+    fn test_a_mirrored_position_scores_the_same() {
+        for (white, black) in [
+            (
+                "4k3/4P3/8/8/8/8/8/4K3 w - - 0 1",
+                "4k3/8/8/8/8/8/4p3/4K3 b - - 0 1",
+            ),
+            (
+                "4k3/8/8/8/8/8/8/R3K3 w - - 0 1",
+                "r3k3/8/8/8/8/8/8/4K3 b - - 0 1",
+            ),
+            (
+                "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
+                "rnbqkbnr/pppp1ppp/8/4p3/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            ),
+        ] {
+            let white = Board::from_fen(white).unwrap();
+            let black = Board::from_fen(black).unwrap();
+            assert_eq!(white.eval(), black.eval(), "{} against {}", white, black);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -959,11 +959,11 @@ mod test_node_counts {
         assert_eq!(
             counted,
             vec![
-                ("opening", 142_845),
-                ("kiwipete", 218_114),
-                ("pawn endgame", 261_194),
-                ("promotions", 121_129),
-                ("middlegame", 207_819),
+                ("opening", 178_740),
+                ("kiwipete", 219_347),
+                ("pawn endgame", 188_709),
+                ("promotions", 121_061),
+                ("middlegame", 207_606),
             ]
         );
     }

--- a/basic_engine/src/pvt.rs
+++ b/basic_engine/src/pvt.rs
@@ -45,7 +45,12 @@ impl PieceValueTables {
     }
 
     pub fn new() -> Self {
-        // From https://www.chessprogramming.org/Simplified_Evaluation_Function
+        // From https://www.chessprogramming.org/Simplified_Evaluation_Function.
+        //
+        // These are written the way the page prints them, with the eighth rank
+        // in the top row, so the first entry is a8 and the last is h1. The
+        // board counts the other way, a1 being index zero, which is why black
+        // takes the tables as written and white takes them mirrored.
         #[rustfmt::skip]
         let pawns = [
             0,  0,  0,  0,  0,  0,  0,  0,
@@ -113,16 +118,103 @@ impl PieceValueTables {
         //    20, 30, 10,  0,  0, 10, 30, 20
         //];
         Self {
-            white_pawns: pawns,
-            black_pawns: mirror(&pawns),
-            white_knights: knights,
-            black_knights: mirror(&knights),
-            white_bishops: bishops,
-            black_bishops: mirror(&bishops),
-            white_rooks: rooks,
-            black_rooks: mirror(&rooks),
-            white_queens: queens,
-            black_queens: mirror(&queens),
+            white_pawns: mirror(&pawns),
+            black_pawns: pawns,
+            white_knights: mirror(&knights),
+            black_knights: knights,
+            white_bishops: mirror(&bishops),
+            black_bishops: bishops,
+            white_rooks: mirror(&rooks),
+            black_rooks: rooks,
+            white_queens: mirror(&queens),
+            black_queens: queens,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::misc::File;
+    use crate::misc::coordinate_to_index;
+
+    fn value(piece: Piece, color: Color, file: File, rank: u8) -> isize {
+        let index = coordinate_to_index(rank, file) as usize;
+        PieceValueTables::new().get_value(index, piece, color)
+    }
+
+    /// The tables are written with the eighth rank first and the board indexes
+    /// a1 as zero, so it is easy to hand each colour the other one's table. Both
+    /// colours are then wrong together, which leaves the two of them still
+    /// mirroring each other and the evaluation still symmetric. Nothing but an
+    /// assertion about which way up a table is will notice, so these name the
+    /// squares rather than compare the colours.
+    #[test]
+    fn a_white_pawn_is_worth_more_the_closer_it_gets_to_promoting() {
+        assert_eq!(value(Piece::Pawn, Color::White, File::E, 2), -20);
+        assert_eq!(value(Piece::Pawn, Color::White, File::E, 4), 20);
+        assert_eq!(value(Piece::Pawn, Color::White, File::E, 7), 50);
+    }
+
+    #[test]
+    fn a_black_pawn_is_worth_more_the_closer_it_gets_to_promoting() {
+        assert_eq!(value(Piece::Pawn, Color::Black, File::E, 7), -20);
+        assert_eq!(value(Piece::Pawn, Color::Black, File::E, 5), 20);
+        assert_eq!(value(Piece::Pawn, Color::Black, File::E, 2), 50);
+    }
+
+    #[test]
+    fn a_rook_belongs_on_the_seventh_rank() {
+        // the seventh rank row is 5 at the edges and 10 across the middle
+        assert_eq!(value(Piece::Rook, Color::White, File::D, 7), 10);
+        assert_eq!(value(Piece::Rook, Color::White, File::A, 7), 5);
+        assert_eq!(value(Piece::Rook, Color::White, File::A, 2), -5);
+        // and the square it lands on castling short is worth a little
+        assert_eq!(value(Piece::Rook, Color::White, File::D, 1), 5);
+
+        assert_eq!(value(Piece::Rook, Color::Black, File::D, 2), 10);
+        assert_eq!(value(Piece::Rook, Color::Black, File::A, 7), -5);
+        assert_eq!(value(Piece::Rook, Color::Black, File::D, 8), 5);
+    }
+
+    #[test]
+    fn a_knight_is_worth_least_in_the_corners() {
+        for (file, rank) in [(File::A, 1), (File::H, 1), (File::A, 8), (File::H, 8)] {
+            assert_eq!(value(Piece::Knight, Color::White, file, rank), -50);
+        }
+        assert_eq!(value(Piece::Knight, Color::White, File::E, 4), 20);
+    }
+
+    /// Weaker than the tests above, since it holds whether or not the tables are
+    /// the right way up, but it is what keeps one colour from being changed
+    /// without the other.
+    #[test]
+    fn the_two_colours_are_reflections_of_each_other() {
+        for piece in [
+            Piece::Pawn,
+            Piece::Knight,
+            Piece::Bishop,
+            Piece::Rook,
+            Piece::Queen,
+        ] {
+            for rank in 1..=8 {
+                for file in File::VARIANTS {
+                    assert_eq!(
+                        value(piece, Color::White, file, rank),
+                        value(piece, Color::Black, file, 9 - rank),
+                        "{:?} on {:?}{}",
+                        piece,
+                        file,
+                        rank
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_king_is_not_scored_by_square() {
+        assert_eq!(value(Piece::King, Color::White, File::E, 1), 0);
+        assert_eq!(value(Piece::King, Color::Black, File::E, 8), 0);
     }
 }


### PR DESCRIPTION
The tables in `pvt.rs` are copied from the simplified evaluation function, which prints them the way a board is drawn, eighth rank in the top row. This board counts a1 as index zero. White was handed the tables as written and black the mirrored ones, which is the wrong way round for both.

Measured off `Board::eval` before the change:

| | scored | should have been |
| --- | --- | --- |
| white pawn e2 | +50 | -20 |
| white pawn e7 | -20 | +50 |
| white rook, seventh rank | -5 | +10 |

From the opening position it would not play e4 at all. Every pawn move looked like giving up half a pawn, so it shuffled a rook between a1 and b1 for a score of zero:

```
before   score cp 0    pv b1c3 g8f6 g1f3 b8c6 a1b1 a8b8 b1a1
after    score cp 35   pv e2e4 b8c6 g1f3 g8f6 e4e5 f6e4 b1c3
```

Twenty paired games at 100ms a move against a build of master: thirteen wins, five draws, two losses. Roughly +215 elo with a 95% interval of about +91 to +428. Small sample, but the lower bound is the part that matters. Worth running the strength workflow on it for a real number.

## Why nothing caught it

Both colours were wrong together, so the two tables still mirrored each other and the evaluation stayed symmetric. The existing check in `mod evaluate` asserts that flipping the side to move negates the score, which is a restatement of what `eval` does on its last three lines and holds however the tables are turned. Nothing named a square, so nothing noticed.

## Tests

Nine new ones, at both levels.

In `pvt.rs`, against the tables directly: a pawn is worth more the nearer it gets to promoting, for each colour; a rook belongs on the seventh; a knight is worth least in the corners; a king is not scored by square.

In `mod evaluate`, against the evaluation: a position with a pawn on e7 beats the same position with it on e2, again for each colour, and a position and its reflection with the colours swapped score the same.

Five of these fail against the old tables. The two mirror tests do not, which is the point of keeping them separate from the ones that name squares.

## Node counts

`test_node_counts_have_not_moved` fails, as it should, and the numbers are updated in this commit. A different evaluation searches a different tree: the opening position costs about a quarter more nodes, the pawn endgame about a quarter fewer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSBdRtPp2XNa7FugJLaizW)_