### PR TITLE
perf(search): Keep sixteen bits of the key in a table slot

### DIFF
--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -413,8 +413,10 @@ struct Pv {
     play: Play,
     score: Score,
     // a depth cannot exceed MAX_DEPTH and a ply is bounded by the history
-    // array, so neither needs a word. Both sit in the padding the key leaves
-    // behind, which is why widening ply to u16 costs nothing.
+    // array, so neither needs a word. These used to sit in padding the full
+    // key left behind; the fragment leaves none, so they are now paid for.
+    // Narrowing ply back to u8 would not help: at eleven bytes the struct
+    // still rounds up to twelve.
     depth: u8,
     node: Node,
     ply: u16,
@@ -431,9 +433,22 @@ enum Node {
     Ordering,
 }
 
-/// A slot in the table. The key is kept alongside the entry so that a probe can
-/// tell a real hit from another position landing on the same index.
-type Entry = Option<(Pv, u64)>;
+/// The part of a position key kept in the slot, so that a probe can tell a real
+/// hit from another position landing on the same index.
+///
+/// The index is drawn from the top of the key, so the bottom of it is what
+/// carries information the index does not already have. Sixteen bits of it
+/// leaves a one in sixty five thousand chance of taking another position's
+/// entry for this one, against the eight bytes a whole key costs in every slot.
+type KeyFragment = u16;
+
+#[inline]
+fn key_fragment(key: u64) -> KeyFragment {
+    key as KeyFragment
+}
+
+/// A slot in the table.
+type Entry = Option<(Pv, KeyFragment)>;
 
 #[derive(Debug)]
 struct HashTable {
@@ -471,7 +486,7 @@ impl HashTable {
     fn get(&self, key: u64) -> Option<&Pv> {
         let index = self.index_for(key);
         if let Some((pv, k)) = &self.table[index] {
-            if *k == key {
+            if *k == key_fragment(key) {
                 return Some(pv);
             }
         }
@@ -493,7 +508,7 @@ impl HashTable {
                     return;
                 }
                 if pv.depth == old_pv.depth
-                    && old_key == key
+                    && old_key == key_fragment(key)
                     && matches!(old_pv.node, Node::Exact)
                     && !matches!(pv.node, Node::Exact)
                 {
@@ -501,7 +516,7 @@ impl HashTable {
                 }
             }
         }
-        self.table[index] = Some((pv, key));
+        self.table[index] = Some((pv, key_fragment(key)));
     }
 }
 
@@ -1262,11 +1277,11 @@ mod test_node_counts {
         assert_eq!(
             counted,
             vec![
-                ("opening", 149_810),
-                ("kiwipete", 217_026),
-                ("pawn endgame", 173_223),
-                ("promotions", 110_643),
-                ("middlegame", 191_607),
+                ("opening", 147_307),
+                ("kiwipete", 216_583),
+                ("pawn endgame", 170_848),
+                ("promotions", 110_551),
+                ("middlegame", 188_555),
             ]
         );
     }


### PR DESCRIPTION
A slot in the transposition table held the whole 64-bit key alongside its entry: `Option<(Pv, u64)>`, 24 bytes for 20 bytes of information. The index is derived from the top of the key by multiply-shift, so only the bottom of it carries anything the index does not already imply. Sixteen bits of that is enough to tell a real hit from another position landing on the same slot.

A slot goes from **24 bytes to 14**, so a table of any given size holds **1.71x** as many positions.

## Measured

Kiwipete at `go depth 9`, interleaved runs against `master`:

| table | master nodes | this nodes | master | this | gain |
| --- | --- | --- | --- | --- | --- |
| 2MB | 79,035,298 | 71,577,254 | 8.08s | 7.32s | -9.4% |
| 8MB | 62,136,735 | 58,080,770 | 6.63s | 6.14s | **-7.3%** |
| 32MB | 53,887,636 | 52,366,490 | 6.12s | 5.82s | -4.9% |
| 128MB | 51,090,397 | 50,694,298 | 5.95s | 5.83s | **-1 to -2%** |

The 8MB and 128MB rows are six interleaved rounds with non-overlapping distributions. The 2MB and 32MB rows are three runs each and are looser.

The gain is almost entirely the extra capacity, not the smaller slot. Sizing the narrow table to exactly the same slot count as the wide one (5,592,405 slots) leaves the layout change alone worth about **0.5%** — 5.889s to 5.858s. Worth stating plainly, because the cache argument is the weaker half of the case for this change, and 14 bytes actually straddles cache lines more than 24 did.

Read the other way: 32MB of these slots searches about as much of the tree as 128MB of the old ones, so this is mostly what lets the table be made smaller.

## Correctness

Taking another position's entry for this one goes from impossible to merely unlikely. Two checks:

- `test_small_table_matches_large_table` passes — an 8KB table colliding constantly still returns the same score as a large one.
- Measured directly, by sizing the narrow table to the same slot count as the wide one so the two map identically: **51,090,377 nodes against 51,090,397**. Twenty nodes different in fifty one million. That gap is the false hits.

`test_node_counts_have_not_moved` is updated in this commit, as `docs/DEVELOPMENT.md` requires. Every one of the five falls, which is the expected direction — a table that holds more of the tree searches less of it:

| position | before | after |
| --- | --- | --- |
| opening | 149,810 | 147,307 |
| kiwipete | 217,026 | 216,583 |
| pawn endgame | 173,223 | 170,848 |
| promotions | 110,643 | 110,551 |
| middlegame | 191,607 | 188,555 |

Full suite green in both release and debug profiles; `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Note

Node counts cannot detect a *worse move*, only a different amount of work, so a strength match is the check that matters for the false-hit risk. One is being run against `master` alongside this PR.

Depends on nothing; sits on top of #48, which removed the root's dependency on reading its own best move back out of the table. That dependency is what made shrinking the key hazardous before — a false hit at the root could have replaced the move actually played.