### PR TITLE
perf(eval): Store the piece square tables in sixteen bits

### DIFF
--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -273,8 +273,10 @@ pub struct Board {
 
     pub white_value: u32,
     pub black_value: u32,
-    // piece square table score, kept up to date incrementally
-    psqt: isize,
+    // piece square table score, kept up to date incrementally. Wider than the
+    // table entries it accumulates so that summing a boardful of them, and
+    // adding the material difference on top, cannot overflow.
+    psqt: i32,
 
     //history: Vec<PlayState>,
     history: [Option<PlayState>; MAX_GAME_SIZE],
@@ -577,7 +579,7 @@ impl Board {
         // TODO should this return white value & black value as separate numbers instead?
         let eval = self.white_value as i32 - self.black_value as i32;
 
-        let eval = (eval + self.psqt as i32) as Score;
+        let eval = (eval + self.psqt) as Score;
 
         match self.active_color {
             Color::White => eval,
@@ -625,18 +627,18 @@ impl Board {
     /// The piece square score of the position as it stands, computed from the
     /// board rather than accumulated as pieces move. `psqt` is meant to equal
     /// this at all times, and nothing checked that until now.
-    pub fn recompute_psqt(&self) -> isize {
-        let mut total = 0;
+    pub fn recompute_psqt(&self) -> i32 {
+        let mut total: i32 = 0;
         // walking the occupied squares rather than all sixty four, an empty
         // board is then free rather than sixty four misses
         let mut occupied = self.white | self.black;
         while occupied != 0 {
             let index = pop_lsb(&mut occupied);
             if let Some((piece, color)) = self.get_piece_and_color_index(index) {
-                total += match color {
+                total += i32::from(match color {
                     Color::White => PVT.get_value(index as usize, piece, Color::White),
                     Color::Black => -PVT.get_value(index as usize, piece, Color::Black),
-                };
+                });
             }
         }
         total
@@ -991,10 +993,10 @@ impl Board {
         debug_assert!(!self.white.is_bit_set(index));
         let zorb: &Zorbrist = &ZORB;
         self.key ^= zorb.get_piece_key(index, piece, color);
-        self.psqt += match color {
+        self.psqt += i32::from(match color {
             Color::White => PVT.get_value(index as usize, piece, Color::White),
             Color::Black => -PVT.get_value(index as usize, piece, Color::Black),
-        };
+        });
         match piece {
             Piece::Pawn => self.pawns.set_bit(index),
             Piece::Knight => self.knights.set_bit(index),
@@ -1025,10 +1027,10 @@ impl Board {
         debug_assert!((self.black | self.white).is_bit_set(index));
         let zorb: &Zorbrist = &ZORB;
         self.key ^= zorb.get_piece_key(index, piece, color);
-        self.psqt -= match color {
+        self.psqt -= i32::from(match color {
             Color::White => PVT.get_value(index as usize, piece, Color::White),
             Color::Black => -PVT.get_value(index as usize, piece, Color::Black),
-        };
+        });
         match piece {
             Piece::Pawn => self.pawns.clear_bit(index),
             Piece::Knight => self.knights.clear_bit(index),

--- a/basic_engine/src/pvt.rs
+++ b/basic_engine/src/pvt.rs
@@ -7,8 +7,8 @@ use crate::misc::Piece;
 /// Written as a `while` rather than with iterators so that it can run at compile
 /// time: the tables are then constants in the binary rather than something built
 /// on startup.
-const fn mirror(array: &[isize; 64]) -> [isize; 64] {
-    let mut mirrored: [isize; 64] = [0; 64];
+const fn mirror(array: &[i16; 64]) -> [i16; 64] {
+    let mut mirrored: [i16; 64] = [0; 64];
     let mut rank = 0;
     while rank < 8 {
         let mut file = 0;
@@ -29,7 +29,7 @@ const fn mirror(array: &[isize; 64]) -> [isize; 64] {
 // written and white takes them mirrored.
 
 #[rustfmt::skip]
-const PAWNS: [isize; 64] = [
+const PAWNS: [i16; 64] = [
     0,  0,  0,  0,  0,  0,  0,  0,
     50, 50, 50, 50, 50, 50, 50, 50,
     10, 10, 20, 30, 30, 20, 10, 10,
@@ -41,7 +41,7 @@ const PAWNS: [isize; 64] = [
 ];
 
 #[rustfmt::skip]
-const KNIGHTS: [isize; 64] = [
+const KNIGHTS: [i16; 64] = [
     -50,-40,-30,-30,-30,-30,-40,-50,
     -40,-20,  0,  0,  0,  0,-20,-40,
     -30,  0, 10, 15, 15, 10,  0,-30,
@@ -53,7 +53,7 @@ const KNIGHTS: [isize; 64] = [
 ];
 
 #[rustfmt::skip]
-const BISHOPS: [isize; 64] = [
+const BISHOPS: [i16; 64] = [
     -20,-10,-10,-10,-10,-10,-10,-20,
     -10,  0,  0,  0,  0,  0,  0,-10,
     -10,  0,  5, 10, 10,  5,  0,-10,
@@ -65,7 +65,7 @@ const BISHOPS: [isize; 64] = [
 ];
 
 #[rustfmt::skip]
-const ROOKS: [isize; 64] = [
+const ROOKS: [i16; 64] = [
     0,  0,  0,  0,  0,  0,  0,  0,
     5, 10, 10, 10, 10, 10, 10,  5,
     -5,  0,  0,  0,  0,  0,  0, -5,
@@ -77,7 +77,7 @@ const ROOKS: [isize; 64] = [
 ];
 
 #[rustfmt::skip]
-const QUEENS: [isize; 64] = [
+const QUEENS: [i16; 64] = [
     -20,-10,-10, -5, -5,-10,-10,-20,
     -10,  0,  0,  0,  0,  0,  0,-10,
     -10,  0,  5,  5,  5,  5,  0,-10,
@@ -88,26 +88,31 @@ const QUEENS: [isize; 64] = [
     -20,-10,-10, -5, -5,-10,-10,-20
 ];
 
+/// The entries are `i16` rather than a machine word because every piece that is
+/// set or cleared reads one, which is several times per move made or unmade, and
+/// the ten tables are then 1280 bytes rather than 5120 and stay in L1 alongside
+/// everything else the search is touching. The values run from -50 to 50, so the
+/// narrower type costs nothing.
 pub struct PieceValueTables {
-    white_pawns: [isize; 64],
-    black_pawns: [isize; 64],
+    white_pawns: [i16; 64],
+    black_pawns: [i16; 64],
 
-    white_knights: [isize; 64],
-    black_knights: [isize; 64],
+    white_knights: [i16; 64],
+    black_knights: [i16; 64],
 
-    white_bishops: [isize; 64],
-    black_bishops: [isize; 64],
+    white_bishops: [i16; 64],
+    black_bishops: [i16; 64],
 
-    white_rooks: [isize; 64],
-    black_rooks: [isize; 64],
+    white_rooks: [i16; 64],
+    black_rooks: [i16; 64],
 
-    white_queens: [isize; 64],
-    black_queens: [isize; 64],
+    white_queens: [i16; 64],
+    black_queens: [i16; 64],
 }
 
 impl PieceValueTables {
     #[inline]
-    pub fn get_value(&self, index: usize, piece: Piece, color: Color) -> isize {
+    pub fn get_value(&self, index: usize, piece: Piece, color: Color) -> i16 {
         match (piece, color) {
             (Piece::Pawn, Color::White) => self.white_pawns[index],
             (Piece::Knight, Color::White) => self.white_knights[index],
@@ -145,7 +150,7 @@ mod tests {
     use crate::misc::File;
     use crate::misc::coordinate_to_index;
 
-    fn value(piece: Piece, color: Color, file: File, rank: u8) -> isize {
+    fn value(piece: Piece, color: Color, file: File, rank: u8) -> i16 {
         let index = coordinate_to_index(rank, file) as usize;
         PieceValueTables::TABLES.get_value(index, piece, color)
     }


### PR DESCRIPTION
The piece square tables were stored as `[isize; 64]`. There are ten of them (white and black for pawns, knights, bishops, rooks and queens), so they occupied 10 x 64 x 8 = 5120 bytes. Every value in them lies between -50 and 50, which fits an `i16` with room to spare, and storing them that way takes the set to 1280 bytes so it stays resident in L1 next to everything else the search is touching.

That matters because these tables are read constantly rather than occasionally. `Board::set_piece_index` and `Board::clear_piece_index` each call `PVT.get_value(...)` on every piece update, which a callgrind pass over Kiwipete at depths 1 to 7 measured as 16.2 million calls across 3.94 million searched nodes. `set_piece_index` alone accounted for 7.4% of all L1 data read misses in that profile.

This is a representation change only. No table value is altered, and move ordering, search and the rest of evaluation are untouched. The `psqt` accumulator on `Board` narrows from `isize` to `i32` rather than to `i16`, which keeps plenty of headroom for summing a boardful of entries and adding the material difference on top; `eval()` already funnelled through `i32` on its way to `Score`.

## Verification

`cargo test --workspace --release` is green: 26 passed in the root crate, 82 passed (1 ignored) in `basic_engine`.

`test_node_counts_have_not_moved` passes with its expected numbers unchanged, which is the evidence that the evaluation is bit identical and the search visits exactly the same tree. The suite was also run in the debug profile, where the overflow checks are live and `debug_assert_state_in_step` cross-checks the incrementally maintained `psqt` against a full recompute after every move; that is green too.

`cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are both clean.

Searching the profiling position to depth 9 returns an identical node count of 50,349,221 before and after. Wall clock was not measurably changed: best-of-eight was 6.73s before and 6.74s after, and the run-to-run spread on this machine (6.7s to 8.0s under background load) is far wider than any difference between the two. A cache footprint change of this size need not show up at this depth, so this is reported as no measurable regression rather than as a speedup.
