### PR TITLE
Only hash en passant when a pawn can take there

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ docker/smoke_test.sh arche-lichess-bot
   - the history array is a fixed size and ply is initialised to twice the full move number, so a
     game of more than about five hundred moves runs past the end of it. A fen with a full move
     number that high panics on the first search rather than after five hundred moves
-  - en passant is hashed for every double pawn push, even when no capture is possible, which
-    slightly reduces transposition hits
 
 ## Acknowledgements
 

--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -785,12 +785,18 @@ impl Board {
             // pawn moves reset the fifty move rule
             self.fifty_move_rule = 0;
             if (play.from as isize - play.to as isize).abs() == 16 {
-                // if a pawn moved two squares forward then we must update the en_passant square
-                self.en_passant = match self.active_color {
-                    Color::White => Some(Coordinate::from_index(play.to - 8)),
-                    Color::Black => Some(Coordinate::from_index(play.to + 8)),
+                // the square the pawn passed over only belongs in the key if
+                // something can be taken on it. Hashing it unconditionally
+                // makes one position hash two ways, which costs transposition
+                // hits and hides a repetition either side of a double push
+                let passed = match self.active_color {
+                    Color::White => play.to - 8,
+                    Color::Black => play.to + 8,
                 };
-                self.key ^= zorb.en_passant_key(play.to);
+                if self.pawn_can_capture_on(passed, opposing_color) {
+                    self.en_passant = Some(Coordinate::from_index(passed));
+                    self.key ^= zorb.en_passant_key(passed);
+                }
             }
             if play.en_passant {
                 let clear_index = match self.active_color {
@@ -933,6 +939,18 @@ impl Board {
         } else {
             self.set_piece_index(to, piece, color);
         }
+    }
+
+    /// Whether a pawn of this colour is placed to take on this square. A mask
+    /// holds the squares a pawn of that colour must stand on to attack the one
+    /// indexed, which is what is being asked here.
+    fn pawn_can_capture_on(&self, index: u8, capturer: Color) -> bool {
+        let attack_masks: &AttackMasks = &ATTACK_MASKS;
+        let (from, pawns) = match capturer {
+            Color::White => (attack_masks.white_pawns[index as usize], self.white),
+            Color::Black => (attack_masks.black_pawns[index as usize], self.black),
+        };
+        from & self.pawns & pawns != 0
     }
 
     pub fn is_king_attacked(&self) -> bool {
@@ -1256,8 +1274,14 @@ impl Game for Board {
             board.key ^= ZORB.side;
         }
         board.key ^= ZORB.castle_key(board.castle);
+        // the same rule as make_move, or a position parsed and the same one
+        // played would not hash alike, which is worse than what is being fixed
         if let Some(en_passant) = board.en_passant {
-            board.key ^= ZORB.en_passant_key(en_passant.as_index());
+            if board.pawn_can_capture_on(en_passant.as_index(), board.active_color) {
+                board.key ^= ZORB.en_passant_key(en_passant.as_index());
+            } else {
+                board.en_passant = None;
+            }
         }
         (board.white_value, board.black_value) = board.material_value();
         Ok(board)
@@ -1583,12 +1607,59 @@ mod position_key {
     }
 
     #[test]
-    fn en_passant_changes_key() {
+    fn en_passant_changes_key_when_a_pawn_can_take_there() {
+        // a black pawn on d4 takes on e3, so the square is real and belongs in
+        // the key
+        let without =
+            Board::from_fen("rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1").unwrap();
+        let with = Board::from_fen("rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")
+            .unwrap();
+        assert_ne!(without.key, with.key);
+        assert!(with.en_passant.is_some());
+    }
+
+    #[test]
+    fn en_passant_no_one_can_take_is_not_in_the_key() {
+        // every black pawn is still on the seventh, so nothing can take on e3.
+        // Interfaces leave the square out of the key in that case, and a key
+        // which disagrees makes one position hash two ways
         let without =
             Board::from_fen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1").unwrap();
         let with =
             Board::from_fen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1").unwrap();
-        assert_ne!(without.key, with.key);
+        assert_eq!(without.key, with.key);
+        assert_eq!(with.en_passant, None);
+    }
+
+    #[test]
+    fn a_double_push_no_one_can_answer_hashes_like_the_position_without_it() {
+        // the same position played and parsed has to hash alike, which is the
+        // half of this that has to match make_move or the fix is worse than the
+        // problem
+        let mut played = Board::from_fen("4k3/7p/8/8/8/8/P7/4K3 w - - 0 1").unwrap();
+        let a2a4 = *played
+            .generate_moves()
+            .iter()
+            .find(|m| format!("{}", m) == "a2a4")
+            .expect("a2a4 is a move here");
+        assert!(played.make_move(&a2a4));
+        let parsed = Board::from_fen("4k3/7p/8/8/P7/8/8/4K3 b - - 0 1").unwrap();
+        assert_eq!(played.key, parsed.key);
+        assert_eq!(played.en_passant, None);
+    }
+
+    #[test]
+    fn a_double_push_which_can_be_answered_still_records_the_square() {
+        let mut played = Board::from_fen("4k3/8/8/8/1p6/8/P7/4K3 w - - 0 1").unwrap();
+        let a2a4 = *played
+            .generate_moves()
+            .iter()
+            .find(|m| format!("{}", m) == "a2a4")
+            .expect("a2a4 is a move here");
+        assert!(played.make_move(&a2a4));
+        let parsed = Board::from_fen("4k3/8/8/8/Pp6/8/8/4K3 b - a3 0 1").unwrap();
+        assert_eq!(played.key, parsed.key);
+        assert!(played.en_passant.is_some());
     }
 
     #[test]

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -1120,11 +1120,11 @@ mod test_node_counts {
         assert_eq!(
             counted,
             vec![
-                ("opening", 172_270),
-                ("kiwipete", 218_778),
-                ("pawn endgame", 174_703),
-                ("promotions", 120_523),
-                ("middlegame", 196_650),
+                ("opening", 149_810),
+                ("kiwipete", 217_026),
+                ("pawn endgame", 173_223),
+                ("promotions", 110_643),
+                ("middlegame", 191_607),
             ]
         );
     }


### PR DESCRIPTION
Closes the last of the known issues in the readme.

A double pawn push hashed the square it passed over whether or not anything could
be taken on it. Interfaces and other engines leave the square out in that case, so
the same position hashed two ways depending on how it was reached: once by playing
the push, once by any other move order. That costs transposition hits, and it hides
a repetition, since the two occurrences either side of a pointless double push do
not compare equal.

`make_move` now sets and hashes the square only when the other side has a pawn
placed to take there, which is one mask lookup and an `and` against that colour's
pawns. `from_fen` applies the same rule and drops the square outright, so a position
parsed and the same position played hash alike. Getting only one of the two would
have been worse than the original bug. A square nothing can take on is no more use
to the move generator than it is to the key.

The test is pseudo legal, so a capturer that is pinned still counts. Making it fully
legal means generating and validating the capture inside `make_move`, which is not
worth the cost for how rare that is.

### Correctness

Perft is unchanged across all twenty nine positions, which it has to be since no
legal move disappears. That is the guard that matters here.

The square ends up recorded in `en_passant` if and only if it is in the key, both
when played and when parsed, so `recompute_key` from #41 needs no change to agree
with it. That assert runs at the end of every `make_move`, so the debug test run
now checks this change against a from scratch recompute under every position the
perft suite reaches.

`en_passant_changes_key` started failing, correctly, because its position has every
black pawn still on the seventh and so nothing can take on e3. It is now four tests:
the square still changes the key when a pawn can take there, it does not when nothing
can, a double push nobody can answer hashes identically to the position reached
without one, and a push that can be answered still records the square. The last two
compare a played position against a parsed one, which is the half that has to match.

### Node counts

| position | before | after | |
| --- | --- | --- | --- |
| opening | 172,270 | 149,810 | -13.0% |
| kiwipete | 218,778 | 217,026 | -0.8% |
| pawn endgame | 174,703 | 173,223 | -0.8% |
| promotions | 120,523 | 110,643 | -8.2% |
| middlegame | 196,650 | 191,607 | -2.6% |

The win is concentrated in the opening and in promotions, which is what you would
expect: the pawns are still on their starting squares, so most double pushes have
no pawn placed to answer them, and those are exactly the keys that used to fork.

### Benchmarks

Measured locally, master against itself first to get a noise floor: identical code
drifts about 6% on `alpha_beta_5` and 3% on the micro benchmarks on this machine.

`perft_3` is the clean read on what this costs, since no table is involved and the
node counts are provably identical, so the timing is purely per node cost. It
straddles zero on both master runs, between -3.5% and +3.1%, with no consistent sign.
`generate_moves` and `square_attacked` do the same.

`alpha_beta_5` only moves beyond noise on the initial position, at -13 to -18%. Nodes
there fall 10.5%, so nodes per second comes out at +6%, inside the noise floor along
with the other three positions which range from -6% to +1%. Nothing to read into
either way: the wall clock gain is the smaller tree, not a faster engine.
