### PR TITLE
Stop a position from the interface taking the engine down

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ docker/smoke_test.sh arche-lichess-bot
   - fail low (alpha) nodes are never stored in the transposition table, only exact and beta nodes
   - transposition table scores don't account for repetition or fifty move history, make_move_str
     clears the key for played moves as a workaround
-  - a fen is barely validated, so one without a king is accepted and then panics as soon as the
-    position is searched
+  - a fen is only validated as far as what the search cannot survive, a king a side and the side
+    not to move being out of check. A position which is illegal in other ways, such as one with
+    nine pawns or castling rights without a rook, is accepted and played from
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,6 @@ docker/smoke_test.sh arche-lichess-bot
     clears the key for played moves as a workaround
   - a fen is barely validated, so one without a king is accepted and then panics as soon as the
     position is searched
-  - the history array is a fixed size and ply is initialised to twice the full move number, so a
-    game of more than about five hundred moves runs past the end of it. A fen with a full move
-    number that high panics on the first search rather than after five hundred moves
 
 ## Acknowledgements
 

--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -35,10 +35,17 @@ struct PlayState {
     position_key: u64,
 }
 
-// Plies of history the board can record. This has to cover the whole game as
-// replayed by the gui plus the depth of the current search, 375 was not enough
-// for games which reached move 175 or so.
+// Plies of history the board can record, as a ring. Only the fifty move window
+// is ever read back, so this has to cover that plus the depth of the current
+// search rather than the whole game.
 const MAX_GAME_SIZE: usize = 1024;
+
+/// Where a ply is recorded. The history is a ring, so a game played past
+/// MAX_GAME_SIZE plies, or a position parsed at a move number past it, wraps
+/// rather than running off the end.
+fn history_index(ply: usize) -> usize {
+    ply % MAX_GAME_SIZE
+}
 
 /// The value a position key starts from, before any piece or right is folded
 /// into it. Arbitrary, it only has to be the same everywhere.
@@ -708,17 +715,13 @@ impl Board {
     /// How many times this position has already appeared, not counting the
     /// position itself.
     fn repetition_count(&self) -> usize {
-        // a position parsed from fen can have a fifty move count higher than the number of plies
-        // we hold history for, and a long enough game runs past the end of the history
-        let start = self.ply.saturating_sub(self.fifty_move_rule);
-        let end = self.ply.min(MAX_GAME_SIZE - 1);
-        if start > end {
-            return 0;
-        }
-        self.history[start..=end]
-            .iter()
-            .filter_map(|h| h.map(|hh| hh.position_key))
-            .filter(|k| *k == self.key)
+        // only the fifty move window can hold a repetition, since a pawn move or
+        // a capture in between puts the position out of reach for good. A fen
+        // can claim a fifty move count longer than the history or the game
+        let window = self.fifty_move_rule.min(self.ply).min(MAX_GAME_SIZE - 1);
+        (self.ply - window..self.ply)
+            .filter_map(|ply| self.history[history_index(ply)])
+            .filter(|state| state.position_key == self.key)
             .count()
     }
 
@@ -737,7 +740,7 @@ impl Board {
     }
 
     pub fn make_move(&mut self, play: &Play) -> bool {
-        self.history[self.ply] = Some(PlayState {
+        self.history[history_index(self.ply)] = Some(PlayState {
             play: *play,
             en_passant: self.en_passant,
             castle: self.castle,
@@ -863,8 +866,9 @@ impl Board {
     }
 
     pub fn undo_move(&mut self) -> Result<(), &str> {
-        let history = self.history[self.ply - 1].unwrap();
-        self.history[self.ply - 1] = None;
+        let previous = history_index(self.ply - 1);
+        let history = self.history[previous].unwrap();
+        self.history[previous] = None;
         let play = history.play;
 
         let opposing_color = !self.active_color;
@@ -1447,7 +1451,7 @@ mod make_move {
     use super::Board;
     use super::Game;
     use super::Play;
-    use super::{A1, A8, B1, B8};
+    use super::{A1, A8, B1, B8, MAX_GAME_SIZE};
     use pretty_assertions::{assert_eq, assert_ne};
 
     macro_rules! test_fen_reversible {
@@ -1531,6 +1535,51 @@ mod make_move {
             assert!(board.make_move(&m));
             board.is_repetition();
         }
+    }
+
+    /// The history is a ring, so a game long enough to run past the end of it
+    /// wraps instead. This position starts at ply 1023, one short of the wrap,
+    /// so the cycle below is recorded either side of it.
+    #[test]
+    fn a_repetition_is_still_seen_when_the_history_wraps() {
+        let mut board = Board::from_fen(
+            "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 b - - 3 511",
+        )
+        .unwrap();
+        assert_eq!(
+            board.ply,
+            MAX_GAME_SIZE - 1,
+            "the cycle must cross the wrap"
+        );
+
+        let cycle = [(A8, B8), (A1, B1), (B8, A8), (B1, A1)];
+        for (from, to) in cycle {
+            assert!(board.make_move(&Play::new(from, to, None, None, false, false)));
+        }
+        assert!(board.has_repeated());
+        for (from, to) in cycle {
+            assert!(board.make_move(&Play::new(from, to, None, None, false, false)));
+        }
+        assert!(board.is_repetition());
+    }
+
+    /// Unmaking reads back the entry making wrote, so it has to agree about
+    /// where the wrap put it.
+    #[test]
+    fn moves_can_be_unmade_across_the_wrap() {
+        let start = Board::from_fen(
+            "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 b - - 3 511",
+        )
+        .unwrap();
+        let mut board = start;
+        let cycle = [(A8, B8), (A1, B1), (B8, A8), (B1, A1)];
+        for (from, to) in cycle {
+            assert!(board.make_move(&Play::new(from, to, None, None, false, false)));
+        }
+        for _ in cycle {
+            board.undo_move().unwrap();
+        }
+        assert_eq!(board, start);
     }
 
     #[test]

--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -850,10 +850,7 @@ impl Board {
         }
 
         // return false if king in check
-        let king_index = match self.active_color {
-            Color::White => (self.kings & self.white).trailing_zeros() as u8,
-            Color::Black => (self.kings & self.black).trailing_zeros() as u8,
-        };
+        let king_index = self.king_index(self.active_color);
         self.active_color = opposing_color;
         self.key ^= zorb.side;
         self.debug_assert_state_in_step();
@@ -959,18 +956,19 @@ impl Board {
         from & self.pawns & pawns != 0
     }
 
-    pub fn is_king_attacked(&self) -> bool {
-        let (index, opposing_color) = match self.active_color {
-            Color::White => (
-                (self.kings & self.white).trailing_zeros() as u8,
-                Color::Black,
-            ),
-            Color::Black => (
-                (self.kings & self.black).trailing_zeros() as u8,
-                Color::White,
-            ),
+    /// Where this side's king stands. Every board has exactly one king a side,
+    /// which is what `from_fen` checks for: without a king this returns 64 and
+    /// the attack masks are indexed off the end.
+    fn king_index(&self, color: Color) -> u8 {
+        let mask = match color {
+            Color::White => self.white,
+            Color::Black => self.black,
         };
-        self.square_attacked(index, opposing_color)
+        (self.kings & mask).trailing_zeros() as u8
+    }
+
+    pub fn is_king_attacked(&self) -> bool {
+        self.square_attacked(self.king_index(self.active_color), !self.active_color)
     }
 
     pub fn attacked_print(&self, color: Color) {
@@ -1286,6 +1284,27 @@ impl Game for Board {
                 _ => return Err("unexpected character in fen".to_string()),
             };
         }
+        // Everything below assumes a position which could actually arise, and
+        // crashes rather than playing badly when it could not. A king a side is
+        // what lets king_index return a real square, and the side which just
+        // moved being out of check is what stops the search replying by taking
+        // the king and emptying that square again.
+        for color in [Color::White, Color::Black] {
+            let mask = match color {
+                Color::White => board.white,
+                Color::Black => board.black,
+            };
+            if (board.kings & mask).count_ones() != 1 {
+                return Err(format!(
+                    "Error parsing FEN: expected exactly one {:?} king",
+                    color
+                ));
+            }
+        }
+        if board.square_attacked(board.king_index(!board.active_color), board.active_color) {
+            return Err("Error parsing FEN: the side which is not to move is in check".to_string());
+        }
+
         // fold the non-piece state into the position key so that keys are
         // comparable between boards parsed from FEN and boards reached by
         // playing moves
@@ -1914,6 +1933,32 @@ mod test_fen {
             Board::from_fen("rnbqkbnar/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")
                 .is_err()
         );
+    }
+
+    /// Each of these parsed happily and then took the engine down on the first
+    /// search, which is the worst place to find out: mid game, from a position
+    /// the interface sent us.
+    #[test]
+    fn a_position_which_could_not_arise_is_rejected_rather_than_searched() {
+        for (fen, why) in [
+            ("8/8/8/8/8/8/8/8 w - - 0 1", "no kings at all"),
+            ("4k3/8/8/8/8/8/8/8 w - - 0 1", "no white king"),
+            ("8/8/8/8/8/8/8/4K3 w - - 0 1", "no black king"),
+            ("4k2k/8/8/8/8/8/8/4K3 w - - 0 1", "two black kings"),
+            (
+                "4k3/8/8/8/8/8/8/4R1K1 w - - 0 1",
+                "black is in check with white to move, so white takes the king",
+            ),
+        ] {
+            assert!(Board::from_fen(fen).is_err(), "{}: {}", why, fen);
+        }
+    }
+
+    /// The side to move being in check is the ordinary case and has to stay
+    /// accepted, which is what stops the check above rejecting real positions.
+    #[test]
+    fn a_position_where_the_side_to_move_is_in_check_is_accepted() {
+        assert!(Board::from_fen("4k3/8/8/8/8/8/8/4R1K1 b - - 0 1").is_ok());
     }
 }
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -206,6 +206,9 @@ mod tests {
             "position fen",
             "position fen not a fen at all",
             "position fen 8/8/8/8/8/8/8/8 w - - 0 1 moves e2e4",
+            // both of these parsed, and then took the engine down on the search
+            "position fen 8/8/8/8/8/8/8/8 w - - 0 1",
+            "position fen 4k3/8/8/8/8/8/8/4R1K1 w - - 0 1",
             "position startpos moves e2e4 zzzz",
             "position startpos moves e2e4 e2e4",
         ] {


### PR DESCRIPTION
Two of the known issues in the readme, both of which crash the engine mid game on
something a gui sent it. Two commits, since the fixes have nothing to do with each
other beyond where they land.

While writing the first I found a third position of the same shape, which is in
here as well.

### Rejecting a position the search cannot survive

A fen without a king parsed happily and then panicked on the first search:
`king_index` has no square to return, so `trailing_zeros` gives 64 and the attack
masks are indexed off the end.

A king a side turns out not to be enough. A position where the side which is *not*
to move is left in check is illegal for the same reason it is unreachable, and the
search answers it by taking the king, which empties the square and panics in the
same place a move later. `4k3/8/8/8/8/8/8/4R1K1 w - - 0 1` is enough to do it.

Both are checked in `from_fen` now. Neither can arise in a real game, so refusing
them with a reason costs nothing and beats crashing. The side to move being in check
is the ordinary case and stays accepted, which is what the second test holds.

`(kings & mask).trailing_zeros()` was written out in three places and is a
`king_index` helper now, so the invariant is stated once where it is relied on.

### Recording the history in a ring

The other one is a fen with a full move number past about five hundred. The history
is indexed by `ply`, and `ply` starts at twice the full move number, so the first
move the search made wrote off the end of the array.

I have not validated the move number, because a fen at move 600 is a legal position
and rejecting it would be wrong. Only the fifty move window is ever read back out of
the history, since a pawn move or a capture in between puts a position out of reach
for good, so it never needs to reach further than about a hundred plies. Wrapping
the index makes the array big enough for any game rather than merely for a long one.

That also fixes the case the readme listed as a limitation rather than a bug: a real
game reaching move 512 ran off the end in exactly the same way. The repetition scan
loses the `.min(MAX_GAME_SIZE - 1)` clamp that was papering over it.

### Checks

Each guard was broken in turn to confirm the tests notice. Reverting `history_index`
to the identity fails both wrap tests; disabling either fen check fails the rejection
test.

The wrap tests start from a position at ply 1023, one short of the boundary, so the
repetition cycle is recorded either side of it. One asserts the repetition is still
seen, the other that make and unmake round trip back to an equal board, since
unmaking has to agree with making about where the wrap put the entry.

`test_node_counts_have_not_moved` is unchanged, which is the statement that the ring
and the `king_index` refactor leave a normal game alone. The two illegal fens are in
the uci tests as well, so the path from a `position` line is covered too.

### Readme

Both entries come off the known issues list, replaced by an honest one: a fen is
validated as far as what the search cannot survive and no further, so a position
which is illegal in other ways, nine pawns or castling rights without a rook, is
still accepted and played from. Those do not crash anything.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BSBdRtPp2XNa7FugJLaizW)_