### PR TITLE
Stop the principal variation reporting a line that repeats

### DIFF
--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -624,20 +624,35 @@ impl Board {
         false
     }
 
-    pub fn is_repetition(&self) -> bool {
+    /// How many times this position has already appeared, not counting the
+    /// position itself.
+    fn repetition_count(&self) -> usize {
         // a position parsed from fen can have a fifty move count higher than the number of plies
         // we hold history for, and a long enough game runs past the end of the history
         let start = self.ply.saturating_sub(self.fifty_move_rule);
         let end = self.ply.min(MAX_GAME_SIZE - 1);
         if start > end {
-            return false;
+            return 0;
         }
-        let matching = self.history[start..=end]
+        self.history[start..=end]
             .iter()
             .filter_map(|h| h.map(|hh| hh.position_key))
             .filter(|k| *k == self.key)
-            .count();
-        matching >= 2
+            .count()
+    }
+
+    /// True on the third occurrence, which is when a game is actually drawn.
+    pub fn is_repetition(&self) -> bool {
+        self.repetition_count() >= 2
+    }
+
+    /// True once this position has come up before. Inside a search that is
+    /// already enough to call it a draw: a position reached twice can be
+    /// reached a third time by whichever side wants it, so neither can be made
+    /// to avoid it, and waiting for the third costs four plies of depth to see
+    /// something that is available now.
+    pub fn has_repeated(&self) -> bool {
+        self.repetition_count() >= 1
     }
 
     pub fn make_move(&mut self, play: &Play) -> bool {
@@ -1404,6 +1419,34 @@ mod make_move {
         // the fifty move counter from the fen is larger than the history we hold
         let board = Board::from_fen("5k2/1p3p1p/p3pK1P/P1P1P3/4bP2/2B5/8/8 w - - 99 1").unwrap();
         assert_eq!(board.is_repetition(), false);
+    }
+
+    /// The search does not wait for the third occurrence. Once a position has
+    /// come back once, either side can take the draw, so there is nothing to be
+    /// gained by spending four more plies of depth confirming it.
+    #[test]
+    fn test_has_repeated_fires_a_cycle_before_is_repetition() {
+        let mut board = Board::from_fen(
+            "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 b - - 3 19",
+        )
+        .unwrap();
+        let cycle = [(A8, B8), (A1, B1), (B8, A8), (B1, A1)];
+        assert_eq!(board.has_repeated(), false);
+        assert_eq!(board.is_repetition(), false);
+
+        for (from, to) in cycle {
+            board.make_move(&Play::new(from, to, None, None, false, false));
+        }
+        // first repeat: a draw is available, so the search stops here
+        assert_eq!(board.has_repeated(), true);
+        assert_eq!(board.is_repetition(), false);
+
+        for (from, to) in cycle {
+            board.make_move(&Play::new(from, to, None, None, false, false));
+        }
+        // second repeat: the game is actually drawn
+        assert_eq!(board.has_repeated(), true);
+        assert_eq!(board.is_repetition(), true);
     }
 
     #[test]

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -309,7 +309,7 @@ impl AlphaBeta {
         // a repetition at the root is not a finished game, the engine still has to move, so only
         // score it as a draw further down the line
         if self.board.fifty_move_rule >= 100
-            || (self.board.line_ply > 0 && self.board.is_repetition())
+            || (self.board.line_ply > 0 && self.board.has_repeated())
         {
             return 0;
         }
@@ -726,9 +726,9 @@ mod test_search {
     #[test]
     fn test_pv_line_stops_at_a_repetition() {
         // a shuffle both sides are content with leaves the table holding a line
-        // that goes round for ever. The game is over the third time the
-        // position comes up, so the line has to stop there rather than report a
-        // continuation nobody would be allowed to play.
+        // that goes round for ever. The line stops once the position comes back,
+        // because from there it is a draw either side can take, rather than
+        // reporting a continuation nobody would go on to play.
         let game = Board::from_fen(
             "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 b - - 3 19",
         )
@@ -742,10 +742,7 @@ mod test_search {
             assert!(board.make_move(&play), "failed to play {}", name);
         }
 
-        assert_eq!(
-            format!("{}", e.pv_line()),
-            "a8b8 a1b1 b8a8 b1a1 a8b8 a1b1 b8a8 b1a1"
-        );
+        assert_eq!(format!("{}", e.pv_line()), "a8b8 a1b1 b8a8 b1a1");
     }
 
     #[test]
@@ -1044,7 +1041,7 @@ impl Engine for AlphaBeta {
             line.push(play);
             // the line is a draw from here, so whatever the table says comes
             // next is a continuation that would never be played
-            if board.fifty_move_rule >= 100 || board.is_repetition() {
+            if board.fifty_move_rule >= 100 || board.has_repeated() {
                 break;
             }
         }
@@ -1123,9 +1120,9 @@ mod test_node_counts {
         assert_eq!(
             counted,
             vec![
-                ("opening", 171_858),
+                ("opening", 171_844),
                 ("kiwipete", 218_290),
-                ("pawn endgame", 180_219),
+                ("pawn endgame", 180_127),
                 ("promotions", 120_717),
                 ("middlegame", 199_263),
             ]

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -214,7 +214,6 @@ impl AlphaBeta {
         }
 
         let mut best_move: Option<Play> = None;
-        let mut best_board: Option<u64> = None;
         let old_alpha = alpha;
         let mut score: Score;
         let pv_line = self.moves.get(self.board.key);
@@ -232,7 +231,6 @@ impl AlphaBeta {
         for m in &moves {
             if self.board.make_move(m) {
                 score = -self.quiescence(-beta, -alpha);
-                let move_key = self.board.key;
                 self.board.undo_move().unwrap();
                 if self.should_stop {
                     // The search was aborted somewhere below us, so the score
@@ -246,7 +244,6 @@ impl AlphaBeta {
                     }
                     alpha = score;
                     best_move = Some(*m);
-                    best_board = Some(move_key);
                 }
             }
         }
@@ -256,7 +253,6 @@ impl AlphaBeta {
                 self.board.key,
                 Pv {
                     play: best_move.unwrap(),
-                    next_key: best_board.unwrap(),
                     score: score_to_tt(alpha, self.board.line_ply),
                     depth: 0, // Never use a quiescence move instead of evaluating, only for move ordering
                     node: Node::Ordering,
@@ -333,7 +329,6 @@ impl AlphaBeta {
         let mut score: Score;
         let mut found_legal_move = false;
         let mut best_move: Option<&Play> = None;
-        let mut best_board: Option<u64> = None;
         let (pv_play, tt_score) = self.get_transposition(self.board.key, alpha, beta, depth);
         if let Some(tt_score) = tt_score {
             return tt_score;
@@ -354,7 +349,6 @@ impl AlphaBeta {
             if self.board.make_move(m) {
                 found_legal_move = true;
                 score = -self.alpha_beta(-beta, -alpha, depth - 1);
-                let move_key = self.board.key;
                 self.board.undo_move().unwrap();
                 if self.should_stop {
                     // The search was aborted somewhere below us, so the score
@@ -364,13 +358,11 @@ impl AlphaBeta {
                 }
                 if score > alpha {
                     best_move = Some(m);
-                    best_board = Some(move_key);
                     if score >= beta {
                         self.moves.set(
                             self.board.key,
                             Pv {
                                 play: *m,
-                                next_key: move_key,
                                 depth,
                                 score: score_to_tt(beta, self.board.line_ply),
                                 node: Node::Beta,
@@ -396,7 +388,6 @@ impl AlphaBeta {
                 self.board.key,
                 Pv {
                     play: *best_move.unwrap(),
-                    next_key: best_board.unwrap(),
                     depth,
                     score: score_to_tt(alpha, self.board.line_ply),
                     node: Node::Exact,
@@ -410,7 +401,6 @@ impl AlphaBeta {
 
 #[derive(Copy, Clone, Debug)]
 struct Pv {
-    next_key: u64,
     play: Play,
     score: Score,
     // a depth cannot exceed MAX_DEPTH and a ply is bounded by the history
@@ -546,6 +536,7 @@ mod test_search {
     use super::Board;
     use super::Engine;
     use super::Game;
+    use super::{Node, Play, Pv};
     use pretty_assertions::assert_eq;
     use std::time;
 
@@ -557,6 +548,27 @@ mod test_search {
 
     fn engine(board: Board) -> AlphaBeta {
         AlphaBeta::with_table_bytes(board, TABLE_BYTES)
+    }
+
+    /// The move of this name in this position, so that a test can name a line
+    /// the way the rest of the world does.
+    fn play_named(board: &Board, name: &str) -> Play {
+        *board
+            .generate_moves()
+            .iter()
+            .find(|m| format!("{}", m) == name)
+            .unwrap_or_else(|| panic!("{} is not a move here", name))
+    }
+
+    /// An entry of the kind a completed search leaves behind.
+    fn searched(play: Play, ply: usize) -> Pv {
+        Pv {
+            play,
+            score: 0,
+            depth: 5,
+            node: Node::Exact,
+            ply: ply as u16,
+        }
     }
 
     #[test]
@@ -712,6 +724,122 @@ mod test_search {
     }
 
     #[test]
+    fn test_pv_line_stops_at_a_repetition() {
+        // a shuffle both sides are content with leaves the table holding a line
+        // that goes round for ever. The game is over the third time the
+        // position comes up, so the line has to stop there rather than report a
+        // continuation nobody would be allowed to play.
+        let game = Board::from_fen(
+            "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 b - - 3 19",
+        )
+        .unwrap();
+        let mut e = engine(game);
+        let cycle = ["a8b8", "a1b1", "b8a8", "b1a1"];
+        let mut board = e.board;
+        for name in cycle.iter().cycle().take(16) {
+            let play = play_named(&board, name);
+            e.moves.set(board.key, searched(play, board.ply));
+            assert!(board.make_move(&play), "failed to play {}", name);
+        }
+
+        assert_eq!(
+            format!("{}", e.pv_line()),
+            "a8b8 a1b1 b8a8 b1a1 a8b8 a1b1 b8a8 b1a1"
+        );
+    }
+
+    #[test]
+    fn test_pv_line_stops_when_the_fifty_move_counter_runs_out() {
+        let game = Board::from_fen("5k2/1p3p1p/p3pK1P/P1P1P3/4bP2/2B5/8/8 w - - 99 112").unwrap();
+        let mut e = engine(game);
+        let mut board = e.board;
+        for name in ["c3d4", "f8g8"] {
+            let play = play_named(&board, name);
+            e.moves.set(board.key, searched(play, board.ply));
+            assert!(board.make_move(&play), "failed to play {}", name);
+        }
+        assert_eq!(board.fifty_move_rule, 101);
+
+        // the first move draws by the fifty move rule, so the reply the table
+        // holds is one the game never gets to
+        assert_eq!(format!("{}", e.pv_line()), "c3d4");
+    }
+
+    #[test]
+    fn test_pv_line_does_not_follow_a_move_which_is_illegal_here() {
+        // two positions which hash to the same key share an entry, so the move
+        // a probe comes back with is not always a move of the position asked
+        // about
+        let mut e = engine(Board::new());
+        let a2 = 8;
+        let a5 = 32;
+        let colliding = Play::new(a2, a5, None, None, false, false);
+        e.moves.set(e.board.key, searched(colliding, e.board.ply));
+
+        assert_eq!(format!("{}", e.pv_line()), "");
+    }
+
+    #[test]
+    fn test_pv_line_does_not_follow_a_quiescence_entry() {
+        // quiescence looks at captures alone, so its move is fit for ordering
+        // the next search and not for saying what the engine means to play
+        let mut e = engine(Board::new());
+        let play = play_named(&e.board, "e2e4");
+        e.moves.set(
+            e.board.key,
+            Pv {
+                play,
+                score: 0,
+                depth: 0,
+                node: Node::Ordering,
+                ply: 0,
+            },
+        );
+
+        assert_eq!(format!("{}", e.pv_line()), "");
+    }
+
+    #[test]
+    fn test_pv_line_does_not_follow_a_move_which_leaves_the_king_in_check() {
+        // moves are generated pseudo legally, so a pinned piece's move is in
+        // the list for this position and still cannot be played. Asking whether
+        // the move belongs to this position is not enough on its own, which is
+        // why the walk goes on to check that making it succeeds.
+        let board = Board::from_fen("4r2k/8/8/8/8/8/4N3/4K3 w - - 0 1").unwrap();
+        let mut e = engine(board);
+        let pinned = play_named(&e.board, "e2d4");
+        e.moves.set(e.board.key, searched(pinned, e.board.ply));
+
+        assert_eq!(format!("{}", e.pv_line()), "");
+    }
+
+    #[test]
+    fn test_pv_line_is_bounded_by_the_search_depth() {
+        // pawns only, so no position comes up twice and the fifty move counter
+        // keeps being reset: nothing stops this line but the bound
+        let mut names = Vec::new();
+        for file in "abcdefgh".chars() {
+            names.push(format!("{file}2{file}3"));
+            names.push(format!("{file}7{file}6"));
+        }
+        for file in "abcdefgh".chars() {
+            names.push(format!("{file}3{file}4"));
+            names.push(format!("{file}6{file}5"));
+        }
+
+        let mut e = engine(Board::new());
+        let mut board = e.board;
+        for name in &names {
+            let play = play_named(&board, name);
+            e.moves.set(board.key, searched(play, board.ply));
+            assert!(board.make_move(&play), "failed to play {}", name);
+        }
+
+        assert!(names.len() > super::MAX_DEPTH as usize);
+        assert_eq!(e.pv_line().line.len(), super::MAX_DEPTH as usize);
+    }
+
+    #[test]
     fn test_stopped_search_does_not_poison_cache() {
         let fen = "r1b2rk1/ppp1qppp/4pn2/6N1/Qn1P4/2NBP3/PP3PPP/R3K2R w KQ - 9 12";
         let game = Board::from_fen(fen).unwrap();
@@ -743,7 +871,6 @@ mod test_hash_table {
 
     fn new_pv(node: Node, depth: u8, ply: u16) -> Pv {
         Pv {
-            next_key: 0,
             play: Play::new(0, 1, None, None, false, false),
             score: 0,
             depth,
@@ -884,14 +1011,41 @@ impl Engine for AlphaBeta {
         println!("{}", self.board);
     }
 
+    /// Replay the line the table holds on a copy of the board, one stored move
+    /// at a time. Walking the positions rather than following a key from one
+    /// entry to the next is what lets the line be checked as it is built: the
+    /// board says whether a stored move is legal here, and whether the line has
+    /// reached a position it would be a draw to play on from.
     fn pv_line(&self) -> PvLine {
         let mut line = Vec::new();
-        let mut key = self.board.key;
-        while let Some(pv) = self.moves.get(key) {
-            line.push(pv.play);
-            key = pv.next_key;
-            if line.len() >= 16 {
-                break; // TODO resolve hash colisions to prevent errors here
+        // Board is Copy, so the search's own board is untouched by this.
+        let mut board = self.board;
+        while line.len() < MAX_DEPTH as usize {
+            let Some(pv) = self.moves.get(board.key) else {
+                break;
+            };
+            if matches!(pv.node, Node::Ordering) {
+                // written by quiescence, which looks at captures alone, so the
+                // move is fit for ordering the next search and not for telling
+                // anyone what the engine intends to play
+                break;
+            }
+            let play = pv.play;
+            // a probe compares the whole key, so what still gets through is
+            // another position which hashed to the same one. Its move belongs
+            // to that position, and playing it here would print a line the
+            // rules do not allow
+            if !board.generate_moves().contains(&play) {
+                break;
+            }
+            if !board.make_move(&play) {
+                break;
+            }
+            line.push(play);
+            // the line is a draw from here, so whatever the table says comes
+            // next is a continuation that would never be played
+            if board.fifty_move_rule >= 100 || board.is_repetition() {
+                break;
             }
         }
         PvLine { line }
@@ -969,11 +1123,11 @@ mod test_node_counts {
         assert_eq!(
             counted,
             vec![
-                ("opening", 173_101),
-                ("kiwipete", 218_914),
-                ("pawn endgame", 183_004),
-                ("promotions", 120_636),
-                ("middlegame", 202_558),
+                ("opening", 171_858),
+                ("kiwipete", 218_290),
+                ("pawn endgame", 180_219),
+                ("promotions", 120_717),
+                ("middlegame", 199_263),
             ]
         );
     }


### PR DESCRIPTION
The strength matches report `Warning; PV continues after threefold repetition`. Two commits, because it takes both to stop it.

## Rebuild the principal variation by replaying it

`pv_line` did not report the line the search followed. It reconstructed one afterwards by chasing `next_key` from entry to entry, with no board and no history, so when two entries pointed at each other it cycled until `if line.len() >= 16 { break }` stopped it.

```
ply 61: a2a5 d2e2 a5a2 e2d2  a2a5 d2e2 a5a2 e2d2  a2a5 d2e2 a5a2 e2d2  a2a5 d2e2 a5a2 e2d2
```

It now copies the board and replays the moves, so at every step it knows what the position is and can ask real questions of it.

Two of the checks are worth distinguishing. A probe compares the whole key, so what gets through is another position that hashed to the same one, and its move belongs to that position — asking whether the move is in *this* position's list catches that. But moves are generated pseudo-legally, so a pinned piece's move is in the list and still cannot be played, which is what making it and looking at the answer catches. Both have a test.

The bound becomes `MAX_DEPTH` rather than the 16 that existed to stop an infinite loop, and the collision TODO is answered.

**Quiescence entries no longer reach the PV.** 2fb47b1 added `Node::Ordering` so they could not be used as a search move, but it filtered `get_transposition`, and `pv_line` walks the table directly.

**`next_key` is dead.** It existed only to chain the PV. Removing it takes a table slot from 40 bytes to 32, so 500MB holds 16.4 million positions instead of 13.1 million, and it was the biggest obstacle to a packed 16 byte entry later.

## Take a draw on the first repetition rather than the third

The first commit alone does not stop the warning. I originally wrote that it did, and that was wrong twice over — about the effect, and about the mechanism.

**The mechanism is the en passant hashing, which is already in the readme's known issues.** A double pawn push hashes an en passant key whether or not any enemy pawn can actually capture; fastchess and python-chess only hash it when one can. In the game that produced the first warning, move 102 is `h7h5` with nothing able to take. So arche's key for that position differs from its key for the same position later, and **arche's repetition count is short by exactly one**:

```
after pv 3 a3c1: rep_count=0  is_rep=false   <- fastchess sees a threefold here
after pv 7 a3c1: rep_count=1  is_rep=false   <- so the line runs on
after pv 8 e2d3: rep_count=2  is_rep=true    <- arche stops, one cycle late
```

Replaying the same game with `h7h6`, the only difference being that no en passant key is mixed in, moves the stop to ply 7 and no warning fires.

`is_repetition` reports a repetition once the position has been seen twice before, which is the rule a game is drawn by and is later than a search needs. A position that has come up twice can be reached a third time by whichever side wants it, so the draw is already available to both. Taking it on the first repetition is worth doing on its own terms — it saves four plies of depth spent confirming something settled — and it also happens to cover the counting error above exactly:

Only one history entry per fifty-move window can carry the taint, because the tainted position is the one immediately after a double push and a double push is irreversible, so it is always the window opener and there is exactly one. Arche's count is therefore either right or short by one. Asking for one occurrence rather than two means arche stops at the first position where its own count reaches one, so at every earlier position the true count was at most one, so no threefold can have been missed. Asking for two leaves no such slack, which is why the first commit alone still warned.

**This buys a cycle of slack over a key bug rather than fixing it.** Fixing the en passant hashing is what actually closes it; that stays a known issue.

## Measured

500 games of the second commit against the first, at 5+0.05 with `8moves_v3`, on a runner:

```
Elo: 8.34 +/- 19.46, nElo: 13.07 +/- 30.45
LOS: 79.99 %, DrawRatio: 56.80 %, PairsRatio: 1.30
Games: 500, Wins: 195, Losses: 183, Draws: 122, Points: 256.0 (51.20 %)
Ptnml(0-2): [17, 30, 142, 46, 15]
```

No measurable strength difference, and none expected: two of the five pinned node counts do not move at all and the rest move by less than a tenth of a percent, because repetitions barely arise inside the horizon with pieces still on. Clean run, 500 of 500, even colours, no disconnects, no losses on time.

What the match does show is the part elo cannot. Across it the first commit alone emitted **45** `PV continues after threefold repetition` warnings and the two together emitted **none**.

## Node counts

They move twice, once per commit, and both times only because the table holds a different number of positions or the search cuts a repeated line sooner. Before updating them in the first commit, the five positions were re-run with the table sized to give the entry count the old layout produced, and all five came back identical to master. Note `kiwipete` goes up: more entries means different collisions, not strictly fewer.

## Tests

Seven. The walk stops at a repetition, stops when the fifty move counter runs out, does not follow a move that is not this position's, does not follow a move that is this position's but leaves the king in check, does not follow a quiescence entry, and is bounded by `MAX_DEPTH`; and the two repetition predicates fire a cycle apart. Each guard was removed in turn and the suite checked — the pinned-move test exists because the first pass through that exercise found the one guard nothing covered.

## Checked

`cargo fmt --check`, clippy `-D warnings`, full suite in release and debug: 26 + 79, 1 ignored.