### PR TITLE
Let the strength match name both sides

### DIFF
--- a/.github/workflows/strength.yml
+++ b/.github/workflows/strength.yml
@@ -1,58 +1,117 @@
 name: Strength
 
-# Plays the checked out version against the last full release and reports the
-# elo difference. Run it from the actions tab against any branch or tag, or let
-# the release workflow call it.
+# Plays one version of the engine against another and reports the elo
+# difference. By default it is whatever it was run against versus the last full
+# release, which is what the release workflow wants. Both sides can be named
+# instead, as a branch, a tag, a commit or a pull request number, so a change
+# can be measured before it is merged and against something other than a
+# release.
+#
+# Fifty games only separates versions that differ by a hundred elo or so. A
+# change worth a handful needs thousands, so raise the count and shorten the
+# time control when the answer matters.
 
 on:
   workflow_dispatch:
     inputs:
+      candidate:
+        description: What to test. A branch, tag, commit or pull request number. Defaults to the ref this is run against.
+        type: string
+      baseline:
+        description: What to measure it against. Same forms. Defaults to the last full release.
+        type: string
       games:
         description: Games to play, rounded down to an even number
         type: number
         default: 50
+      time_control:
+        description: Passed to fastchess as tc
+        type: string
+        default: 10+0.1
   workflow_call:
     inputs:
+      candidate:
+        type: string
+        required: false
+      baseline:
+        type: string
+        required: false
       games:
         type: number
         default: 50
+      time_control:
+        type: string
+        default: 10+0.1
       publish:
         description: Append the result to the release notes for this tag
         type: boolean
         default: false
 
-env:
-  TIME_CONTROL: 10+0.1
-
 jobs:
   # Split out so the match job can be skipped in one place rather than every
   # step having to ask whether there is anything to compare against.
-  previous:
+  resolve:
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.find.outputs.tag }}
+      baseline_name: ${{ steps.find.outputs.baseline_name }}
+      baseline_sha: ${{ steps.find.outputs.baseline_sha }}
+      candidate_name: ${{ steps.find.outputs.candidate_name }}
+      candidate_sha: ${{ steps.find.outputs.candidate_sha }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      # Release candidates are not a baseline worth measuring against, and a
-      # release is compared with the one before it rather than with itself.
-      - name: Find the last full release
+      - name: Work out what is playing what
         id: find
+        env:
+          CANDIDATE: ${{ inputs.candidate }}
+          BASELINE: ${{ inputs.baseline }}
         run: |
+          # a number is a pull request, whose head is not fetched by default;
+          # anything else is a branch, tag or commit
+          resolve() {
+            if [ "$1" -eq "$1" ] 2>/dev/null; then
+              git fetch -q origin "refs/pull/$1/head" || return 1
+              git rev-parse FETCH_HEAD
+              return 0
+            fi
+            git rev-parse --verify --quiet "$1^{commit}" && return 0
+            git fetch -q origin "$1" && git rev-parse FETCH_HEAD
+          }
+
+          if [ -n "$CANDIDATE" ]; then
+            sha=$(resolve "$CANDIDATE") || { echo "::error::cannot resolve candidate ${CANDIDATE}"; exit 1; }
+            echo "candidate_name=${CANDIDATE}" >> "$GITHUB_OUTPUT"
+            echo "candidate_sha=${sha}" >> "$GITHUB_OUTPUT"
+          else
+            echo "candidate_name=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "candidate_sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "$BASELINE" ]; then
+            sha=$(resolve "$BASELINE") || { echo "::error::cannot resolve baseline ${BASELINE}"; exit 1; }
+            echo "baseline_name=${BASELINE}" >> "$GITHUB_OUTPUT"
+            echo "baseline_sha=${sha}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Release candidates are not a baseline worth measuring against, and a
+          # release is compared with the one before it rather than with itself.
           tag=$(git tag --list 'v[0-9]*' --sort=-v:refname \
                 | grep -v -- '-' \
                 | grep -v -x "$GITHUB_REF_NAME" \
                 | head -1)
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "baseline_name=${tag}" >> "$GITHUB_OUTPUT"
           if [ -z "$tag" ]; then
             echo "::notice::No previous release to compare against, skipping"
+          else
+            echo "baseline_sha=$(git rev-parse "${tag}^{commit}")" >> "$GITHUB_OUTPUT"
           fi
 
   match:
-    needs: previous
-    if: needs.previous.outputs.tag != ''
+    needs: resolve
+    if: needs.resolve.outputs.baseline_sha != ''
     runs-on: ubuntu-latest
     outputs:
       line: ${{ steps.summary.outputs.line }}
@@ -61,7 +120,11 @@ jobs:
     timeout-minutes: 180
     env:
       GAMES: ${{ inputs.games }}
-      PREVIOUS: ${{ needs.previous.outputs.tag }}
+      TIME_CONTROL: ${{ inputs.time_control }}
+      CANDIDATE: ${{ needs.resolve.outputs.candidate_name }}
+      CANDIDATE_SHA: ${{ needs.resolve.outputs.candidate_sha }}
+      PREVIOUS: ${{ needs.resolve.outputs.baseline_name }}
+      BASELINE_SHA: ${{ needs.resolve.outputs.baseline_sha }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -89,12 +152,20 @@ jobs:
 
       - name: Build both versions
         run: |
+          # a pull request head is not fetched by default and the resolve job
+          # ran on a different machine, so fetch anything not already here
+          for sha in "$CANDIDATE_SHA" "$BASELINE_SHA"; do
+            git cat-file -e "${sha}^{commit}" 2>/dev/null \
+              || git fetch -q origin "$sha" \
+              || git fetch -q origin "+refs/pull/*/head:refs/remotes/pull/*"
+          done
+          git checkout --detach "$CANDIDATE_SHA"
           cargo build --release
           cp target/release/arche tools/new
-          git checkout --detach "$PREVIOUS"
+          git checkout --detach "$BASELINE_SHA"
           cargo build --release
           cp target/release/arche tools/old
-          # back to the version under test, the summary script lives there
+          # back to the ref this was run against, the summary script lives there
           git checkout --detach "$GITHUB_SHA"
 
       - name: Play the match
@@ -104,7 +175,7 @@ jobs:
           # uci, which four copies starting at once can take longer over than
           # the ten second default allows
           ./fastchess \
-            -engine "name=$GITHUB_REF_NAME" cmd=./new \
+            -engine "name=$CANDIDATE" cmd=./new \
             -engine "name=$PREVIOUS" cmd=./old \
             -each proto=uci "tc=$TIME_CONTROL" -startup-ms 20000 \
             -openings file=8moves_v3.pgn format=pgn order=random \
@@ -120,7 +191,13 @@ jobs:
           line="Performance compared to ${PREVIOUS} | $(python3 scripts/match_summary.py tools/result.txt)"
           echo "::notice::$line"
           echo "line=${line}" >> "$GITHUB_OUTPUT"
-          echo "$line" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "${CANDIDATE} (\`${CANDIDATE_SHA:0:8}\`) against ${PREVIOUS} (\`${BASELINE_SHA:0:8}\`)"
+            echo
+            echo "$line"
+            echo
+            echo "At ${GAMES} games only a difference of about $(python3 -c "print(int(800/(${GAMES}**0.5)))") elo can be told from none."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # The docker workflow appends to the same release notes, and the edit is a
   # read and a write rather than an append, so the two have to take turns.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -153,14 +153,33 @@ Notes on the flags:
   Watch for `disconnect` in the output, a crashing engine scores zero for that
   game and the result is no longer a fair estimate of strength.
 
-The error bar shrinks with the square root of the number of games. Fifty games
-only detects very large differences, a few hundred is needed before a result of
-twenty or thirty elo means anything.
+The error bar shrinks with the square root of the number of games, so roughly
+`800 / sqrt(games)` elo is the smallest difference a match can tell from none.
+Fifty games settles nothing below about a hundred elo. A change worth ten needs
+thousands of games, which is worth knowing before spending an afternoon on one
+that cannot be measured:
+
+| games | smallest difference worth believing |
+| --- | --- |
+| 50 | ~110 elo |
+| 500 | ~35 elo |
+| 5000 | ~11 elo |
 
 The **Strength** workflow does the same thing on a runner. Run it from the
-actions tab against any branch or tag and give it a number of games, and it
-plays that version against the last full release, ignoring release candidates.
-The result goes to the run summary.
+actions tab and it plays one version against another, reporting to the run
+summary.
+
+Both sides can be named, as a branch, a tag, a commit or a pull request number:
+
+- `candidate` is what is being tested, and defaults to the ref the workflow was
+  run against
+- `baseline` is what it is measured against, and defaults to the last full
+  release, ignoring release candidates
+- `games` and `time_control` are the size and the speed of the match
+
+So a change can be measured before it is merged by running the workflow with
+`candidate` set to the pull request number and leaving the rest alone, or two
+arbitrary commits compared by naming both.
 
 The release workflow calls the same workflow with fifty games, and that run is
 the only one that appends its result to the release notes.


### PR DESCRIPTION
The match always played whatever it was run against versus the last full release. That answers the question a release asks and not the one a change asks, which is whether this branch beats the thing it is about to be merged into. Measuring that meant merging first and finding out afterwards.

## What changes

Both sides can now be named, as a branch, a tag, a commit or a pull request number:

| input | default |
| --- | --- |
| `candidate` | the ref the workflow was run against |
| `baseline` | the last full release, ignoring release candidates |
| `games` | 50 |
| `time_control` | 10+0.1 |

Both defaults are what happened before, so the release path is unchanged and `workflow_call` keeps working with the arguments it already passes.

Measuring a change before it lands is now: run the workflow, put the pull request number in `candidate`, leave the rest alone.

Ref resolution was checked against this repository rather than assumed:

```
v0.3.8                   -> c9548fc9c0b4
master                   -> a4c77bc36229
origin/master            -> ec9ce7df0eb7
35                       -> ed7228576d4e     <- pull request number
fix-pv-reconstruction    -> ed7228576d4e     <- same commit, by branch
wibble-does-not-exist    -> FAILED
```

Two things that would have bitten otherwise: a pull request head is not fetched by default, and the job that resolves the refs runs on a different machine from the one that builds them. The build step fetches anything it does not already have rather than assuming a name resolves the same way twice.

## The time control is an input too

Fifty games at 10+0.1 cannot see a difference below about a hundred elo. The way to see a smaller one is more games at a faster control, and that was not reachable without editing the file.

## The summary says what it can and cannot tell you

It now names both commits and states the smallest difference the game count could have detected. This came out of measuring a real change and getting `+70 elo, 95% interval -0 to +147` from sixty games, which reads like a result and is not one.

`docs/DEVELOPMENT.md` gets the same point as a table, since it is worth knowing before spending an afternoon on a change that cannot be measured at the size a match will be run at:

| games | smallest difference worth believing |
| --- | --- |
| 50 | ~110 elo |
| 500 | ~35 elo |
| 5000 | ~11 elo |

## Checked

All seven workflow files parse. The resolution shell was run against the real repository, including the failure case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSBdRtPp2XNa7FugJLaizW)_