### PR TITLE
Score the files each side's pawns stand on

### DIFF
--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -1071,6 +1071,8 @@ impl Board {
         // The pawn bitboard was cleared above and the colour bitboard is cleared
         // before the file is tested below, so the file has been emptied exactly
         // when the intersection is empty, not when it holds only this pawn.
+        // Either clear on its own is enough to keep this pawn out of the
+        // intersection, so moving the test past one of them stays correct.
         match color {
             Color::Black => {
                 self.black.clear_bit(index);
@@ -1483,7 +1485,7 @@ mod evaluate {
         assert_eq!(Board::new().eval(), 0);
     }
 
-    /// a2 and b2 are worth the same on the piece square table, so the two
+    /// b2 and c2 are worth the same on the piece square table, so the two
     /// positions differ by nothing but which files the pawns stand on.
     #[test]
     fn test_pawns_on_their_own_files_cost_isolation_and_an_island() {
@@ -1495,10 +1497,17 @@ mod evaluate {
         );
     }
 
+    /// The same two structures given to black instead, which has to move the
+    /// score the other way. Subtracting the two holds everything else still, an
+    /// assertion on the sign alone would pass on the piece square tables.
     #[test]
     fn test_an_isolated_pawn_is_a_penalty_for_the_side_that_has_it() {
-        let board = Board::from_fen("4k3/1pp5/8/8/8/8/P1P5/4K3 w - - 0 1").unwrap();
-        assert!(board.eval() < 0, "scored {}", board.eval());
+        let split = Board::from_fen("4k3/p1p5/8/8/8/8/8/4K3 w - - 0 1").unwrap();
+        let together = Board::from_fen("4k3/pp6/8/8/8/8/8/4K3 w - - 0 1").unwrap();
+        assert_eq!(
+            split.eval() - together.eval(),
+            2 * ISOLATED_FILE + EXTRA_ISLAND
+        );
     }
 
     /// A position and its reflection, colours swapped, have to score the same
@@ -1896,21 +1905,28 @@ mod pawn_files {
     use super::Game;
     use pretty_assertions::assert_eq;
 
-    fn walk(board: &mut Board, depth: u8) {
+    fn check(board: &Board) {
         assert_eq!(
             (board.white_pawn_files, board.black_pawn_files),
             board.recompute_pawn_files(),
             "{}",
             board
         );
+    }
+
+    fn walk(board: &mut Board, depth: u8) {
+        check(board);
         if depth == 0 {
             return;
         }
         for m in &board.generate_moves() {
+            // a move that leaves the king in check undoes itself, so the bytes
+            // are worth checking whether it was legal or not
             if board.make_move(m) {
                 walk(board, depth - 1);
                 board.undo_move().unwrap();
             }
+            check(board);
         }
     }
 

--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -5,6 +5,7 @@ use super::misc::{
 };
 use super::play::Play;
 use crate::Game;
+use crate::file_signature;
 use crate::magic::Magic;
 use crate::pvt::PieceValueTables;
 use crate::zorbrist::Zorbrist;
@@ -53,6 +54,16 @@ const E1: u8 = 4;
 const F1: u8 = 5;
 const G1: u8 = 6;
 const H1: u8 = 7;
+
+const FILE_MASKS: [u64; 8] = {
+    let mut masks = [0u64; 8];
+    let mut file = 0;
+    while file < 8 {
+        masks[file] = 0x0101_0101_0101_0101 << file;
+        file += 1;
+    }
+    masks
+};
 
 const A8: u8 = 56;
 const B8: u8 = 57;
@@ -277,6 +288,9 @@ pub struct Board {
     // table entries it accumulates so that summing a boardful of them, and
     // adding the material difference on top, cannot overflow.
     psqt: i32,
+    // one bit per file holding a pawn, also kept up to date incrementally
+    white_pawn_files: u8,
+    black_pawn_files: u8,
 
     //history: Vec<PlayState>,
     history: [Option<PlayState>; MAX_GAME_SIZE],
@@ -579,7 +593,11 @@ impl Board {
         // TODO should this return white value & black value as separate numbers instead?
         let eval = self.white_value as i32 - self.black_value as i32;
 
-        let eval = (eval + self.psqt) as Score;
+        let eval = eval
+            + self.psqt
+            + file_signature::score(self.white_pawn_files, self.black_pawn_files) as i32;
+
+        let eval = eval as Score;
 
         match self.active_color {
             Color::White => eval,
@@ -599,6 +617,11 @@ impl Board {
             "material out of step"
         );
         debug_assert_eq!(self.key, self.recompute_key(), "key out of step");
+        debug_assert_eq!(
+            (self.white_pawn_files, self.black_pawn_files),
+            self.recompute_pawn_files(),
+            "pawn files out of step"
+        );
     }
 
     /// The position key computed from the board rather than maintained as moves
@@ -1009,10 +1032,16 @@ impl Board {
             Color::Black => {
                 self.black.set_bit(index);
                 self.black_value += piece.material_value();
+                if matches!(piece, Piece::Pawn) {
+                    self.black_pawn_files |= 1 << (index & 7);
+                }
             }
             Color::White => {
                 self.white.set_bit(index);
                 self.white_value += piece.material_value();
+                if matches!(piece, Piece::Pawn) {
+                    self.white_pawn_files |= 1 << (index & 7);
+                }
             }
         };
     }
@@ -1039,14 +1068,27 @@ impl Board {
             Piece::Queen => self.queens.clear_bit(index),
             Piece::King => self.kings.clear_bit(index),
         };
+        // The pawn bitboard was cleared above and the colour bitboard is cleared
+        // before the file is tested below, so the file has been emptied exactly
+        // when the intersection is empty, not when it holds only this pawn.
         match color {
             Color::Black => {
                 self.black.clear_bit(index);
                 self.black_value -= piece.material_value();
+                if matches!(piece, Piece::Pawn)
+                    && (self.pawns & self.black & FILE_MASKS[(index & 7) as usize]) == 0
+                {
+                    self.black_pawn_files &= !(1 << (index & 7));
+                }
             }
             Color::White => {
                 self.white.clear_bit(index);
                 self.white_value -= piece.material_value();
+                if matches!(piece, Piece::Pawn)
+                    && (self.pawns & self.white & FILE_MASKS[(index & 7) as usize]) == 0
+                {
+                    self.white_pawn_files &= !(1 << (index & 7));
+                }
             }
         };
     }
@@ -1152,6 +1194,22 @@ impl Board {
         (white_value, black_value)
     }
 
+    /// The file occupancy computed from the pawn bitboards rather than
+    /// maintained as pieces are set and cleared.
+    pub fn recompute_pawn_files(&self) -> (u8, u8) {
+        let mut white = 0u8;
+        let mut black = 0u8;
+        for (file, mask) in FILE_MASKS.iter().enumerate() {
+            if (self.pawns & self.white & mask) != 0 {
+                white |= 1 << file;
+            }
+            if (self.pawns & self.black & mask) != 0 {
+                black |= 1 << file;
+            }
+        }
+        (white, black)
+    }
+
     pub fn perft(&mut self, depth: u8) -> u64 {
         // Based on psedocode at https://www.chessprogramming.org/Perft
         let mut nodes = 0;
@@ -1234,6 +1292,8 @@ impl Game for Board {
             white_value: 0,
             black_value: 0,
             psqt: 0,
+            white_pawn_files: 0,
+            black_pawn_files: 0,
 
             history: EMPTY_HISTORY,
             key: INITIAL_KEY,
@@ -1349,6 +1409,7 @@ mod evaluate {
     use super::Board;
 
     use super::Game;
+    use crate::file_signature::{EXTRA_ISLAND, ISOLATED_FILE};
     use pretty_assertions::assert_eq;
 
     macro_rules! test_fen {
@@ -1413,6 +1474,31 @@ mod evaluate {
             advanced.eval(),
             home.eval()
         );
+    }
+
+    /// Both sides hold every file, so the pawn structure cancels along with the
+    /// material and the piece square tables.
+    #[test]
+    fn test_the_starting_position_scores_level() {
+        assert_eq!(Board::new().eval(), 0);
+    }
+
+    /// a2 and b2 are worth the same on the piece square table, so the two
+    /// positions differ by nothing but which files the pawns stand on.
+    #[test]
+    fn test_pawns_on_their_own_files_cost_isolation_and_an_island() {
+        let split = Board::from_fen("4k3/8/8/8/8/8/P1P5/4K3 w - - 0 1").unwrap();
+        let together = Board::from_fen("4k3/8/8/8/8/8/PP6/4K3 w - - 0 1").unwrap();
+        assert_eq!(
+            together.eval() - split.eval(),
+            2 * ISOLATED_FILE + EXTRA_ISLAND
+        );
+    }
+
+    #[test]
+    fn test_an_isolated_pawn_is_a_penalty_for_the_side_that_has_it() {
+        let board = Board::from_fen("4k3/1pp5/8/8/8/8/P1P5/4K3 w - - 0 1").unwrap();
+        assert!(board.eval() < 0, "scored {}", board.eval());
     }
 
     /// A position and its reflection, colours swapped, have to score the same
@@ -1801,6 +1887,57 @@ mod perft {
         assert_eq!(board.perft(2), 2079);
         assert_eq!(board.perft(3), 89890);
         assert_eq!(board.perft(4), 3894594);
+    }
+}
+
+#[cfg(test)]
+mod pawn_files {
+    use super::Board;
+    use super::Game;
+    use pretty_assertions::assert_eq;
+
+    fn walk(board: &mut Board, depth: u8) {
+        assert_eq!(
+            (board.white_pawn_files, board.black_pawn_files),
+            board.recompute_pawn_files(),
+            "{}",
+            board
+        );
+        if depth == 0 {
+            return;
+        }
+        for m in &board.generate_moves() {
+            if board.make_move(m) {
+                walk(board, depth - 1);
+                board.undo_move().unwrap();
+            }
+        }
+    }
+
+    /// The bytes are only maintained by set_piece_index and clear_piece_index,
+    /// so anything that pairs them up differently is worth walking over:
+    /// captures leaving a file, promotions leaving one for good, and en passant
+    /// clearing a square the move did not land on.
+    const CASES: [(&str, u8); 5] = [
+        (
+            "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+            3,
+        ),
+        ("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1", 4),
+        (
+            "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1",
+            3,
+        ),
+        ("n1n5/PPPk4/8/8/8/8/4Kppp/5N1N w - - 0 1", 3),
+        ("8/8/1k6/2b5/2pP4/8/5K2/8 b - d3 0 1", 4),
+    ];
+
+    #[test]
+    fn test_the_occupancy_bytes_survive_make_and_undo() {
+        for (fen, depth) in CASES {
+            let mut board = Board::from_fen(fen).unwrap();
+            walk(&mut board, depth);
+        }
     }
 }
 

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -1296,11 +1296,11 @@ mod test_node_counts {
         assert_eq!(
             counted,
             vec![
-                ("opening", 149_810),
-                ("kiwipete", 217_026),
-                ("pawn endgame", 173_223),
-                ("promotions", 110_643),
-                ("middlegame", 191_607),
+                ("opening", 151_172),
+                ("kiwipete", 200_808),
+                ("pawn endgame", 168_882),
+                ("promotions", 110_814),
+                ("middlegame", 190_616),
             ]
         );
     }

--- a/basic_engine/src/file_signature.rs
+++ b/basic_engine/src/file_signature.rs
@@ -19,6 +19,9 @@ const fn penalty(files: u8) -> i16 {
     (islands - 1) * EXTRA_ISLAND + isolated * ISOLATED_FILE
 }
 
+/// Sixty five thousand iterations is within what rustc will evaluate at compile
+/// time but not by a wide margin, and going over it is a hard error rather than
+/// a slow build. Anything much heavier than this belongs in a lazy static.
 const fn build() -> [i16; 65536] {
     let mut scores = [0i16; 65536];
     let mut white = 0usize;

--- a/basic_engine/src/file_signature.rs
+++ b/basic_engine/src/file_signature.rs
@@ -1,0 +1,95 @@
+//! Scoring the shape of a pawn structure from the files it occupies.
+//!
+//! Each side's pawns reduce to one bit per file, the two bytes together index a
+//! table built at compile time, and the evaluation is then a single load. The
+//! occupancy says nothing about how many pawns stand on a file, so doubled
+//! pawns are invisible to this term.
+
+/// Centipawns charged for a pawn on a file with neither neighbouring file occupied.
+pub(crate) const ISOLATED_FILE: i16 = 12;
+/// Centipawns charged for every pawn island after the first.
+pub(crate) const EXTRA_ISLAND: i16 = 6;
+
+const fn penalty(files: u8) -> i16 {
+    if files == 0 {
+        return 0;
+    }
+    let islands = (files & !(files << 1)).count_ones() as i16;
+    let isolated = (files & !(files << 1 | files >> 1)).count_ones() as i16;
+    (islands - 1) * EXTRA_ISLAND + isolated * ISOLATED_FILE
+}
+
+const fn build() -> [i16; 65536] {
+    let mut scores = [0i16; 65536];
+    let mut white = 0usize;
+    while white < 256 {
+        let mut black = 0usize;
+        while black < 256 {
+            scores[white | black << 8] = penalty(black as u8) - penalty(white as u8);
+            black += 1;
+        }
+        white += 1;
+    }
+    scores
+}
+
+static SCORES: [i16; 65536] = build();
+
+/// Positive is good for white.
+#[inline]
+pub fn score(white_files: u8, black_files: u8) -> i16 {
+    SCORES[white_files as usize | (black_files as usize) << 8]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    /// The files a side occupies are the whole of the input, and file topology
+    /// does not know which colour it belongs to, so swapping the two bytes has
+    /// to swap the sign.
+    #[test]
+    fn the_table_is_antisymmetric() {
+        for white in 0..=255usize {
+            for black in 0..=255usize {
+                assert_eq!(
+                    score(white as u8, black as u8),
+                    -score(black as u8, white as u8),
+                    "white {:08b} against black {:08b}",
+                    white,
+                    black
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_full_board_of_files_is_even() {
+        assert_eq!(score(0xFF, 0xFF), 0);
+        assert_eq!(score(0, 0), 0);
+    }
+
+    /// A pawn on the a file has only one neighbouring file, and the shift that
+    /// looks for the other one must not find the h file.
+    #[test]
+    fn an_edge_pawn_is_isolated_when_its_only_neighbour_is_empty() {
+        assert_eq!(score(0b0000_0001, 0), -ISOLATED_FILE);
+        assert_eq!(score(0b1000_0000, 0), -ISOLATED_FILE);
+        assert_eq!(score(0b0000_0011, 0), 0);
+        assert_eq!(score(0b1100_0000, 0), 0);
+    }
+
+    #[test]
+    fn splitting_a_structure_costs_an_island() {
+        assert_eq!(score(0b1111_1111, 0), 0);
+        assert_eq!(score(0b1110_1111, 0), -EXTRA_ISLAND);
+        assert_eq!(score(0b1110_1011, 0), -2 * EXTRA_ISLAND - ISOLATED_FILE);
+    }
+
+    #[test]
+    fn a_side_is_only_charged_for_its_own_files() {
+        assert_eq!(score(0b0000_0101, 0b0000_0101), 0);
+        assert_eq!(score(0, 0b0000_0101), 2 * ISOLATED_FILE + EXTRA_ISLAND);
+    }
+}

--- a/basic_engine/src/lib.rs
+++ b/basic_engine/src/lib.rs
@@ -4,6 +4,7 @@ extern crate lazy_static;
 mod bitboard;
 mod board;
 mod engine;
+mod file_signature;
 mod magic;
 mod misc;
 mod play;


### PR DESCRIPTION
First evaluation term beyond material and piece-square tables.

Each side's pawns reduce to one bit per file. The two bytes together index a 65536-entry table built at compile time, so the evaluation is a single load. The bytes are maintained incrementally in `set_piece_index` / `clear_piece_index`, alongside the material values and the piece-square score that already live there.

The scoring is deliberately minimal to start with: a penalty per pawn island after the first, and a penalty per file whose neighbours are both empty. Both weights are named constants. No open-file, rook, majority or king-shelter terms yet.

## Correctness

The two failure modes are a wrong table and a desynchronised byte, so there is a test for each.

- File topology does not know which colour it belongs to, so `T[w | b<<8] == -T[b | w<<8]` has to hold. Checked over all 65536 entries.
- The bytes are recomputed from the pawn bitboards and compared against the maintained values at every node of a perft walk over kiwipete, position 3, position 4, the all-promotions position and an en-passant-gives-check position. Captures, promotions and en passant are where the set/clear pairs get interesting.

The clear side is the subtle one. Removing a pawn only clears the file bit if no pawn of that colour remains on the file, so it tests the bitboard rather than clearing unconditionally, and it relies on both the piece and the colour bitboard already having been updated. There is a comment on it.

## Speed

Criterion is not usable for this. Changing the evaluation changes the tree, so the same depth is no longer the same work — the search benchmarks move by up to 16% in both directions and none of it means anything.

Measured nodes per second directly instead, best of seven over four positions, iterative deepening to depth 5 with a cold table:

| | nodes | Mnps |
| --- | --- | --- |
| before | 523,915 | 6.50 / 6.34 / 6.29 |
| after | 509,592 | 6.50 / 6.21 / 6.22 / 6.17 |

The spread within each side is as wide as the gap between them, and wall clock for the same four searches is unchanged. A 128KB table is past L1, so a miss per evaluation was the thing to watch for, and it does not show up — most plausibly because a search revisits few distinct pawn signatures.

Pinned node counts move because the search sees different scores, so they are updated in the same commit.

## Known limitations

- The score is `penalty(black) - penalty(white)`, a difference of two independent per-side functions, so the 16-bit index is not yet earning its size. A 256-entry table of per-side penalties would encode the same thing in 512 bytes. The wide index only starts paying when a term depends on the interaction of the two masks, which is what open files and majorities would need.
- File occupancy cannot see how many pawns stand on a file, so doubled pawns are invisible. Combined with the island count that has a direction: recapturing towards the centre to double a pawn but connect the structure reads as strictly good.
- The two terms overlap. An isolated pawn is almost always also an extra island, so it costs 18cp rather than 12. Tune them as a pair.

Whether any of this gains elo needs a few hundred games and is not claimed here.

`cargo test --workspace` in debug and release, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_014jxWwpz5SfpeZxfbNq1qRa)_