### PR TITLE
Post the benchmark comparison to the pull request, and get off node 20

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,6 +23,7 @@ env:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -73,14 +74,42 @@ jobs:
         shell: bash
         run: |
           {
+            # marks the comment as this job's, so the next run replaces it
+            echo "<!-- benchmark-summary -->"
             echo "## Benchmark against \`${BASE_SHA:0:8}\`"
             echo
             python3 scripts/benchmark_summary.py < benchmark-output.txt
-          } >> "$GITHUB_STEP_SUMMARY"
+          } > benchmark-summary.md
+          cat benchmark-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      # A summary nobody opens is barely better than none, so put it where the
+      # change is being read. Done with the api rather than an action so there
+      # is one less thing to keep off a deprecated node.
+      - name: Post the summary to the pull request
+        # a fork's pull request gets a read only token, so there is nothing to
+        # post with and failing the job over it would help no one
+        if: always() && !github.event.pull_request.head.repo.fork
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          jq -n --rawfile body benchmark-summary.md '{body: $body}' > comment.json
+          # edit the comment the last run left rather than adding one per push
+          existing=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+            --jq '.[] | select(.body | startswith("<!-- benchmark-summary -->")) | .id' \
+            | tail -1)
+          if [ -n "$existing" ]; then
+            gh api --silent --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" --input comment.json
+          else
+            gh api --silent --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --input comment.json
+          fi
 
       - name: Keep the measurements
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-output
           path: benchmark-output.txt


### PR DESCRIPTION
Two things to `benchmark.yml`.

## The comparison goes back on the pull request

When the cached master baseline was replaced with the same-runner comparison, the table went to the step summary and nowhere else, so the result sat on a page there is no reason to open. The version before it commented on the pull request. Losing that was not the point of the change.

The summary is now written to a file, put in the step summary as before, and also posted as a comment. Two differences from the old behaviour:

- The comment carries a marker in an HTML comment, so each run edits the one the previous run left instead of adding another. The old job added a comment per push.
- A pull request from a fork gets a read-only token, so that case is skipped rather than left to fail the job.

It posts through the API with the `gh` CLI rather than an action, which means no Node runtime and nothing to keep bumping — which is the other half of this change.

## `upload-artifact` was the last thing on node 20

Every Benchmark run ended with:

```
##[warning]Node.js 20 is deprecated. The following actions target Node.js 20
but are being forced to run on Node.js 24: actions/upload-artifact@v4
```

`v7` is the current major and runs on node 24. Breaking changes since v4 are the move to ESM inside the action and a new `archive` input whose default keeps the existing behaviour; the three inputs used here are unchanged.

I went through the job logs for the rest rather than bumping on sight:

- `actions/cache@v4` used to emit the same warning from the old sanity check job. That job is now `strength.yml` on `actions/cache@v6` and runs clean.
- `dtolnay/rust-toolchain@1.85` looks like a stale pin and is not — that names the toolchain the MSRV job exists to check, not the action version. Dependabot is already configured to leave it alone.
- The `taiki-e/*` actions are shell, not node.
- The `punycode` and `url.parse()` DeprecationWarnings come from inside `Swatinem/rust-cache`'s own dependencies. Nothing here can fix those.

Nothing else in the repository targets node 20.

## Checked

All seven workflow files parse. The summary generation, the JSON payload and the marker match were dry-run locally against real criterion output from run 30732888059.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSBdRtPp2XNa7FugJLaizW)_