### PR TITLE
Give a candidate a changelog section it can be released from

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -285,6 +285,14 @@ Merging that pull request tags the release and starts the build. Closing it
 without merging calls the release off, nothing is tagged or published until it
 lands.
 
+A candidate gets a changelog section like any other release, because the github
+release is created from the section matching the tag and cannot be created
+without one. The section is a preview rather than a record: it covers everything
+since the last full release, which is the same range the release itself will
+cover, so the next thing written replaces it rather than being added alongside
+it. A release at the end of a run of candidates ends up with the changelog it
+would have had if none of them had happened.
+
 Two things are worth knowing about why it is shaped this way:
 
 - `master` only takes changes through a pull request, so a workflow cannot push

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -5,19 +5,35 @@ set -euo pipefail
 
 version="${1:?usage: changelog.sh <version>}"
 
-# Release candidates do not get a section of their own. Their commits belong to
-# the release they lead up to, and are written out when that release is cut.
-case "$version" in
-  *-*)
-    echo "changelog: skipping pre-release $version"
-    exit 0
-    ;;
-esac
-
 # Everything since the last full release rather than since the last tag, so that
 # a release preceded by candidates still lists all of its changes. git-cliff has
 # --ignore-tags, but it does not affect the range --unreleased picks.
 previous=$(git tag --list 'v[0-9]*' --sort=-v:refname | grep -v -- '-' | head -1)
+
+# A candidate does get a section, because the github release is created from the
+# section matching the tag and there is nothing to create it from otherwise. It
+# is a preview rather than a record though: it covers the same range the release
+# will, so whatever is written next replaces it rather than joining it, and the
+# release at the end of a run of candidates reads as though none of them
+# happened.
+#
+# Dropping any section for this version too makes the hook safe to run twice
+# over, which is worth having because the only sign that it had would be a
+# changelog with the same release in it twice.
+if [ -f CHANGELOG.md ]; then
+  awk -v version="$version" '
+    # the version is what is inside the brackets, so that the date after them,
+    # which always has dashes in it, is not read as a pre-release
+    /^## \[/ {
+      bracketed = $0
+      sub(/^## \[/, "", bracketed)
+      sub(/\].*/, "", bracketed)
+      superseded = (bracketed ~ /-/) || (bracketed == version)
+    }
+    !superseded
+  ' CHANGELOG.md > CHANGELOG.md.tmp
+  mv CHANGELOG.md.tmp CHANGELOG.md
+fi
 
 if [ -n "$previous" ]; then
   echo "changelog: ${version}, covering ${previous}..HEAD"


### PR DESCRIPTION
Cutting `v0.3.9-rc.1` tagged it, started the release and then failed:

```
error: not found release note for '0.3.9-rc.1' in CHANGELOG.md
```

`create-gh-release-action` builds the release body from the changelog section matching the tag, with `allow-missing-changelog: false`. Candidates stopped getting a section in 0447a06, which moved the changelog to being written from the last full release, so there is nothing for it to find.

## The fix

Candidates get a section again, and the reason it was taken away is handled by replacing rather than by omitting.

A candidate's section covers everything since the last full release — the same range the release itself will cover — so it is a preview rather than a record. Before writing a new section the hook drops any section whose bracketed version is a pre-release, or is the version being written. Cutting rc.1, then rc.2, then the release therefore leaves the changelog as though neither candidate had happened.

That last part is tested rather than asserted. Running the hook for `0.3.9-rc.1`, then `0.3.9-rc.2`, then `0.3.9` against the real repository produces a `CHANGELOG.md` **byte for byte identical** to running the previous script straight to `0.3.9`:

```
$ diff direct.md via_rcs.md && echo IDENTICAL
IDENTICAL
```

Dropping a section for the version being written also makes the hook safe to run twice over, which is worth having because the only sign that it had run twice would be a changelog with the same release in it twice.

## Testing

Run against a clone of the repository with git-cliff 2.10.1:

| | result |
| --- | --- |
| `0.3.9-rc.1` → `0.3.9-rc.2` → `0.3.9` | one section each time, never accumulating |
| final changelog vs cutting `0.3.9` directly | byte identical |
| same version twice | stable, no duplicate section |
| header (`# Changelog` + preamble) | preserved |
| `mawk`, which is what `awk` is on the runners | strips pre-release and beta sections, keeps full releases |
| `shellcheck` | clean |

The section the release action reads was extracted from the result to confirm it is populated rather than an empty heading.

## Note on the tag already pushed

This takes effect from the next release. `v0.3.9-rc.1` is already tagged against a commit whose changelog has no section for it, so re-running the release workflow against that tag will still fail — the fix has to be in the commit being released. Cutting `rc.2` from `master` once this lands is the clean way forward.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhiJhdHPF8YDStbv8Wbsm9)_