### PR TITLE
Build the piece square tables at compile time, and check the eval counters in debug

### DIFF
--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -59,6 +59,8 @@ const F8: u8 = 61;
 const G8: u8 = 62;
 const H8: u8 = 63;
 
+static PVT: PieceValueTables = PieceValueTables::TABLES;
+
 lazy_static! {
     static ref ATTACK_MASKS: AttackMasks = AttackMasks::new();
     pub static ref BASE_CONVERSIONS: BaseConversions = BaseConversions::new();
@@ -71,7 +73,6 @@ lazy_static! {
         coordinate_to_index(8, File::H),
     ];
     static ref ZORB: Zorbrist = Zorbrist::new();
-    static ref PVT: PieceValueTables = PieceValueTables::new();
     static ref MAGIC: Magic = Magic::new();
     static ref B1_C1_D1: u64 = {
         let mut mask = 0u64;

--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -581,6 +581,56 @@ impl Board {
         }
     }
 
+    /// Check the incrementally maintained counters against the position they
+    /// describe. Perft never looks at either, so without this a mistake in them
+    /// leaves every count correct and only shows up as the engine playing
+    /// slightly worse. Debug only: it walks the whole board.
+    fn debug_assert_eval_in_step(&self) {
+        debug_assert_eq!(self.psqt, self.recompute_psqt(), "psqt out of step");
+        debug_assert_eq!(
+            (self.white_value, self.black_value),
+            self.recompute_material(),
+            "material out of step"
+        );
+    }
+
+    /// The piece square score of the position as it stands, computed from the
+    /// board rather than accumulated as pieces move. `psqt` is meant to equal
+    /// this at all times, and nothing checked that until now.
+    pub fn recompute_psqt(&self) -> isize {
+        let mut total = 0;
+        // walking the occupied squares rather than all sixty four, an empty
+        // board is then free rather than sixty four misses
+        let mut occupied = self.white | self.black;
+        while occupied != 0 {
+            let index = pop_lsb(&mut occupied);
+            if let Some((piece, color)) = self.get_piece_and_color_index(index) {
+                total += match color {
+                    Color::White => PVT.get_value(index as usize, piece, Color::White),
+                    Color::Black => -PVT.get_value(index as usize, piece, Color::Black),
+                };
+            }
+        }
+        total
+    }
+
+    /// The material of each side, computed the same way and for the same reason.
+    pub fn recompute_material(&self) -> (u32, u32) {
+        let mut white = 0;
+        let mut black = 0;
+        let mut occupied = self.white | self.black;
+        while occupied != 0 {
+            let index = pop_lsb(&mut occupied);
+            if let Some((piece, color)) = self.get_piece_and_color_index(index) {
+                match color {
+                    Color::White => white += piece.material_value(),
+                    Color::Black => black += piece.material_value(),
+                }
+            }
+        }
+        (white, black)
+    }
+
     pub fn square_attacked(&self, index: u8, color: Color) -> bool {
         let all = self.black | self.white;
         let attack_masks: &AttackMasks = &ATTACK_MASKS;
@@ -767,6 +817,7 @@ impl Board {
         };
         self.active_color = opposing_color;
         self.key ^= zorb.side;
+        self.debug_assert_eval_in_step();
         if self.square_attacked(king_index, opposing_color) {
             self.undo_move().unwrap();
             false

--- a/basic_engine/src/pvt.rs
+++ b/basic_engine/src/pvt.rs
@@ -1,13 +1,92 @@
 use crate::misc::Color;
 use crate::misc::Piece;
 
-fn mirror(array: &[isize; 64]) -> [isize; 64] {
+/// Flip a table top to bottom, so that a table written with the eighth rank
+/// first reads correctly for a board that indexes a1 as zero.
+///
+/// Written as a `while` rather than with iterators so that it can run at compile
+/// time: the tables are then constants in the binary rather than something built
+/// on startup.
+const fn mirror(array: &[isize; 64]) -> [isize; 64] {
     let mut mirrored: [isize; 64] = [0; 64];
-    for (i, a) in array.rchunks_exact(8).flatten().enumerate() {
-        mirrored[i] = *a;
+    let mut rank = 0;
+    while rank < 8 {
+        let mut file = 0;
+        while file < 8 {
+            mirrored[rank * 8 + file] = array[(7 - rank) * 8 + file];
+            file += 1;
+        }
+        rank += 1;
     }
     mirrored
 }
+
+// From https://www.chessprogramming.org/Simplified_Evaluation_Function.
+//
+// These are written the way the page prints them, with the eighth rank in the
+// top row, so the first entry is a8 and the last is h1. The board counts the
+// other way, a1 being index zero, which is why black takes the tables as
+// written and white takes them mirrored.
+
+#[rustfmt::skip]
+const PAWNS: [isize; 64] = [
+    0,  0,  0,  0,  0,  0,  0,  0,
+    50, 50, 50, 50, 50, 50, 50, 50,
+    10, 10, 20, 30, 30, 20, 10, 10,
+    5,  5, 10, 25, 25, 10,  5,  5,
+    1,  1,  1, 20, 20,  1,  1,  1,
+    5, -5,-10,  0,  0,-10, -5,  5,
+    5, 10, 10,-20,-20, 10, 10,  5,
+    0,  0,  0,  0,  0,  0,  0,  0
+];
+
+#[rustfmt::skip]
+const KNIGHTS: [isize; 64] = [
+    -50,-40,-30,-30,-30,-30,-40,-50,
+    -40,-20,  0,  0,  0,  0,-20,-40,
+    -30,  0, 10, 15, 15, 10,  0,-30,
+    -30,  5, 15, 20, 20, 15,  5,-30,
+    -30,  0, 15, 20, 20, 15,  0,-30,
+    -30,  5, 10, 15, 15, 10,  5,-30,
+    -40,-20,  0,  5,  5,  0,-20,-40,
+    -50,-40,-30,-30,-30,-30,-40,-50,
+];
+
+#[rustfmt::skip]
+const BISHOPS: [isize; 64] = [
+    -20,-10,-10,-10,-10,-10,-10,-20,
+    -10,  0,  0,  0,  0,  0,  0,-10,
+    -10,  0,  5, 10, 10,  5,  0,-10,
+    -10,  5,  5, 10, 10,  5,  5,-10,
+    -10,  0, 10, 10, 10, 10,  0,-10,
+    -10, 10, 10, 10, 10, 10, 10,-10,
+    -10,  5,  0,  0,  0,  0,  5,-10,
+    -20,-10,-10,-10,-10,-10,-10,-20,
+];
+
+#[rustfmt::skip]
+const ROOKS: [isize; 64] = [
+    0,  0,  0,  0,  0,  0,  0,  0,
+    5, 10, 10, 10, 10, 10, 10,  5,
+    -5,  0,  0,  0,  0,  0,  0, -5,
+    -5,  0,  0,  0,  0,  0,  0, -5,
+    -5,  0,  0,  0,  0,  0,  0, -5,
+    -5,  0,  0,  0,  0,  0,  0, -5,
+    -5,  0,  0,  0,  0,  0,  0, -5,
+    0,  0,  0,  5,  5,  0,  0,  0
+];
+
+#[rustfmt::skip]
+const QUEENS: [isize; 64] = [
+    -20,-10,-10, -5, -5,-10,-10,-20,
+    -10,  0,  0,  0,  0,  0,  0,-10,
+    -10,  0,  5,  5,  5,  5,  0,-10,
+    -5,  0,  5,  5,  5,  5,  0, -5,
+    0,  0,  5,  5,  5,  5,  0, -5,
+    -10,  5,  5,  5,  5,  5,  0,-10,
+    -10,  0,  5,  0,  0,  0,  0,-10,
+    -20,-10,-10, -5, -5,-10,-10,-20
+];
 
 pub struct PieceValueTables {
     white_pawns: [isize; 64],
@@ -44,92 +123,20 @@ impl PieceValueTables {
         }
     }
 
-    pub fn new() -> Self {
-        // From https://www.chessprogramming.org/Simplified_Evaluation_Function.
-        //
-        // These are written the way the page prints them, with the eighth rank
-        // in the top row, so the first entry is a8 and the last is h1. The
-        // board counts the other way, a1 being index zero, which is why black
-        // takes the tables as written and white takes them mirrored.
-        #[rustfmt::skip]
-        let pawns = [
-            0,  0,  0,  0,  0,  0,  0,  0,
-            50, 50, 50, 50, 50, 50, 50, 50,
-            10, 10, 20, 30, 30, 20, 10, 10,
-             5,  5, 10, 25, 25, 10,  5,  5,
-             1,  1,  1, 20, 20,  1,  1,  1,
-             5, -5,-10,  0,  0,-10, -5,  5,
-             5, 10, 10,-20,-20, 10, 10,  5,
-             0,  0,  0,  0,  0,  0,  0,  0
-        ];
-        #[rustfmt::skip]
-        let knights = [
-            -50,-40,-30,-30,-30,-30,-40,-50,
-            -40,-20,  0,  0,  0,  0,-20,-40,
-            -30,  0, 10, 15, 15, 10,  0,-30,
-            -30,  5, 15, 20, 20, 15,  5,-30,
-            -30,  0, 15, 20, 20, 15,  0,-30,
-            -30,  5, 10, 15, 15, 10,  5,-30,
-            -40,-20,  0,  5,  5,  0,-20,-40,
-            -50,-40,-30,-30,-30,-30,-40,-50,
-        ];
-        #[rustfmt::skip]
-        let bishops = [
-            -20,-10,-10,-10,-10,-10,-10,-20,
-            -10,  0,  0,  0,  0,  0,  0,-10,
-            -10,  0,  5, 10, 10,  5,  0,-10,
-            -10,  5,  5, 10, 10,  5,  5,-10,
-            -10,  0, 10, 10, 10, 10,  0,-10,
-            -10, 10, 10, 10, 10, 10, 10,-10,
-            -10,  5,  0,  0,  0,  0,  5,-10,
-            -20,-10,-10,-10,-10,-10,-10,-20,
-        ];
-        #[rustfmt::skip]
-        let rooks = [
-             0,  0,  0,  0,  0,  0,  0,  0,
-             5, 10, 10, 10, 10, 10, 10,  5,
-            -5,  0,  0,  0,  0,  0,  0, -5,
-            -5,  0,  0,  0,  0,  0,  0, -5,
-            -5,  0,  0,  0,  0,  0,  0, -5,
-            -5,  0,  0,  0,  0,  0,  0, -5,
-            -5,  0,  0,  0,  0,  0,  0, -5,
-             0,  0,  0,  5,  5,  0,  0,  0
-        ];
-        #[rustfmt::skip]
-        let queens = [
-            -20,-10,-10, -5, -5,-10,-10,-20,
-            -10,  0,  0,  0,  0,  0,  0,-10,
-            -10,  0,  5,  5,  5,  5,  0,-10,
-             -5,  0,  5,  5,  5,  5,  0, -5,
-              0,  0,  5,  5,  5,  5,  0, -5,
-            -10,  5,  5,  5,  5,  5,  0,-10,
-            -10,  0,  5,  0,  0,  0,  0,-10,
-            -20,-10,-10, -5, -5,-10,-10,-20
-        ];
-        //#[rustfmt::skip]
-        //let kings = [
-        //   -30,-40,-40,-50,-50,-40,-40,-30,
-        //   -30,-40,-40,-50,-50,-40,-40,-30,
-        //   -30,-40,-40,-50,-50,-40,-40,-30,
-        //   -30,-40,-40,-50,-50,-40,-40,-30,
-        //   -20,-30,-30,-40,-40,-30,-30,-20,
-        //   -10,-20,-20,-20,-20,-20,-20,-10,
-        //    20, 20,  0,  0,  0,  0, 20, 20,
-        //    20, 30, 10,  0,  0, 10, 30, 20
-        //];
-        Self {
-            white_pawns: mirror(&pawns),
-            black_pawns: pawns,
-            white_knights: mirror(&knights),
-            black_knights: knights,
-            white_bishops: mirror(&bishops),
-            black_bishops: bishops,
-            white_rooks: mirror(&rooks),
-            black_rooks: rooks,
-            white_queens: mirror(&queens),
-            black_queens: queens,
-        }
-    }
+    /// Built at compile time, so there is nothing to construct on startup and
+    /// nothing to synchronise on when reading it.
+    pub const TABLES: PieceValueTables = PieceValueTables {
+        white_pawns: mirror(&PAWNS),
+        black_pawns: PAWNS,
+        white_knights: mirror(&KNIGHTS),
+        black_knights: KNIGHTS,
+        white_bishops: mirror(&BISHOPS),
+        black_bishops: BISHOPS,
+        white_rooks: mirror(&ROOKS),
+        black_rooks: ROOKS,
+        white_queens: mirror(&QUEENS),
+        black_queens: QUEENS,
+    };
 }
 
 #[cfg(test)]
@@ -140,7 +147,7 @@ mod tests {
 
     fn value(piece: Piece, color: Color, file: File, rank: u8) -> isize {
         let index = coordinate_to_index(rank, file) as usize;
-        PieceValueTables::new().get_value(index, piece, color)
+        PieceValueTables::TABLES.get_value(index, piece, color)
     }
 
     /// The tables are written with the eighth rank first and the board indexes


### PR DESCRIPTION
Two related changes to the evaluation side, each in its own commit.

## Build the piece square tables at compile time

The tables were built on startup behind a `lazy_static`, which meant a `Once` and an atomic on every read of a value that has been known since the source was written. The arrays are hoisted to module level constants, `mirror` becomes a `const fn`, and `PieceValueTables::TABLES` replaces `PieceValueTables::new`.

`mirror` is written as a `while` loop rather than with iterators because iterators are not available in a const context. It was previously `array.rchunks_exact(8).flatten().enumerate()`, which is the reason the table could not be a constant before now.

No behaviour change: the tables hold the same values, and the existing tests in `pvt.rs` that pin which way up they are still pass unchanged.

## Assert the eval counters against a recompute in debug

`psqt`, `white_value` and `black_value` are maintained a piece at a time as moves are made, and nothing compared them against the position they are supposed to describe. Perft counts nodes and never looks at an evaluation, so a mistake in any of them leaves every perft count correct and shows up only as the engine playing slightly worse.

`recompute_psqt` and `recompute_material` compute the same quantities from the bitboards, and a `debug_assert` at the end of `make_move` checks one against the other. That puts them under every position the perft suite reaches, which is where promotions, castling and en passant actually get exercised.

Both walk the occupied squares rather than all sixty four, which keeps the cost down. Measured back to back, the assert takes the debug test run from 66s to 99s; it moves around on a loaded machine. The release profile compiles it out entirely, so the engine as shipped is unaffected.

It found nothing, which is the expected result — every update to these counters goes through `set_piece_index` and `clear_piece_index`, which are exact inverses. It is worth having for what comes next rather than for what it catches today: null move pruning flips the side to move without moving a piece, and is the next change on the TODO list that could put the counters out of step.

## Checks

- `cargo test --workspace --release` — 79 passed
- `cargo test --workspace` (debug, so the new assert is live) — 79 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_018C1CJd4kYxW71PzqotpbJx)_