### PR TITLE
Correct how sensitive a match of a given size is

### DIFF
--- a/.github/workflows/strength.yml
+++ b/.github/workflows/strength.yml
@@ -184,7 +184,13 @@ jobs:
 
       - name: Summarise the result
         id: summary
+        env:
+          # measured, not assumed: a release against the one before it came out
+          # at 684/sqrt(games), two branches a couple of lines apart at 411,
+          # because near identical builds draw far more and the variance falls
+          SENSITIVITY_CONSTANT: 684
         run: |
+          SENSITIVITY=$(python3 -c "print(int(${SENSITIVITY_CONSTANT}/(${GAMES}**0.5)))")
           if grep -qiE 'disconnect|stalled|loses on time' tools/result.txt; then
             echo "::warning::An engine crashed or lost on time, the estimate is unreliable"
           fi
@@ -196,7 +202,11 @@ jobs:
             echo
             echo "$line"
             echo
-            echo "At ${GAMES} games only a difference of about $(python3 -c "print(int(800/(${GAMES}**0.5)))") elo can be told from none."
+            # the interval fastchess prints is the one to trust; this is only
+            # to stop a null result being read as a finding. Two builds that
+            # differ by little draw a lot, which is what makes the interval
+            # narrower than a release to release comparison of the same length
+            echo "Roughly ${SENSITIVITY} elo is the smallest difference ${GAMES} games can tell from none, less if the two are close enough to draw often. The interval above is the real one."
           } >> "$GITHUB_STEP_SUMMARY"
 
   # The docker workflow appends to the same release notes, and the edit is a

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -153,17 +153,29 @@ Notes on the flags:
   Watch for `disconnect` in the output, a crashing engine scores zero for that
   game and the result is no longer a fair estimate of strength.
 
-The error bar shrinks with the square root of the number of games, so roughly
-`800 / sqrt(games)` elo is the smallest difference a match can tell from none.
-Fifty games settles nothing below about a hundred elo. A change worth ten needs
-thousands of games, which is worth knowing before spending an afternoon on one
-that cannot be measured:
+The error bar shrinks with the square root of the number of games, and how fast
+depends on how alike the two engines are. Two builds that differ by little draw
+far more often, the variance of a paired result falls, and the same number of
+games says more. Both of these are measured from real runs:
 
-| games | smallest difference worth believing |
+| | smallest difference worth believing |
 | --- | --- |
-| 50 | ~110 elo |
-| 500 | ~35 elo |
-| 5000 | ~11 elo |
+| a release against the one before it | `684 / sqrt(games)` |
+| two branches a few lines apart | `411 / sqrt(games)` |
+
+| games | release to release | branch to branch |
+| --- | --- | --- |
+| 50 | ~97 elo | ~58 elo |
+| 500 | ~31 elo | ~18 elo |
+| 5000 | ~10 elo | ~6 elo |
+
+So fifty games settles nothing below about a hundred elo, and a change worth
+ten needs thousands, which is worth knowing before spending an afternoon on one
+that cannot be measured at the size the match will be run at.
+
+Take the interval fastchess prints over either of these. It works from the
+pentanomial counts of the actual games, so it already knows how much the two
+drew; the figures above are only for deciding how many games to ask for.
 
 The **Strength** workflow does the same thing on a runner. Run it from the
 actions tab and it plays one version against another, reporting to the run


### PR DESCRIPTION
The strength summary and the development notes both said the smallest difference a match can see is `800 / sqrt(games)`. I put that figure in and it is wrong.

The first real run under it reported an interval of **±19.5 elo** with a line underneath saying **35 elo** was the least it could tell from none. A summary that contradicts the number directly above it teaches people to ignore both.

## The constant is not one number

It depends on how alike the two engines are. A pair that differ by little draw far more often, the variance of a paired result falls, and the same number of games says more. Recomputed from the pentanomial counts of two real runs:

| run | games | drawn pairs | interval | implied constant |
| --- | --- | --- | --- | --- |
| v0.3.8 against the release before it | 50 | 16% | ±96.8 | **684** |
| two branches a couple of lines apart | 320 | 59% | ±23.0 | **411** |

Against the 800 that was being claimed for both.

The summary now uses 684, which is the conservative figure and the case the workflow runs by default, and says a closer pair does better. `DEVELOPMENT.md` gets both, since choosing a game count is the one thing these figures are good for:

| games | release to release | branch to branch |
| --- | --- | --- |
| 50 | ~97 elo | ~58 elo |
| 500 | ~31 elo | ~18 elo |
| 5000 | ~10 elo | ~6 elo |

## Both now point at the right number

The interval fastchess prints is computed from the pentanomial counts of the games actually played, so it already knows how much the two drew. That is the one to believe. These figures are for deciding how many games to ask for before a run, not for reading one afterwards, and both places now say so.

Incidentally the correction cuts both ways: the workflow is more useful than I advertised. 1200 games of a small change resolves about 12 elo, not the 23 I said when recommending run sizes.

## Checked

Workflow parses, and the summary shell was dry run with the real environment:

```
Roughly 30 elo is the smallest difference 500 games can tell from none, less if
the two are close enough to draw often. The interval above is the real one.
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSBdRtPp2XNa7FugJLaizW)_