### PR TITLE
perf(magic): Only look for a capture where there can be one

### DIFF
--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -412,7 +412,7 @@ impl Board {
             let mut __m = kmoves;
             while __m != 0 {
                 let to = pop_lsb(&mut __m);
-                let capture = self.get_piece_index(to);
+                let capture = self.capture_on(to, capture_mask);
                 moves.push(Play::new(from, to, capture, None, false, false));
             }
         }
@@ -424,7 +424,7 @@ impl Board {
             let mut __m = move_mask;
             while __m != 0 {
                 let to = pop_lsb(&mut __m);
-                let capture = self.get_piece_index(to);
+                let capture = self.capture_on(to, capture_mask);
                 moves.push(Play::new(from, to, capture, None, false, false));
             }
         }
@@ -436,7 +436,7 @@ impl Board {
             let mut __m = move_mask;
             while __m != 0 {
                 let to = pop_lsb(&mut __m);
-                let capture = self.get_piece_index(to);
+                let capture = self.capture_on(to, capture_mask);
                 moves.push(Play::new(from, to, capture, None, false, false));
             }
         }
@@ -449,7 +449,7 @@ impl Board {
             let mut __m = kmove;
             while __m != 0 {
                 let to = pop_lsb(&mut __m);
-                let capture = self.get_piece_index(to);
+                let capture = self.capture_on(to, capture_mask);
                 moves.push(Play::new(from, to, capture, None, false, false));
             }
             // 1. castle permission is available
@@ -1047,6 +1047,19 @@ impl Board {
                 self.white_value -= piece.material_value();
             }
         };
+    }
+
+    /// What is being taken on the to square, without asking when nothing can
+    /// be. `get_piece_index` only answers `None` after testing all six piece
+    /// bitboards, and most of the moves generated are quiet, so the mask of
+    /// squares a capture is even possible on is worth a look first.
+    #[inline(always)]
+    fn capture_on(&self, to: u8, capture_mask: u64) -> Option<Piece> {
+        if capture_mask.is_bit_set(to) {
+            self.get_piece_index(to)
+        } else {
+            None
+        }
     }
 
     #[inline]


### PR DESCRIPTION
A callgrind profile of Kiwipete over depths 1-7 (3.94M nodes, 4.816B
instructions) showed the engine repeatedly rediscovering which piece is on a
square. `Board::get_piece_index` walks up to six bitboards to answer, and
`make_move` and `undo_move` were each called 3.35M times over those 3.94M
nodes; between them and `set_piece_index`/`clear_piece_index` they account for
33% of all instructions executed.

The cheapest of those redundancies to remove is in `generate_moves`. Every move
it produced asked `get_piece_index` what stood on the to square in order to
fill in `Play::capture`, including quiet moves — and a quiet move only gets
`None` back after all six piece bitboards have been tested. Quiet moves are the
majority of what is generated, so most of those calls paid six tests to be told
the square was empty.

Testing the capture mask first answers the same question with a single bit test
in the common case, and `get_piece_index` is only reached on squares something
is actually standing on. This applies to the knight, rook/queen, bishop/queen
and king loops. It deliberately does not apply to:

- `generate_captures`, where every target is a capture by construction
- the pawn diagonal-capture loop, for the same reason
- pawn forward moves, which already passed `None`

## No change to the searched tree

This is a representation change and nothing else. It changes how the capture on
a square is found, not what is found, so the moves generated, their order, and
the tree the search walks are all bit-identical.

The evidence is `test_node_counts_have_not_moved` in `basic_engine/src/engine.rs`,
which passes with its committed numbers untouched. The perft suite in
`basic_engine/src/board.rs`, including the edge-case positions, is unchanged
too. `cargo test --workspace` also passes on the debug profile, where the
`debug_assert` checks compare the incrementally maintained psqt, material and
position key against a recompute after every move.

## Measurement

Release build, `go depth 9` on Kiwipete, ten runs of each binary interleaved
round-robin. This machine is shared and single runs vary by more than the effect
being measured, so the whole distribution is given rather than a single number:

| | min | median | mean | max |
| --- | --- | --- | --- | --- |
| master | 6.84s | 7.00s | 7.02s | 7.23s |
| this branch | 6.68s | 6.91s | 6.86s | 7.00s |

About two percent. The spreads overlap, which is why it is quoted from ten
interleaved runs rather than one; the branch was faster in nine of the ten
rounds and tied in the tenth. Both binaries searched exactly 50,349,221 nodes,
which is the count `master` gives on this machine with the transposition table
at its default size.

## What was left out

The profile also motivates carrying the moving piece in `Play` so that
`make_move`, `undo_move` and `Play::mmv_lva` do not have to look up the from
square either. That was written and measured, and it is a loss: `Play` grows
from 6 bytes to 7, which takes the inline footprint of
`MoveList = SmallVec<[Play; 64]>` from 384 to 448 bytes, and on the same
ten-round harness it came out around 4% *slower* than master — enough to wipe
out this change and go negative. Same node count, so it was correct, just not
worth having. It is not in this branch. Making it pay would mean packing the
piece into spare bits rather than adding a field, which is a bigger change than
this one.

## Notes for reviewers

- Touches `basic_engine/src/board.rs` only. The concurrent `perf/psqt-i16`
  branch edits `set_piece_index`/`clear_piece_index` in the same file; this
  change is confined to `generate_moves`, so they should not collide, but it is
  the same file.
- #48 ("refactor(search): Return the outcome from the root instead of probing
  the table") is expected to land first. It adds a third `m.mmv_lva(&self.board)`
  call site and fresh `make_move`/`undo_move` calls in `AlphaBeta::search()`.
  Nothing here touches `mmv_lva` or make/unmake, so there is no conflict and
  nothing to update on rebase — but if the carried-piece idea above is ever
  revisited, that new root site would need the same treatment as the other three.
