### PR TITLE
Place the engine on the ccrl scale at each release

### DIFF
--- a/.github/actions/match-tools/action.yml
+++ b/.github/actions/match-tools/action.yml
@@ -1,0 +1,41 @@
+name: Match tools
+description: Build fastchess and fetch the opening book, into tools/, cached between runs.
+
+inputs:
+  fastchess:
+    description: The fastchess release to build
+    # every fastchess release is tagged -alpha, there is no plain v1.8.2
+    default: v1.8.2-alpha
+
+runs:
+  using: composite
+  steps:
+    - name: Cache the match tools
+      id: cache
+      uses: actions/cache@v6
+      with:
+        # Named one by one rather than as the whole of tools/, because a match
+        # writes its games, its results and the engines it played into the same
+        # directory, and caching those would mean a later run restoring an
+        # earlier run's games and being able to read them as its own.
+        path: |
+          tools/fastchess
+          tools/8moves_v3.pgn
+        # the version belongs to the input rather than to the key, so that
+        # bumping it cannot leave the key naming a build it no longer describes
+        key: match-tools-${{ inputs.fastchess }}-8moves-v3
+
+    - name: Build the match tools
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        FASTCHESS: ${{ inputs.fastchess }}
+      run: |
+        mkdir -p tools
+        git clone --depth 1 --branch "$FASTCHESS" \
+          https://github.com/Disservin/fastchess.git /tmp/fastchess
+        make -C /tmp/fastchess -j"$(nproc)"
+        cp /tmp/fastchess/fastchess tools/
+        curl -sSLf -o /tmp/book.zip \
+          https://raw.githubusercontent.com/official-stockfish/books/master/8moves_v3.pgn.zip
+        unzip -qo /tmp/book.zip -d tools

--- a/.github/workflows/calibrate.yml
+++ b/.github/workflows/calibrate.yml
@@ -1,0 +1,212 @@
+name: Calibrate
+
+# Estimates what the engine would be rated on the ccrl scale by playing it
+# against engines that already have a rating there.
+#
+# This is not the same question as the Strength workflow answers. That one plays
+# a version against another version and says which is better, which is what a
+# change wants to know and says nothing about where either of them sits. This
+# one gives a number that can be compared with other engines, at the cost of
+# depending on ratings earned elsewhere, on other hardware, at a slower time
+# control. Treat it as a rough placement rather than a rating.
+#
+# The opponents are old releases of Stash, which are ranked on ccrl, build in a
+# second from a plain makefile, and are a few tens of kilobytes each. The rungs
+# are an input so they can be moved up as the engine improves: a pairing that
+# ends 25-0 says little beyond "stronger than that", so the useful opponents are
+# the ones close enough to take games off.
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate:
+        description: What to measure. A branch, tag, commit or pull request number. Defaults to the ref this is run against.
+        type: string
+      games:
+        description: Games against each opponent, rounded down to an even number
+        type: number
+        default: 26
+      time_control:
+        description: Passed to fastchess as tc
+        type: string
+        default: 20+0.2
+      ladder:
+        description: Opponents, as stash tag and ccrl blitz rating
+        type: string
+        default: v10:1620,v11:1690,v12:1886,v13:1972
+  workflow_call:
+    inputs:
+      candidate:
+        type: string
+        required: false
+      games:
+        type: number
+        default: 26
+      time_control:
+        type: string
+        default: 20+0.2
+      ladder:
+        type: string
+        default: v10:1620,v11:1690,v12:1886,v13:1972
+      publish:
+        description: Append the result to the release notes for this tag
+        type: boolean
+        default: false
+
+jobs:
+  match:
+    runs-on: ubuntu-latest
+    outputs:
+      line: ${{ steps.estimate.outputs.line }}
+    # the default ladder at the default time control takes about an hour, the
+    # rest is headroom for a slower runner or a longer control
+    timeout-minutes: 150
+    env:
+      GAMES: ${{ inputs.games }}
+      TIME_CONTROL: ${{ inputs.time_control }}
+      LADDER: ${{ inputs.ladder }}
+      CANDIDATE: ${{ inputs.candidate }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # shared with the Strength workflow, which builds the same two things the
+      # same way, so whichever runs first pays for both
+      - name: Cache the match tools
+        id: tools
+        uses: actions/cache@v6
+        with:
+          path: tools
+          key: match-tools-fastchess-1.8.2-alpha-8moves-v3
+
+      - name: Build the match tools
+        if: steps.tools.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p tools
+          # every fastchess release is tagged -alpha, there is no plain v1.8.2
+          git clone --depth 1 --branch v1.8.2-alpha \
+            https://github.com/Disservin/fastchess.git /tmp/fastchess
+          make -C /tmp/fastchess -j"$(nproc)"
+          cp /tmp/fastchess/fastchess tools/
+          curl -sSLf -o /tmp/book.zip \
+            https://raw.githubusercontent.com/official-stockfish/books/master/8moves_v3.pgn.zip
+          unzip -qo /tmp/book.zip -d tools
+
+      - name: Build the engine
+        run: |
+          mkdir -p tools
+          # a pull request head is not fetched by default; anything else is a
+          # branch, tag or commit
+          if [ -n "$CANDIDATE" ]; then
+            if [ "$CANDIDATE" -eq "$CANDIDATE" ] 2>/dev/null; then
+              git fetch -q origin "refs/pull/${CANDIDATE}/head"
+              sha=$(git rev-parse FETCH_HEAD)
+            else
+              git rev-parse --verify --quiet "${CANDIDATE}^{commit}" >/dev/null \
+                || git fetch -q origin "$CANDIDATE"
+              sha=$(git rev-parse --verify --quiet "${CANDIDATE}^{commit}" || git rev-parse FETCH_HEAD)
+            fi
+            git checkout --detach "$sha"
+          else
+            sha=$GITHUB_SHA
+          fi
+          echo "CANDIDATE_SHA=${sha}" >> "$GITHUB_ENV"
+          cargo build --release
+          cp target/release/arche tools/arche
+          # back to the ref this was run against, the estimate script lives there
+          git checkout --detach "$GITHUB_SHA"
+
+      # Not cached. Each one is a second of compiling and eighty kilobytes, so
+      # fetching a cache costs more than building them does.
+      - name: Build the opponents
+        run: |
+          git clone -q https://github.com/mhouppin/stash-bot.git /tmp/stash
+          for rung in ${LADDER//,/ }; do
+            tag=${rung%%:*}
+            git -C /tmp/stash checkout -q "$tag"
+            # the makefile moved into src/ after v12
+            dir=/tmp/stash
+            [ -f /tmp/stash/src/Makefile ] && dir=/tmp/stash/src
+            make -C "$dir" -j"$(nproc)" > /dev/null
+            cp "$dir/stash-bot" "tools/stash-${tag}"
+            git -C /tmp/stash clean -qfdx
+          done
+          ls -l tools/stash-*
+
+      - name: Play the gauntlet
+        working-directory: tools
+        run: |
+          # the engine allocates a 500MB transposition table before it answers
+          # uci, which takes it several seconds and the ten second default does
+          # not always allow for
+          engines=(-engine name=arche cmd=./arche)
+          for rung in ${LADDER//,/ }; do
+            tag=${rung%%:*}
+            # ccrl plays every engine in a match on the same hash, so give the
+            # opponents a comparable table rather than their 16MB default
+            engines+=(-engine "name=stash-${tag}" "cmd=./stash-${tag}" option.Hash=256)
+          done
+          ./fastchess "${engines[@]}" \
+            -tournament gauntlet -seeds 1 \
+            -each proto=uci "tc=$TIME_CONTROL" -startup-ms 20000 \
+            -openings file=8moves_v3.pgn format=pgn order=random \
+            -rounds "$((GAMES / 2))" -games 2 -repeat -concurrency 2 -recover \
+            -pgnout file=gauntlet.pgn \
+            | tee result.txt
+
+      - name: Work out the rating
+        id: estimate
+        run: |
+          if grep -qiE 'disconnect|stalled|loses on time' tools/result.txt; then
+            echo "::warning::An engine crashed or lost on time, the estimate is unreliable"
+          fi
+          # the pgn names the opponents stash-<tag>, the ladder names them <tag>
+          spec=$(echo "$LADDER" | sed 's/\([^,]*\)/stash-\1/g')
+          python3 scripts/rating_estimate.py tools/gauntlet.pgn arche "$spec" > estimate.txt
+          cat estimate.txt
+          line=$(grep 'ccrl blitz scale' estimate.txt)
+          echo "line=Estimated rating | ${line}" >> "$GITHUB_OUTPUT"
+          echo "::notice::${line}"
+          {
+            echo "### Rating estimate"
+            echo
+            echo "\`${CANDIDATE_SHA:0:8}\` at ${TIME_CONTROL} against ranked releases of"
+            echo "[Stash](https://github.com/mhouppin/stash-bot)."
+            echo
+            echo "| opponent | ccrl | w-d-l | score | implies |"
+            echo "| --- | --- | --- | --- | --- |"
+            grep '^|' estimate.txt
+            echo
+            grep -v '^|' estimate.txt | grep -v '^$'
+            echo
+            echo "The opponents were rated at 2m+1s on other hardware, so the"
+            echo "placement carries a systematic error the game count does not"
+            echo "describe. It is worth about a hundred points, and no number of"
+            echo "games reduces it."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # The docker and strength workflows append to the same release notes, and each
+  # edit is a read and a write rather than an append, so they have to take turns.
+  release-notes:
+    needs: match
+    if: inputs.publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: release-notes-${{ github.ref }}
+    steps:
+      - name: Add the estimate to the release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          LINE: ${{ needs.match.outputs.line }}
+        run: |
+          # the marker is an html comment, so it does not render but does let a
+          # rerun replace the line it wrote last time rather than add another
+          # cat -s closes up the blank line the deleted line leaves behind
+          body=$(gh release view "$GITHUB_REF_NAME" --json body -q .body \
+                 | sed '/<!-- arche:rating -->/d' | cat -s)
+          printf '%s\n\n%s <!-- arche:rating -->\n' "$body" "$LINE" > notes.md
+          gh release edit "$GITHUB_REF_NAME" --notes-file notes.md

--- a/.github/workflows/calibrate.yml
+++ b/.github/workflows/calibrate.yml
@@ -31,7 +31,7 @@ on:
         type: string
         default: 20+0.2
       ladder:
-        description: Opponents, as stash tag and ccrl blitz rating
+        description: Opponents to play, as stash tag and ccrl blitz rating — v10:1620,v11:1690
         type: string
         default: v10:1620,v11:1690,v12:1886,v13:1972
   workflow_call:
@@ -53,6 +53,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   match:
     runs-on: ubuntu-latest
@@ -61,6 +64,11 @@ jobs:
     # the default ladder at the default time control takes about an hour, the
     # rest is headroom for a slower runner or a longer control
     timeout-minutes: 150
+    defaults:
+      run:
+        # naming the shell is what turns on pipefail, without it a fastchess
+        # that died is hidden by the tee it is piped into
+        shell: bash
     env:
       GAMES: ${{ inputs.games }}
       TIME_CONTROL: ${{ inputs.time_control }}
@@ -71,48 +79,24 @@ jobs:
         with:
           fetch-depth: 0
 
-      # shared with the Strength workflow, which builds the same two things the
-      # same way, so whichever runs first pays for both
-      - name: Cache the match tools
-        id: tools
-        uses: actions/cache@v6
-        with:
-          path: tools
-          key: match-tools-fastchess-1.8.2-alpha-8moves-v3
+      - uses: ./.github/actions/match-tools
 
-      - name: Build the match tools
-        if: steps.tools.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p tools
-          # every fastchess release is tagged -alpha, there is no plain v1.8.2
-          git clone --depth 1 --branch v1.8.2-alpha \
-            https://github.com/Disservin/fastchess.git /tmp/fastchess
-          make -C /tmp/fastchess -j"$(nproc)"
-          cp /tmp/fastchess/fastchess tools/
-          curl -sSLf -o /tmp/book.zip \
-            https://raw.githubusercontent.com/official-stockfish/books/master/8moves_v3.pgn.zip
-          unzip -qo /tmp/book.zip -d tools
-
+      # Deliberately not Swatinem/rust-cache, which the workflows that build one
+      # commit do use. This builds whichever commit it was pointed at into the
+      # same target directory, so a cache keyed on the ref would be poisoned by
+      # whatever it was last asked to measure.
       - name: Build the engine
         run: |
-          mkdir -p tools
-          # a pull request head is not fetched by default; anything else is a
-          # branch, tag or commit
           if [ -n "$CANDIDATE" ]; then
-            if [ "$CANDIDATE" -eq "$CANDIDATE" ] 2>/dev/null; then
-              git fetch -q origin "refs/pull/${CANDIDATE}/head"
-              sha=$(git rev-parse FETCH_HEAD)
-            else
-              git rev-parse --verify --quiet "${CANDIDATE}^{commit}" >/dev/null \
-                || git fetch -q origin "$CANDIDATE"
-              sha=$(git rev-parse --verify --quiet "${CANDIDATE}^{commit}" || git rev-parse FETCH_HEAD)
-            fi
+            sha=$(scripts/resolve_ref.sh "$CANDIDATE") \
+              || { echo "::error::cannot resolve candidate ${CANDIDATE}"; exit 1; }
             git checkout --detach "$sha"
           else
             sha=$GITHUB_SHA
           fi
           echo "CANDIDATE_SHA=${sha}" >> "$GITHUB_ENV"
           cargo build --release
+          mkdir -p tools
           cp target/release/arche tools/arche
           # back to the ref this was run against, the estimate script lives there
           git checkout --detach "$GITHUB_SHA"
@@ -122,36 +106,48 @@ jobs:
       - name: Build the opponents
         run: |
           git clone -q https://github.com/mhouppin/stash-bot.git /tmp/stash
+          spec=""
           for rung in ${LADDER//,/ }; do
             tag=${rung%%:*}
-            git -C /tmp/stash checkout -q "$tag"
+            git -C /tmp/stash checkout -q "$tag" \
+              || { echo "::error::no such stash tag ${tag}"; exit 1; }
             # the makefile moved into src/ after v12
             dir=/tmp/stash
-            [ -f /tmp/stash/src/Makefile ] && dir=/tmp/stash/src
+            if [ -f /tmp/stash/src/Makefile ]; then
+              dir=/tmp/stash/src
+            fi
             make -C "$dir" -j"$(nproc)" > /dev/null
             cp "$dir/stash-bot" "tools/stash-${tag}"
             git -C /tmp/stash clean -qfdx
+            # the engines play under a stash- prefixed name, so the ladder the
+            # estimate is given has to carry the same names the games do
+            spec="${spec}${spec:+,}stash-${rung}"
           done
+          echo "LADDER_SPEC=${spec}" >> "$GITHUB_ENV"
           ls -l tools/stash-*
 
       - name: Play the gauntlet
         working-directory: tools
         run: |
-          # the engine allocates a 500MB transposition table before it answers
-          # uci, which takes it several seconds and the ten second default does
-          # not always allow for
+          # only fastchess and the book are cached, but a rerun on the same
+          # runner would still find the last attempt's games lying here
+          rm -f gauntlet.pgn result.txt config.json
           engines=(-engine name=arche cmd=./arche)
           for rung in ${LADDER//,/ }; do
             tag=${rung%%:*}
-            # ccrl plays every engine in a match on the same hash, so give the
-            # opponents a comparable table rather than their 16MB default
+            # The engine's own table is 500MB and is not settable over uci, so
+            # the sides cannot be matched. 256MB is what ccrl gives an engine
+            # and the closest the opponents get, which leaves the engine a small
+            # advantage in exactly the direction that flatters the estimate.
             engines+=(-engine "name=stash-${tag}" "cmd=./stash-${tag}" option.Hash=256)
           done
+          # the engine allocates its table before it answers uci, which takes it
+          # several seconds and the ten second default does not always allow for
           ./fastchess "${engines[@]}" \
             -tournament gauntlet -seeds 1 \
             -each proto=uci "tc=$TIME_CONTROL" -startup-ms 20000 \
             -openings file=8moves_v3.pgn format=pgn order=random \
-            -rounds "$((GAMES / 2))" -games 2 -repeat -concurrency 2 -recover \
+            -rounds "$((GAMES / 2))" -repeat -concurrency 2 -recover \
             -pgnout file=gauntlet.pgn \
             | tee result.txt
 
@@ -161,24 +157,32 @@ jobs:
           if grep -qiE 'disconnect|stalled|loses on time' tools/result.txt; then
             echo "::warning::An engine crashed or lost on time, the estimate is unreliable"
           fi
-          # the pgn names the opponents stash-<tag>, the ladder names them <tag>
-          spec=$(echo "$LADDER" | sed 's/\([^,]*\)/stash-\1/g')
-          python3 scripts/rating_estimate.py tools/gauntlet.pgn arche "$spec" > estimate.txt
-          cat estimate.txt
-          line=$(grep 'ccrl blitz scale' estimate.txt)
+          # anything the estimate wants to say about itself, a rung that played
+          # no games or a fit the pairings disagree with, goes to stderr, so it
+          # is picked up from there rather than parsed back out of the table
+          python3 scripts/rating_estimate.py \
+            tools/gauntlet.pgn arche "$LADDER_SPEC" > table.md 2> notes.txt \
+            || { cat notes.txt >&2; exit 1; }
+          # asked for again rather than cut out of the table, so that a change
+          # to how the table is laid out cannot quietly change what is published
+          line=$(python3 scripts/rating_estimate.py \
+            tools/gauntlet.pgn arche "$LADDER_SPEC" --line 2> /dev/null)
           echo "line=Estimated rating | ${line}" >> "$GITHUB_OUTPUT"
           echo "::notice::${line}"
+          while read -r remark; do
+            echo "::warning::${remark}"
+          done < notes.txt
           {
             echo "### Rating estimate"
             echo
             echo "\`${CANDIDATE_SHA:0:8}\` at ${TIME_CONTROL} against ranked releases of"
             echo "[Stash](https://github.com/mhouppin/stash-bot)."
             echo
-            echo "| opponent | ccrl | w-d-l | score | implies |"
-            echo "| --- | --- | --- | --- | --- |"
-            grep '^|' estimate.txt
-            echo
-            grep -v '^|' estimate.txt | grep -v '^$'
+            cat table.md
+            if [ -s notes.txt ]; then
+              echo
+              sed 's/^/> [!WARNING]\n> /' notes.txt
+            fi
             echo
             echo "The opponents were rated at 2m+1s on other hardware, so the"
             echo "placement carries a systematic error the game count does not"
@@ -186,27 +190,23 @@ jobs:
             echo "games reduces it."
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # The docker and strength workflows append to the same release notes, and each
-  # edit is a read and a write rather than an append, so they have to take turns.
+      # The games are the expensive part and the estimate is cheap, so keeping
+      # them means a ladder corrected afterwards can be applied without playing
+      # the hour again.
+      - name: Keep the games
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: gauntlet-${{ github.run_id }}
+          path: tools/gauntlet.pgn
+          if-no-files-found: warn
+
   release-notes:
     needs: match
     if: inputs.publish
-    runs-on: ubuntu-latest
     permissions:
       contents: write
-    concurrency:
-      group: release-notes-${{ github.ref }}
-    steps:
-      - name: Add the estimate to the release notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          LINE: ${{ needs.match.outputs.line }}
-        run: |
-          # the marker is an html comment, so it does not render but does let a
-          # rerun replace the line it wrote last time rather than add another
-          # cat -s closes up the blank line the deleted line leaves behind
-          body=$(gh release view "$GITHUB_REF_NAME" --json body -q .body \
-                 | sed '/<!-- arche:rating -->/d' | cat -s)
-          printf '%s\n\n%s <!-- arche:rating -->\n' "$body" "$LINE" > notes.md
-          gh release edit "$GITHUB_REF_NAME" --notes-file notes.md
+    uses: ./.github/workflows/release-note.yml
+    with:
+      marker: arche:rating
+      line: ${{ needs.match.outputs.line }}

--- a/.github/workflows/calibrate.yml
+++ b/.github/workflows/calibrate.yml
@@ -179,9 +179,13 @@ jobs:
             echo "[Stash](https://github.com/mhouppin/stash-bot)."
             echo
             cat table.md
+            # one alert with every remark inside it, rather than one alert each,
+            # which renders as the first alert with the rest of the markup
+            # showing through as text
             if [ -s notes.txt ]; then
               echo
-              sed 's/^/> [!WARNING]\n> /' notes.txt
+              echo "> [!WARNING]"
+              sed 's/^/> /' notes.txt
             fi
             echo
             echo "The opponents were rated at 2m+1s on other hardware, so the"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,9 @@ jobs:
       packages: write
     outputs:
       digest: ${{ steps.push.outputs.digest }}
+      # named here rather than where it is used, because the env context is not
+      # one of the few a reusable workflow's inputs are allowed to read
+      image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v7
 
@@ -96,29 +99,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # The strength workflow appends to the same release notes, and the edit is a
-  # read and a write rather than an append, so the two have to take turns.
   release-notes:
     needs: build
     if: inputs.release
-    runs-on: ubuntu-latest
     permissions:
       contents: write
-    concurrency:
-      group: release-notes-${{ github.ref }}
-    steps:
-      - name: Add the image to the release notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-          DIGEST: ${{ needs.build.outputs.digest }}
-        run: |
-          # the marker is an html comment, so it does not render but does let a
-          # rerun replace the line it wrote last time rather than add another
-          line="Docker image: \`$IMAGE\` (\`$DIGEST\`) <!-- arche:image -->"
-          # cat -s closes up the blank line the deleted line leaves behind
-          body=$(gh release view "$GITHUB_REF_NAME" --json body -q .body \
-                 | sed '/<!-- arche:image -->/d' | cat -s)
-          printf '%s\n\n%s\n' "$body" "$line" > notes.md
-          gh release edit "$GITHUB_REF_NAME" --notes-file notes.md
+    uses: ./.github/workflows/release-note.yml
+    with:
+      marker: arche:image
+      line: "Docker image: `${{ needs.build.outputs.image }}` (`${{ needs.build.outputs.digest }}`)"

--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -19,14 +19,11 @@ on:
         description: The line to add, without the marker
         type: string
         required: true
-      tag:
-        description: The release to edit. Defaults to the ref this was called for.
-        type: string
-        required: false
 
-permissions:
-  contents: read
-
+# No workflow level permissions. There is one job, it declares what it needs,
+# and a reusable workflow cannot grant itself more than its caller allowed
+# anyway, so a second more restrictive declaration up here would only be one
+# more thing to reason about on the last step of a release.
 jobs:
   append:
     runs-on: ubuntu-latest
@@ -36,7 +33,7 @@ jobs:
     concurrency:
       # Cancelling would lose the line rather than delay it, and these take
       # seconds, so a caller that has waited its turn is left to finish.
-      group: release-notes-${{ inputs.tag || github.ref }}
+      group: release-notes-${{ github.ref_name }}
       cancel-in-progress: false
     steps:
       - name: Add the line to the release notes
@@ -46,7 +43,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           MARKER: ${{ inputs.marker }}
           LINE: ${{ inputs.line }}
-          TAG: ${{ inputs.tag || github.ref_name }}
+          TAG: ${{ github.ref_name }}
         run: |
           # the marker is an html comment, so it does not render but does let a
           # rerun replace the line it wrote last time rather than add another

--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -1,0 +1,57 @@
+name: Release note
+
+# Adds one line to the notes of a release, for the workflows that finish after
+# the release exists and have something to say about it.
+#
+# Editing release notes is a read and a write rather than an append, so every
+# workflow that adds a line has to take its turn. Keeping the turn taking here
+# means there is one queue rather than one per caller, and one place to look at
+# when a line goes missing.
+
+on:
+  workflow_call:
+    inputs:
+      marker:
+        description: Identifies this workflow's line so a rerun replaces it rather than adding another
+        type: string
+        required: true
+      line:
+        description: The line to add, without the marker
+        type: string
+        required: true
+      tag:
+        description: The release to edit. Defaults to the ref this was called for.
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  append:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    concurrency:
+      # Cancelling would lose the line rather than delay it, and these take
+      # seconds, so a caller that has waited its turn is left to finish.
+      group: release-notes-${{ inputs.tag || github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Add the line to the release notes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          MARKER: ${{ inputs.marker }}
+          LINE: ${{ inputs.line }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          # the marker is an html comment, so it does not render but does let a
+          # rerun replace the line it wrote last time rather than add another
+          # cat -s closes up the blank line the deleted line leaves behind
+          body=$(gh release view "$TAG" --json body -q .body \
+                 | sed "/<!-- ${MARKER} -->/d" | cat -s)
+          printf '%s\n\n%s <!-- %s -->\n' "$body" "$LINE" "$MARKER" > notes.md
+          gh release edit "$TAG" --notes-file notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,8 +95,16 @@ jobs:
   # clock and buys two things: the two of them do not race to build and save the
   # same fastchess cache from cold, and only two jobs are ever queued to edit
   # the release notes, which is the most that queue holds without dropping one.
+  #
+  # The condition is what makes that sequencing rather than dependency. Needing
+  # a job means needing it to have succeeded, and this needs nothing strength
+  # produces, so without the condition a strength match that failed or that had
+  # no previous release to measure against would take the rating estimate down
+  # with it. Cancelled is excluded so that calling off a release does not still
+  # spend an hour of runner on it.
   calibrate:
     needs: [create-release, strength]
+    if: ${{ !cancelled() && needs.create-release.result == 'success' }}
     permissions:
       contents: write
     uses: ./.github/workflows/calibrate.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,10 +90,16 @@ jobs:
   # Places the release on the ccrl scale by playing rated opponents, which says
   # something the match against the previous release cannot: that one says which
   # of the two is better, this one says roughly where both of them sit.
+  #
+  # After strength rather than alongside it, which costs an hour of release wall
+  # clock and buys two things: the two of them do not race to build and save the
+  # same fastchess cache from cold, and only two jobs are ever queued to edit
+  # the release notes, which is the most that queue holds without dropping one.
   calibrate:
-    needs: create-release
+    needs: [create-release, strength]
     permissions:
       contents: write
     uses: ./.github/workflows/calibrate.yml
     with:
+      games: 26
       publish: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,14 @@ jobs:
     with:
       games: 50
       publish: true
+
+  # Places the release on the ccrl scale by playing rated opponents, which says
+  # something the match against the previous release cannot: that one says which
+  # of the two is better, this one says roughly where both of them sit.
+  calibrate:
+    needs: create-release
+    permissions:
+      contents: write
+    uses: ./.github/workflows/calibrate.yml
+    with:
+      publish: true

--- a/.github/workflows/strength.yml
+++ b/.github/workflows/strength.yml
@@ -47,11 +47,18 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   # Split out so the match job can be skipped in one place rather than every
   # step having to ask whether there is anything to compare against.
   resolve:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
     outputs:
       baseline_name: ${{ steps.find.outputs.baseline_name }}
       baseline_sha: ${{ steps.find.outputs.baseline_sha }}
@@ -68,20 +75,9 @@ jobs:
           CANDIDATE: ${{ inputs.candidate }}
           BASELINE: ${{ inputs.baseline }}
         run: |
-          # a number is a pull request, whose head is not fetched by default;
-          # anything else is a branch, tag or commit
-          resolve() {
-            if [ "$1" -eq "$1" ] 2>/dev/null; then
-              git fetch -q origin "refs/pull/$1/head" || return 1
-              git rev-parse FETCH_HEAD
-              return 0
-            fi
-            git rev-parse --verify --quiet "$1^{commit}" && return 0
-            git fetch -q origin "$1" && git rev-parse FETCH_HEAD
-          }
-
           if [ -n "$CANDIDATE" ]; then
-            sha=$(resolve "$CANDIDATE") || { echo "::error::cannot resolve candidate ${CANDIDATE}"; exit 1; }
+            sha=$(scripts/resolve_ref.sh "$CANDIDATE") \
+              || { echo "::error::cannot resolve candidate ${CANDIDATE}"; exit 1; }
             echo "candidate_name=${CANDIDATE}" >> "$GITHUB_OUTPUT"
             echo "candidate_sha=${sha}" >> "$GITHUB_OUTPUT"
           else
@@ -90,7 +86,8 @@ jobs:
           fi
 
           if [ -n "$BASELINE" ]; then
-            sha=$(resolve "$BASELINE") || { echo "::error::cannot resolve baseline ${BASELINE}"; exit 1; }
+            sha=$(scripts/resolve_ref.sh "$BASELINE") \
+              || { echo "::error::cannot resolve baseline ${BASELINE}"; exit 1; }
             echo "baseline_name=${BASELINE}" >> "$GITHUB_OUTPUT"
             echo "baseline_sha=${sha}" >> "$GITHUB_OUTPUT"
             exit 0
@@ -118,6 +115,11 @@ jobs:
     # enough for about five hundred games at the time control above, a run that
     # wants more is better split up
     timeout-minutes: 180
+    defaults:
+      run:
+        # naming the shell is what turns on pipefail, without it a fastchess
+        # that died is hidden by the tee it is piped into
+        shell: bash
     env:
       GAMES: ${{ inputs.games }}
       TIME_CONTROL: ${{ inputs.time_control }}
@@ -130,28 +132,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache the match tools
-        id: tools
-        uses: actions/cache@v6
-        with:
-          path: tools
-          key: match-tools-fastchess-1.8.2-alpha-8moves-v3
+      - uses: ./.github/actions/match-tools
 
-      - name: Build the match tools
-        if: steps.tools.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p tools
-          # every fastchess release is tagged -alpha, there is no plain v1.8.2
-          git clone --depth 1 --branch v1.8.2-alpha \
-            https://github.com/Disservin/fastchess.git /tmp/fastchess
-          make -C /tmp/fastchess -j"$(nproc)"
-          cp /tmp/fastchess/fastchess tools/
-          curl -sSLf -o /tmp/book.zip \
-            https://raw.githubusercontent.com/official-stockfish/books/master/8moves_v3.pgn.zip
-          unzip -qo /tmp/book.zip -d tools
-
+      # Deliberately not Swatinem/rust-cache, which the workflows that build one
+      # commit do use. This builds two arbitrary commits into the same target
+      # directory, so a cache keyed on the ref would be poisoned by whichever
+      # pair it was last asked to compare.
       - name: Build both versions
         run: |
+          mkdir -p tools
           # a pull request head is not fetched by default and the resolve job
           # ran on a different machine, so fetch anything not already here
           for sha in "$CANDIDATE_SHA" "$BASELINE_SHA"; do
@@ -171,6 +160,9 @@ jobs:
       - name: Play the match
         working-directory: tools
         run: |
+          # only fastchess and the book are cached, but a rerun on the same
+          # runner would still find the last attempt's results lying here
+          rm -f result.txt config.json
           # the engine allocates a 500MB transposition table before it answers
           # uci, which four copies starting at once can take longer over than
           # the ten second default allows
@@ -179,7 +171,7 @@ jobs:
             -engine "name=$PREVIOUS" cmd=./old \
             -each proto=uci "tc=$TIME_CONTROL" -startup-ms 20000 \
             -openings file=8moves_v3.pgn format=pgn order=random \
-            -rounds "$((GAMES / 2))" -repeat 2 -concurrency 2 -recover \
+            -rounds "$((GAMES / 2))" -repeat -concurrency 2 -recover \
             | tee result.txt
 
       - name: Summarise the result
@@ -199,27 +191,12 @@ jobs:
             echo "At ${GAMES} games only a difference of about $(python3 -c "print(int(800/(${GAMES}**0.5)))") elo can be told from none."
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # The docker workflow appends to the same release notes, and the edit is a
-  # read and a write rather than an append, so the two have to take turns.
   release-notes:
     needs: match
     if: inputs.publish
-    runs-on: ubuntu-latest
     permissions:
       contents: write
-    concurrency:
-      group: release-notes-${{ github.ref }}
-    steps:
-      - name: Add the result to the release notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          LINE: ${{ needs.match.outputs.line }}
-        run: |
-          # the marker is an html comment, so it does not render but does let a
-          # rerun replace the line it wrote last time rather than add another
-          # cat -s closes up the blank line the deleted line leaves behind
-          body=$(gh release view "$GITHUB_REF_NAME" --json body -q .body \
-                 | sed '/<!-- arche:strength -->/d' | cat -s)
-          printf '%s\n\n%s <!-- arche:strength -->\n' "$body" "$LINE" > notes.md
-          gh release edit "$GITHUB_REF_NAME" --notes-file notes.md
+    uses: ./.github/workflows/release-note.yml
+    with:
+      marker: arche:strength
+      line: ${{ needs.match.outputs.line }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .cargo
 .rustup
 
+# the scripts the workflows call leave these behind when imported
+__pycache__/
+
 # profiling
 perf.data*
 callgrind.out*

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .cargo
 .rustup
 
-# the scripts the workflows call leave these behind when imported
 __pycache__/
 
 # profiling

--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ Each release plays a short match against its predecessor and the result is added
 release notes. The estimate is only as good as the number of games behind it, which is why
 the error bar is published alongside it.
 
-The engine has not been entered into any rating list, so there is no comparable rating
-against other engines.
+Each release also plays a gauntlet against old releases of
+[Stash](https://github.com/mhouppin/stash-bot), which are ranked on the
+[ccrl](https://computerchess.org.uk/) blitz list, and the rating that implies is added
+alongside. The engine has not been entered into any rating list itself, and the gauntlet
+is played faster and on different hardware than the list it borrows its opponents from,
+so read that figure as a placement to within about a hundred points rather than a rating.
 
 ## Development
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -137,7 +137,7 @@ fastchess \
   -engine name=old cmd=/tmp/old \
   -each proto=uci tc=10+0.1 -startup-ms 20000 \
   -openings file=8moves_v3.pgn format=pgn order=random \
-  -rounds 200 -repeat 2 -concurrency 2 -recover
+  -rounds 200 -repeat -concurrency 2 -recover
 ```
 
 Notes on the flags:
@@ -147,8 +147,9 @@ Notes on the flags:
   once can take longer over than the ten second default allows. Generating the
   magic bitboards used to dominate this and no longer does, they are constants
   now, so the allowance does not need to be anywhere near as generous as it was.
-- `-repeat 2` plays each opening twice with the colours reversed, which removes
-  most of the advantage of drawing a good opening.
+- `-repeat` plays each opening twice with the colours reversed, which removes most
+  of the advantage of drawing a good opening. It takes no argument, it is a spelling
+  of `-games 2`.
 - `-recover` keeps the match going if an engine crashes rather than aborting.
   Watch for `disconnect` in the output, a crashing engine scores zero for that
   game and the result is no longer a fair estimate of strength.
@@ -229,18 +230,30 @@ around it:
 
 ### Reading the result
 
-Two error bars come out of the fit and the larger is the one reported. The first
-is how much a score of this size wobbles. The second is how far the opponents
-disagree with each other, which is the one that catches a fit being quietly
-wrong: a single rating cannot describe an engine that does better against one
-opponent than another predicts, and when that happens the first error bar is an
-understatement rather than an estimate.
+The margin printed with the figure is how much a score of that size wobbles, and
+it describes the games and nothing else.
 
-Neither of them covers the part that matters most. The opponents earned their
-ratings at 2m+1s on other hardware, and this runs at twenty seconds on a shared
-runner, so the placement carries a systematic error worth something like a
-hundred points. More games shrink the error bar printed next to the number and
-do nothing at all to that. It is a placement, not a rating.
+Whether one rating describes the results at all is a different question, and it
+is asked separately rather than folded into the margin. A single number cannot
+describe an engine that does better against one opponent than another predicts,
+so each pairing's score is compared with the one the fit expects of it, and when
+they disagree by more than chance allows the run says so and the margin should
+be read as an understatement. It is a test rather than a second opinion on
+purpose: reporting whichever of the two was larger sounded careful and was not,
+because both of them estimate the same thing when the fit is sound, so taking
+the larger inflated the margin by about a fifth and cried wolf on around two
+runs in five of perfectly ordinary data.
+
+Neither covers the part that matters most. The opponents earned their ratings at
+2m+1s on other hardware, and this runs at twenty seconds on a shared runner, so
+the placement carries a systematic error worth something like a hundred points.
+More games shrink the margin printed next to the number and do nothing at all to
+that. It is a placement, not a rating.
+
+The ladder is held as exact, too. A rung whose rating is a community estimate
+rather than a ccrl ranking, which is what v10 in the default ladder is, hands
+whatever it is wrong by straight to the answer, and no error bar here covers
+that either.
 
 The time control is a compromise rather than a default worth keeping by
 accident. Ten seconds runs the hundred games in about twenty minutes but leaves

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -184,6 +184,76 @@ arbitrary commits compared by naming both.
 The release workflow calls the same workflow with fifty games, and that run is
 the only one that appends its result to the release notes.
 
+## Placing the engine on the ccrl scale
+
+A match against the previous version says which of the two is better. It cannot
+say where either of them sits, because both sides of it are this engine. For a
+number that means something next to other engines, the opponents have to be
+engines that already have a rating.
+
+The **Calibrate** workflow plays a gauntlet against old releases of
+[Stash](https://github.com/mhouppin/stash-bot), which are ranked on the
+[ccrl](https://computerchess.org.uk/) blitz list, build in about a second from a
+plain makefile and are eighty kilobytes each. It holds each opponent at its
+published rating and fits the one number that is unknown, which is ours:
+
+```
+python3 scripts/rating_estimate.py gauntlet.pgn arche stash-v11:1690,stash-v12:1886
+```
+
+Locally the same thing is the fastchess command from the previous section with
+more `-engine` arguments and `-tournament gauntlet`, which plays the first
+engine against all the others.
+
+### Choosing the opponents
+
+`ladder` is a list of stash tags and the rating each one holds on ccrl blitz.
+The rungs that are worth playing are the ones close enough to trade games with:
+a pairing that ends 25-0 puts no upper bound on the winner, so it contributes
+almost nothing however many games it is given. The list is an input so it can be
+moved up as the engine improves.
+
+These are the versions around the range the engine is in, and whether ccrl
+ranked the version itself or the figure is a community estimate from the games
+around it:
+
+| tag | ccrl blitz | |
+| --- | --- | --- |
+| v9 | 1275 | ranked |
+| v10 | 1620 | estimated |
+| v11 | 1690 | ranked |
+| v12 | 1886 | ranked |
+| v13 | 1972 | ranked |
+| v14 | 2060 | ranked |
+| v17 | 2298 | ranked |
+
+### Reading the result
+
+Two error bars come out of the fit and the larger is the one reported. The first
+is how much a score of this size wobbles. The second is how far the opponents
+disagree with each other, which is the one that catches a fit being quietly
+wrong: a single rating cannot describe an engine that does better against one
+opponent than another predicts, and when that happens the first error bar is an
+understatement rather than an estimate.
+
+Neither of them covers the part that matters most. The opponents earned their
+ratings at 2m+1s on other hardware, and this runs at twenty seconds on a shared
+runner, so the placement carries a systematic error worth something like a
+hundred points. More games shrink the error bar printed next to the number and
+do nothing at all to that. It is a placement, not a rating.
+
+The time control is a compromise rather than a default worth keeping by
+accident. Ten seconds runs the hundred games in about twenty minutes but leaves
+so little headroom that a runner hiccup shows up as a loss on time, and one
+forfeit in a twenty-five game pairing is worth about thirty elo of noise. Two
+minutes would match the list it is calibrated against and takes most of a day.
+Twenty seconds costs about an hour and sits closer to the list than ten does.
+
+Games run long here, a little under two hundred plies on average, so most of the
+clock a game uses is increment rather than the base time. That is why doubling
+the base from ten to twenty costs closer to three times the wall clock than
+twice it, and worth remembering before raising it again.
+
 ## Cutting a release
 
 Releases are driven by [cargo-release](https://github.com/crate-ci/cargo-release)

--- a/scripts/rating_estimate.py
+++ b/scripts/rating_estimate.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Estimate a rating on the ccrl scale from a gauntlet against rated engines.
+
+Every opponent is held at its published ccrl figure, so the only free parameter
+is our own rating, and the maximum likelihood fit of the logistic model is
+simply the rating at which the expected score equals the score actually made.
+
+Two error bars come out of this and the larger is the one reported. The first is
+the usual one from how much a score of this size wobbles. The second is how far
+the opponents disagree with each other: a single number cannot describe an
+engine that does better against one opponent than another predicts, and when
+that happens the first error bar is an understatement rather than an estimate.
+"""
+
+import math
+import re
+import sys
+from pathlib import Path
+
+LN10_OVER_400 = math.log(10) / 400
+# a pairing that ends 25-0 puts no bound on how much stronger the winner is, so
+# the implied rating is capped rather than allowed to run off to infinity
+MAX_IMPLIED = 1200.0
+
+GAME = re.compile(
+    r'\[White "([^"]+)"\].*?\[Black "([^"]+)"\].*?\[Result "([^"]+)"\]',
+    re.DOTALL,
+)
+
+
+def expected(rating: float, opponent: float) -> float:
+    return 1.0 / (1.0 + 10 ** ((opponent - rating) / 400))
+
+
+def implied(opponent: float, score: float, games: int) -> float:
+    """The rating a single pairing on its own points at."""
+    fraction = score / games
+    if fraction <= 0.0:
+        return opponent - MAX_IMPLIED
+    if fraction >= 1.0:
+        return opponent + MAX_IMPLIED
+    return opponent - 400 * math.log10(1 / fraction - 1)
+
+
+def fit(pairings: list[tuple[str, float, int, int, int]]) -> tuple[float, float, str]:
+    scored = sum(w + d / 2 for _, _, w, d, _ in pairings)
+
+    # the expected score only rises with the rating, so bisection cannot miss
+    low, high = 0.0, 4000.0
+    for _ in range(200):
+        mid = (low + high) / 2
+        total = sum(
+            (w + d + loss) * expected(mid, opponent)
+            for _, opponent, w, d, loss in pairings
+        )
+        if total < scored:
+            low = mid
+        else:
+            high = mid
+    rating = (low + high) / 2
+
+    # How much a result of this size wobbles. The variance is the one the games
+    # actually showed rather than one a win/loss model assumes, so that draws
+    # count as the low variance results they are.
+    variance = 0.0
+    slope = 0.0
+    for _, opponent, w, d, loss in pairings:
+        games = w + d + loss
+        mean = (w + d / 2) / games
+        second_moment = (w + d / 4) / games
+        variance += games * max(second_moment - mean * mean, 1e-9)
+        chance = expected(rating, opponent)
+        slope += games * LN10_OVER_400 * chance * (1 - chance)
+    statistical = math.sqrt(variance) / slope
+
+    # How far the opponents disagree. With one opponent there is nothing to
+    # disagree with, so there is no second opinion to report.
+    points = [
+        implied(opponent, w + d / 2, w + d + loss)
+        for _, opponent, w, d, loss in pairings
+    ]
+    if len(points) > 1:
+        mean = sum(points) / len(points)
+        spread = math.sqrt(sum((p - mean) ** 2 for p in points) / (len(points) - 1))
+        between = spread / math.sqrt(len(points))
+    else:
+        between = 0.0
+
+    if between > statistical:
+        return (
+            rating,
+            between,
+            "opponents disagree by more than the games alone explain",
+        )
+    return rating, statistical, ""
+
+
+def read_pairings(
+    pgn: Path, engine: str, ladder: dict[str, float]
+) -> list[tuple[str, float, int, int, int]]:
+    tally: dict[str, list[int]] = {name: [0, 0, 0] for name in ladder}
+    for white, black, result in GAME.findall(pgn.read_text()):
+        if engine not in (white, black):
+            continue
+        opponent = black if white == engine else white
+        if opponent not in tally:
+            continue
+        if result == "1/2-1/2":
+            tally[opponent][1] += 1
+        elif (result == "1-0") == (white == engine):
+            tally[opponent][0] += 1
+        else:
+            tally[opponent][2] += 1
+    return [
+        (name, ladder[name], *tally[name]) for name in ladder if sum(tally[name]) > 0
+    ]
+
+
+def main() -> None:
+    pgn, engine, spec = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+    ladder = {}
+    for entry in spec.split(","):
+        name, rating = entry.rsplit(":", 1)
+        ladder[name.strip()] = float(rating)
+
+    pairings = read_pairings(pgn, engine, ladder)
+    if not pairings:
+        sys.exit(f"no games for {engine} against any of {', '.join(ladder)}")
+
+    rating, margin, caveat = fit(pairings)
+    for name, opponent, w, d, loss in pairings:
+        games = w + d + loss
+        percent = 100 * (w + d / 2) / games
+        print(
+            f"| {name} | {opponent:.0f} | {w}-{d}-{loss} | {percent:.1f}% |"
+            f" {implied(opponent, w + d / 2, games):.0f} |"
+        )
+    total = sum(w + d + loss for _, _, w, d, loss in pairings)
+    print()
+    print(f"{rating:.0f} ±{margin:.0f} on the ccrl blitz scale ({total} games)")
+    if caveat:
+        print(f"note: {caveat}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rating_estimate.py
+++ b/scripts/rating_estimate.py
@@ -5,27 +5,30 @@ Every opponent is held at its published ccrl figure, so the only free parameter
 is our own rating, and the maximum likelihood fit of the logistic model is
 simply the rating at which the expected score equals the score actually made.
 
-Two error bars come out of this and the larger is the one reported. The first is
-the usual one from how much a score of this size wobbles. The second is how far
-the opponents disagree with each other: a single number cannot describe an
-engine that does better against one opponent than another predicts, and when
-that happens the first error bar is an understatement rather than an estimate.
+The margin printed with it is how much a score of this size wobbles, and it
+describes the games and nothing else. Whether one rating can describe the
+results at all is a separate question, asked separately: when the opponents
+disagree with each other by more than chance allows, that margin is an
+understatement rather than an estimate, and a note saying so goes to stderr.
 """
 
+import argparse
 import math
 import re
 import sys
 from pathlib import Path
 
 LN10_OVER_400 = math.log(10) / 400
-# a pairing that ends 25-0 puts no bound on how much stronger the winner is, so
-# the implied rating is capped rather than allowed to run off to infinity
+# A pairing that ends 25-0 puts no upper bound on the winner, so both the
+# implied rating and the search for the fitted one stop this far out rather than
+# running off to wherever the bracket happens to end.
 MAX_IMPLIED = 1200.0
 
-GAME = re.compile(
-    r'\[White "([^"]+)"\].*?\[Black "([^"]+)"\].*?\[Result "([^"]+)"\]',
-    re.DOTALL,
-)
+# Games are read one at a time rather than by scanning the whole file for tags,
+# so that a game truncated by an interrupted match cannot pair its opponent with
+# the next game's result.
+RECORD = re.compile(r"^\[Event ", re.MULTILINE)
+TAG = re.compile(r'^\[(White|Black|Result) "([^"]*)"\]', re.MULTILINE)
 
 
 def expected(rating: float, opponent: float) -> float:
@@ -42,11 +45,46 @@ def implied(opponent: float, score: float, games: int) -> float:
     return opponent - 400 * math.log10(1 / fraction - 1)
 
 
-def fit(pairings: list[tuple[str, float, int, int, int]]) -> tuple[float, float, str]:
-    scored = sum(w + d / 2 for _, _, w, d, _ in pairings)
+def chi_square_95(dof: int) -> float:
+    """The point a chi square of this many degrees of freedom passes one time in
+    twenty by chance. Wilson and Hilferty's cube root approximation, which is
+    within a couple of percent from one degree of freedom upwards and saves
+    carrying a table of critical values around."""
+    return dof * (1 - 2 / (9 * dof) + 1.645 * math.sqrt(2 / (9 * dof))) ** 3
 
-    # the expected score only rises with the rating, so bisection cannot miss
-    low, high = 0.0, 4000.0
+
+class Estimate:
+    def __init__(self, rating: float, margin: float, games: int, bounded: str = ""):
+        self.rating = rating
+        self.margin = margin
+        self.games = games
+        # set when every game went one way, so the games bound the rating from
+        # one side only and a figure with a margin either side would be a lie
+        self.bounded = bounded
+
+    def __str__(self) -> str:
+        if self.bounded:
+            return f"{self.bounded} on the ccrl blitz scale ({self.games} games)"
+        return (
+            f"{self.rating:.0f} ±{self.margin:.0f}"
+            f" on the ccrl blitz scale ({self.games} games)"
+        )
+
+
+def fit(pairings: list[tuple[str, float, int, int, int]]) -> tuple[Estimate, str]:
+    scored = sum(w + d / 2 for _, _, w, d, _ in pairings)
+    played = sum(w + d + loss for _, _, w, d, loss in pairings)
+    opponents = [opponent for _, opponent, _, _, _ in pairings]
+
+    if scored == 0:
+        return Estimate(0, 0, played, f"below {min(opponents):.0f}"), ""
+    if scored == played:
+        return Estimate(0, 0, played, f"above {max(opponents):.0f}"), ""
+
+    # The expected score only rises with the rating, so bisection cannot miss.
+    # The bracket stops where a single pairing would, because past that point
+    # the games say nothing and the answer would be the bracket, not the fit.
+    low, high = min(opponents) - MAX_IMPLIED, max(opponents) + MAX_IMPLIED
     for _ in range(200):
         mid = (low + high) / 2
         total = sum(
@@ -61,46 +99,59 @@ def fit(pairings: list[tuple[str, float, int, int, int]]) -> tuple[float, float,
 
     # How much a result of this size wobbles. The variance is the one the games
     # actually showed rather than one a win/loss model assumes, so that draws
-    # count as the low variance results they are.
-    variance = 0.0
+    # count as the low variance results they are, and it is pooled across the
+    # pairings because how often a game is drawn is a property of the engines
+    # rather than of the opponent, and a pairing that was swept shows none.
+    spread = 0.0
+    modelled = 0.0
     slope = 0.0
     for _, opponent, w, d, loss in pairings:
         games = w + d + loss
         mean = (w + d / 2) / games
-        second_moment = (w + d / 4) / games
-        variance += games * max(second_moment - mean * mean, 1e-9)
+        spread += games * max((w + d / 4) / games - mean * mean, 0.0)
         chance = expected(rating, opponent)
+        modelled += games * chance * (1 - chance)
         slope += games * LN10_OVER_400 * chance * (1 - chance)
-    statistical = math.sqrt(variance) / slope
+    # Every game going the same way inside every pairing leaves no wobble to
+    # measure, which is not the same as there being none, so fall back to the
+    # wobble the fitted rating would predict rather than report no doubt at all.
+    if spread == 0.0:
+        spread = modelled
+    per_game = spread / played
+    margin = math.sqrt(spread) / slope
 
-    # How far the opponents disagree. With one opponent there is nothing to
-    # disagree with, so there is no second opinion to report.
-    points = [
-        implied(opponent, w + d / 2, w + d + loss)
-        for _, opponent, w, d, loss in pairings
-    ]
-    if len(points) > 1:
-        mean = sum(points) / len(points)
-        spread = math.sqrt(sum((p - mean) ** 2 for p in points) / (len(points) - 1))
-        between = spread / math.sqrt(len(points))
-    else:
-        between = 0.0
-
-    if between > statistical:
-        return (
-            rating,
-            between,
-            "opponents disagree by more than the games alone explain",
+    # Whether one rating describes all of the pairings, which is a different
+    # question from how precisely it is pinned down. Comparing each pairing's
+    # score with the one the fit expects of it answers it, and a fit that has
+    # already been bent to match the total costs a degree of freedom.
+    dof = len(pairings) - 1
+    note = ""
+    if dof > 0:
+        chi = sum(
+            ((w + d / 2) - (w + d + loss) * expected(rating, opponent)) ** 2
+            / ((w + d + loss) * per_game)
+            for _, opponent, w, d, loss in pairings
         )
-    return rating, statistical, ""
+        if chi > chi_square_95(dof):
+            note = (
+                "the opponents disagree with each other by more than chance"
+                " allows, so one rating does not describe these results and the"
+                " margin above understates how uncertain the figure is"
+            )
+    return Estimate(rating, margin, played, ""), note
 
 
 def read_pairings(
     pgn: Path, engine: str, ladder: dict[str, float]
 ) -> list[tuple[str, float, int, int, int]]:
     tally: dict[str, list[int]] = {name: [0, 0, 0] for name in ladder}
-    for white, black, result in GAME.findall(pgn.read_text()):
-        if engine not in (white, black):
+    text = pgn.read_text()
+    for record in RECORD.split(text)[1:]:
+        tags = dict(TAG.findall(record))
+        white, black, result = tags.get("White"), tags.get("Black"), tags.get("Result")
+        # a game still in progress when the match was interrupted has no result
+        # to count, and no business borrowing the next one's
+        if not (white and black and result) or engine not in (white, black):
             continue
         opponent = black if white == engine else white
         if opponent not in tally:
@@ -109,37 +160,66 @@ def read_pairings(
             tally[opponent][1] += 1
         elif (result == "1-0") == (white == engine):
             tally[opponent][0] += 1
-        else:
+        elif result in ("1-0", "0-1"):
             tally[opponent][2] += 1
+    for name in ladder:
+        if sum(tally[name]) == 0:
+            print(f"{name} played no games and is not in the fit", file=sys.stderr)
     return [
         (name, ladder[name], *tally[name]) for name in ladder if sum(tally[name]) > 0
     ]
 
 
-def main() -> None:
-    pgn, engine, spec = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+def read_ladder(spec: str) -> dict[str, float]:
     ladder = {}
     for entry in spec.split(","):
-        name, rating = entry.rsplit(":", 1)
-        ladder[name.strip()] = float(rating)
+        entry = entry.strip()
+        if not entry:
+            continue
+        name, _, rating = entry.rpartition(":")
+        try:
+            ladder[name.strip()] = float(rating)
+        except ValueError:
+            sys.exit(f"ladder entry {entry!r} is not name:rating")
+        if not name.strip():
+            sys.exit(f"ladder entry {entry!r} is not name:rating")
+    if not ladder:
+        sys.exit("the ladder is empty")
+    return ladder
 
-    pairings = read_pairings(pgn, engine, ladder)
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pgn", type=Path, help="the games the gauntlet played")
+    parser.add_argument("engine", help="the name the engine played under")
+    parser.add_argument("ladder", help="opponents, as name:rating pairs")
+    parser.add_argument(
+        "--line",
+        action="store_true",
+        help="print only the estimate, for somewhere a table does not fit",
+    )
+    args = parser.parse_args()
+
+    ladder = read_ladder(args.ladder)
+    pairings = read_pairings(args.pgn, args.engine, ladder)
     if not pairings:
-        sys.exit(f"no games for {engine} against any of {', '.join(ladder)}")
+        sys.exit(f"no games for {args.engine} against any of {', '.join(ladder)}")
 
-    rating, margin, caveat = fit(pairings)
-    for name, opponent, w, d, loss in pairings:
-        games = w + d + loss
-        percent = 100 * (w + d / 2) / games
-        print(
-            f"| {name} | {opponent:.0f} | {w}-{d}-{loss} | {percent:.1f}% |"
-            f" {implied(opponent, w + d / 2, games):.0f} |"
-        )
-    total = sum(w + d + loss for _, _, w, d, loss in pairings)
-    print()
-    print(f"{rating:.0f} ±{margin:.0f} on the ccrl blitz scale ({total} games)")
-    if caveat:
-        print(f"note: {caveat}")
+    estimate, note = fit(pairings)
+    if not args.line:
+        print("| opponent | ccrl | w-d-l | score | implies |")
+        print("| --- | --- | --- | --- | --- |")
+        for name, opponent, w, d, loss in pairings:
+            games = w + d + loss
+            percent = 100 * (w + d / 2) / games
+            print(
+                f"| {name} | {opponent:.0f} | {w}-{d}-{loss} | {percent:.1f}% |"
+                f" {implied(opponent, w + d / 2, games):.0f} |"
+            )
+        print()
+    print(estimate)
+    if note:
+        print(f"note: {note}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/rating_estimate.py
+++ b/scripts/rating_estimate.py
@@ -145,23 +145,33 @@ def read_pairings(
     pgn: Path, engine: str, ladder: dict[str, float]
 ) -> list[tuple[str, float, int, int, int]]:
     tally: dict[str, list[int]] = {name: [0, 0, 0] for name in ladder}
+    unfinished = 0
     text = pgn.read_text()
     for record in RECORD.split(text)[1:]:
         tags = dict(TAG.findall(record))
         white, black, result = tags.get("White"), tags.get("Black"), tags.get("Result")
         # a game still in progress when the match was interrupted has no result
         # to count, and no business borrowing the next one's
-        if not (white and black and result) or engine not in (white, black):
+        if not (white and black) or engine not in (white, black):
             continue
         opponent = black if white == engine else white
         if opponent not in tally:
             continue
         if result == "1/2-1/2":
             tally[opponent][1] += 1
-        elif (result == "1-0") == (white == engine):
-            tally[opponent][0] += 1
-        elif result in ("1-0", "0-1"):
-            tally[opponent][2] += 1
+        elif result == "1-0":
+            tally[opponent][0 if white == engine else 2] += 1
+        elif result == "0-1":
+            tally[opponent][2 if white == engine else 0] += 1
+        else:
+            unfinished += 1
+    # A handful of these is a match that was interrupted. A lot of them is the
+    # estimate being drawn from a fraction of the games that were paid for, so
+    # say how many rather than quietly fitting whatever finished.
+    if unfinished:
+        print(
+            f"{unfinished} games have no result and are not in the fit", file=sys.stderr
+        )
     for name in ladder:
         if sum(tally[name]) == 0:
             print(f"{name} played no games and is not in the fit", file=sys.stderr)

--- a/scripts/rating_estimate.py
+++ b/scripts/rating_estimate.py
@@ -169,8 +169,10 @@ def read_pairings(
     # estimate being drawn from a fraction of the games that were paid for, so
     # say how many rather than quietly fitting whatever finished.
     if unfinished:
+        plural = "" if unfinished == 1 else "s"
         print(
-            f"{unfinished} games have no result and are not in the fit", file=sys.stderr
+            f"{unfinished} game{plural} with no result, left out of the fit",
+            file=sys.stderr,
         )
     for name in ladder:
         if sum(tally[name]) == 0:

--- a/scripts/resolve_ref.sh
+++ b/scripts/resolve_ref.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Resolve what a workflow was asked to play into a commit, and print it.
+#
+# A number is a pull request, whose head a checkout does not fetch. Anything
+# else is a branch, a tag or a commit, which a full clone may already have and
+# otherwise has to be asked for by name.
+#
+# Lives here rather than inside a workflow so that the shellcheck hook sees it,
+# and so that the two match workflows resolve a ref the same way rather than
+# each having their own idea of what a ref is.
+set -euo pipefail
+
+ref=${1:?usage: resolve_ref.sh <branch|tag|commit|pull request number>}
+
+if [ "$ref" -eq "$ref" ] 2>/dev/null; then
+    git fetch -q origin "refs/pull/${ref}/head"
+    git rev-parse FETCH_HEAD
+    exit 0
+fi
+
+# already here, so nothing to fetch
+if sha=$(git rev-parse --verify --quiet "${ref}^{commit}"); then
+    echo "$sha"
+    exit 0
+fi
+
+git fetch -q origin "$ref"
+git rev-parse FETCH_HEAD


### PR DESCRIPTION
Adds a **Calibrate** workflow that estimates what the engine would be rated on the ccrl scale, and shares out what it turned out to have in common with **Strength**.

A match against the previous release says which of the two is better and nothing about where either sits, because both sides of it are this engine. This plays a gauntlet against opponents that already have a rating, holds each of them at their published figure, and fits the one number that is unknown.

## Why old releases of Stash rather than an engine with an adjustable elo

The adjustable ones weaken a strong engine by injecting mistakes, so the opponent is not like a real engine of that rating — it plays 3000-strength moves punctuated by blunders, and a score against that does not map onto the scale being calibrated to. Stockfish's own `UCI_Elo` is calibrated by playing these same Stash versions and still only claims ±100, so playing them directly skips a conversion worth more than the thing being measured.

Stash is also unusually convenient: every version is tagged, each builds in about a second from a plain makefile with no dependencies, and the binaries are eighty kilobytes. They are built fresh each run rather than cached, because fetching a cache costs more.

## What it reports

Measured on this branch, 104 games at 10+0.1:

| opponent | ccrl | w-d-l | score | implies |
| --- | --- | --- | --- | --- |
| stash-v11 | 1690 | 12-4-10 | 53.8% | 1717 |
| stash-v12 | 1886 | 3-2-21 | 15.4% | 1590 |
| stash-v13 | 1972 | 3-4-19 | 19.2% | 1723 |
| stash-v14 | 2060 | 4-0-22 | 15.4% | 1764 |

`1696 ±38 on the ccrl blitz scale (104 games)`

A separate 32-game run at 20+0.2 against the default ladder gave 1701, which is the same answer from different games at a different speed.

The default rungs are `v10:1620,v11:1690,v12:1886,v13:1972` rather than the four above, because a pairing that ends 25-0 puts no bound on the winner and contributes almost nothing: the four here score 69/31/44/13% where the ones measured scored 54/15/19/15%. They are an input so they can be moved up as the engine improves.

## The time control

`20+0.2`, about an hour for a hundred games, measured rather than guessed. Ten seconds runs it in twenty minutes but leaves so little headroom that a runner hiccup shows up as a loss on time, and one forfeit in a twenty-five game pairing is worth about thirty elo. Two minutes would match the list being calibrated against and takes most of a day. Games here run a little under two hundred plies, so most of the clock a game uses is increment rather than base time, which is why doubling the base costs closer to three times the wall clock than twice.

## What this does not claim

The opponents earned their ratings at 2m+1s on other hardware. The margin printed next to the figure describes the games and nothing else; the systematic error is worth something like a hundred points and no number of games reduces it. The ladder is held as exact too, and `v10`'s 1620 is a community estimate rather than a ccrl ranking. It is a placement, not a rating, and the run summary says so.

## Sharing what the two workflows had in common

The new workflow arrived as a copy of the old one, and reviewing the pair turned up two ways that ends badly:

- Both cached the whole of `tools/`, which is also where a match writes its games, its results and the engines that played. A run that missed the cache saved all of it, and a later run restored an earlier run's games before playing its own.
- Both piped fastchess into `tee` without naming the shell, which is what turns pipefail on, so a fastchess that died left the step green. Together those two publish a rating worked out from somebody else's games. `benchmark.yml` already carries a comment about the tee; these two did not.

So: the tools move to a composite action that caches the two files it builds and takes the fastchess version as an input, so the version and the cache key cannot drift apart. Ref resolution moves to a script, where the shellcheck hook can see it. Appending a line to release notes moves to a reusable workflow, which is where the queue its three callers take turns in belongs.

The fastchess invocation stays duplicated on purpose. The two differ in tournament type, in how the engine list is built and in what they keep, and an action taking an engine array would be longer than what it replaced and would hide the line a reader opens these workflows to see.

`-repeat` takes no argument — it is a spelling of `-games 2` — so the `2` after it in `strength.yml` did nothing, and the note in the development guide explaining what the `2` meant was explaining a token that was never read.

## Testing

Every step was rehearsed locally rather than left for CI to try first: all four rungs build, the gauntlet runs end to end, and the estimate step produces the summary above. The estimator was exercised against the real gauntlet PGNs and against synthetic ones for a clean sweep, a truncated match, unfinished games, an off-ladder opponent, both colours, and every malformed ladder spec I could construct.

Not yet exercised: the workflow on a real runner. The first release to use it is still the first true test of the hosted path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhiJhdHPF8YDStbv8Wbsm9)_