### PR TITLE
refactor(uci): Move protocol printing out of the library

### DIFF
--- a/basic_engine/benches/benchmark.rs
+++ b/basic_engine/benches/benchmark.rs
@@ -81,7 +81,7 @@ bench_engine_fen!(
     {
         engine.clear_cache();
     },
-    { engine.iterative_deepening_search(SearchParameters::new_with_depth(5)) }
+    { engine.iterative_deepening_search(SearchParameters::new_with_depth(5), |_, _, _| {}) }
 );
 
 criterion_group!(board_benches, square_attacked, generate_moves,);

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -58,8 +58,16 @@ pub trait Engine {
 
     fn make_move_str(&mut self, play: &str) -> bool;
 
-    fn iterative_deepening_search(&mut self, search_options: SearchParameters) -> Option<Play> {
-        let mut best_move: Option<Play> = None;
+    /// Search each depth in turn until one is the last to finish. The caller
+    /// hears about every completed iteration through on_depth, which is where
+    /// a protocol adapter reports progress from; the library itself never
+    /// prints.
+    fn iterative_deepening_search(
+        &mut self,
+        search_options: SearchParameters,
+        mut on_depth: impl FnMut(u8, &SearchResult, PvLine),
+    ) -> SearchOutcome {
+        let mut best: Option<SearchResult> = None;
         let max_depth = match search_options.depth {
             Some(depth) => depth,
             None => MAX_DEPTH,
@@ -73,43 +81,25 @@ pub trait Engine {
                     // one's best-so-far, which may be a fail high that never
                     // got re-searched. The partial only fills in when depth 1
                     // itself ran out of time.
-                    return best_move.or_else(|| partial.map(|r| r.best_move));
+                    return SearchOutcome::Aborted(best.or(partial));
                 }
                 SearchOutcome::GameOver => {
                     // checkmate, stalemate or a rule draw: deeper searches
                     // cannot change it, so don't run them
-                    println!("info string no legal moves identified");
-                    return None;
+                    return SearchOutcome::GameOver;
                 }
-                SearchOutcome::Complete(m) => {
-                    best_move = Some(m.best_move);
-                    if search_options.print_info {
-                        if let Some(mate_in) = m.checkmate_in() {
-                            println!(
-                                "info depth {} seldepth {} nodes {} score mate {} pv {}",
-                                depth,
-                                m.selective_depth,
-                                m.nodes,
-                                mate_in,
-                                self.pv_line(),
-                            );
-                        } else {
-                            println!(
-                                "info depth {} seldepth {} nodes {} score cp {} pv {}",
-                                depth,
-                                m.selective_depth,
-                                m.nodes,
-                                m.score,
-                                self.pv_line(),
-                                // TODO add search time to this
-                                // TODO add nodes per second
-                            );
-                        }
-                    }
+                SearchOutcome::Complete(result) => {
+                    on_depth(depth, &result, self.pv_line());
+                    best = Some(result);
                 }
             }
         }
-        best_move
+        match best {
+            Some(result) => SearchOutcome::Complete(result),
+            // a depth of zero runs no iterations, so there is nothing to
+            // report beyond that no move was looked for
+            None => SearchOutcome::Aborted(None),
+        }
     }
 
     fn configure(&mut self, start_time: time::Instant, search_duration: Option<time::Duration>);
@@ -125,7 +115,6 @@ pub struct SearchParameters {
     pub depth: Option<u8>,
     pub search_duration: Option<time::Duration>,
     pub start_time: time::Instant,
-    pub print_info: bool,
 }
 
 impl Default for SearchParameters {
@@ -140,7 +129,6 @@ impl SearchParameters {
             depth: None,
             search_duration: None,
             start_time: time::Instant::now(),
-            print_info: false,
         }
     }
 
@@ -149,7 +137,6 @@ impl SearchParameters {
             depth: Some(depth),
             search_duration: None,
             start_time: time::Instant::now(),
-            print_info: false,
         }
     }
 }
@@ -509,6 +496,14 @@ pub struct PvLine {
     line: Vec<Play>,
 }
 
+impl PvLine {
+    /// A line built by hand, which is how a protocol adapter's tests pin the
+    /// format of a reported line without running a search.
+    pub fn new(line: Vec<Play>) -> Self {
+        Self { line }
+    }
+}
+
 impl fmt::Display for PvLine {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let out: Vec<String> = self.line.iter().map(|p| format!("{}", p)).collect();
@@ -541,14 +536,14 @@ struct Aborted;
 
 #[derive(Debug)]
 pub struct SearchResult {
-    nodes: u64,          // The number of results examined as part of the search
-    selective_depth: u8, // Selective search depth in plies
-    best_move: Play,     // The best move found as part of the search
-    score: Score,        // The estimated score for the best move if played
+    pub nodes: u64,          // The number of results examined as part of the search
+    pub selective_depth: u8, // Selective search depth in plies
+    pub best_move: Play,     // The best move found as part of the search
+    pub score: Score,        // The estimated score for the best move if played
 }
 
 impl SearchResult {
-    fn checkmate_in(&self) -> Option<Score> {
+    pub fn checkmate_in(&self) -> Option<Score> {
         if (CHECKMATE_SCORE - self.score.abs()) < 300 {
             let mut mate = (CHECKMATE_SCORE - self.score.abs() + 1) / 2;
             if self.score < 0 {
@@ -719,9 +714,48 @@ mod test_search {
             depth: None,
             search_duration: Some(time::Duration::from_millis(50)),
             start_time: time::Instant::now(),
-            print_info: false,
         };
-        assert!(e.iterative_deepening_search(params).is_some());
+        let outcome = e.iterative_deepening_search(params, |_, _, _| {});
+        assert!(matches!(outcome, SearchOutcome::Aborted(Some(_))));
+    }
+
+    #[test]
+    fn test_deepening_reports_each_completed_depth() {
+        use super::SearchParameters;
+        let mut e = engine(Board::new());
+        let mut depths = Vec::new();
+        let outcome = e.iterative_deepening_search(
+            SearchParameters::new_with_depth(3),
+            |depth, result, _| {
+                assert!(result.nodes > 0);
+                depths.push(depth);
+            },
+        );
+        assert_eq!(depths, vec![1, 2, 3]);
+        assert!(matches!(outcome, SearchOutcome::Complete(_)));
+    }
+
+    #[test]
+    fn test_deepening_stops_reporting_at_game_over() {
+        use super::SearchParameters;
+        // fool's mate again: there is nothing to report and nothing to play
+        let game = Board::from_fen("rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 1 3")
+            .unwrap();
+        let mut e = engine(game);
+        let outcome = e
+            .iterative_deepening_search(SearchParameters::new_with_depth(3), |_, _, _| {
+                panic!("a finished game has no depths to report")
+            });
+        assert!(matches!(outcome, SearchOutcome::GameOver));
+    }
+
+    #[test]
+    fn test_deepening_to_depth_zero_finds_nothing() {
+        use super::SearchParameters;
+        let mut e = engine(Board::new());
+        let outcome =
+            e.iterative_deepening_search(SearchParameters::new_with_depth(0), |_, _, _| {});
+        assert!(matches!(outcome, SearchOutcome::Aborted(None)));
     }
 
     #[test]

--- a/basic_engine/src/lib.rs
+++ b/basic_engine/src/lib.rs
@@ -11,8 +11,9 @@ mod pvt;
 mod zorbrist;
 
 pub use board::Board;
-pub use engine::{AlphaBeta, Engine, SearchParameters};
-pub use misc::Color;
+pub use engine::{AlphaBeta, Engine, PvLine, SearchOutcome, SearchParameters, SearchResult};
+pub use misc::{Color, Score};
+pub use play::Play;
 use std::fmt;
 
 pub trait Game: fmt::Display {

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,9 +1,12 @@
 use crate::time_control::TimeControl;
 use basic_engine::Color;
 use basic_engine::Engine;
+use basic_engine::SearchOutcome;
 use basic_engine::SearchParameters;
+use basic_engine::{PvLine, SearchResult};
 use regex::Regex;
 use std::io::BufRead;
+use std::time::Duration;
 
 const START_FEN: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
@@ -152,16 +155,47 @@ impl<T: Engine> UCI<T> {
 
     fn parse_go(&mut self, line: &str) {
         let mut sp = SearchParameters::new();
-        sp.print_info = true;
-
         sp.search_duration = time_control_from(line, self.engine.active_color()).budget();
         sp.depth = capture(&DEPTH_RE, line).map(|depth| depth.try_into().unwrap_or(u8::MAX));
 
-        match self.engine.iterative_deepening_search(sp) {
-            // 0000 is the null move, used to report that there is no move to make
-            Some(play) => println!("bestmove {}", play),
-            None => println!("bestmove 0000"),
+        let start = sp.start_time;
+        let outcome = self
+            .engine
+            .iterative_deepening_search(sp, |depth, result, pv| {
+                println!("{}", format_info(depth, result, &pv, start.elapsed()));
+            });
+        match outcome {
+            SearchOutcome::Complete(result) | SearchOutcome::Aborted(Some(result)) => {
+                println!("bestmove {}", result.best_move);
+            }
+            SearchOutcome::GameOver => {
+                println!("info string no legal moves identified");
+                // 0000 is the null move, used to report that there is no move
+                // to make
+                println!("bestmove 0000");
+            }
+            SearchOutcome::Aborted(None) => println!("bestmove 0000"),
         }
+    }
+}
+
+/// One completed depth as a UCI info line. The elapsed time arrives as a
+/// parameter rather than being read from a clock here, so that tests can pin
+/// the whole line.
+fn format_info(depth: u8, result: &SearchResult, pv: &PvLine, elapsed: Duration) -> String {
+    let millis = elapsed.as_millis();
+    // measure a search faster than a millisecond as one, so the rate stays
+    // finite and the arithmetic stays whole
+    let nps = (result.nodes as u128 * 1000 / millis.max(1)) as u64;
+    match result.checkmate_in() {
+        Some(mate_in) => format!(
+            "info depth {} seldepth {} nodes {} time {} nps {} score mate {} pv {}",
+            depth, result.selective_depth, result.nodes, millis, nps, mate_in, pv
+        ),
+        None => format!(
+            "info depth {} seldepth {} nodes {} time {} nps {} score cp {} pv {}",
+            depth, result.selective_depth, result.nodes, millis, nps, result.score, pv
+        ),
     }
 }
 
@@ -308,5 +342,63 @@ mod tests {
     #[test]
     fn an_oversized_depth_does_not_panic() {
         assert_eq!(capture(&DEPTH_RE, "go depth 999"), Some(999));
+    }
+
+    use basic_engine::Play;
+
+    /// The move of this name in the starting position, for building the
+    /// synthetic results the format tests pin.
+    fn play_named(name: &str) -> Play {
+        *Board::new()
+            .generate_moves()
+            .iter()
+            .find(|m| format!("{}", m) == name)
+            .unwrap_or_else(|| panic!("{} is not a move here", name))
+    }
+
+    #[test]
+    fn an_info_line_reports_a_centipawn_score() {
+        let result = SearchResult {
+            nodes: 2000,
+            selective_depth: 7,
+            best_move: play_named("e2e4"),
+            score: 25,
+        };
+        let pv = PvLine::new(vec![play_named("e2e4"), play_named("g1f3")]);
+        assert_eq!(
+            format_info(5, &result, &pv, Duration::from_millis(500)),
+            "info depth 5 seldepth 7 nodes 2000 time 500 nps 4000 score cp 25 pv e2e4 g1f3"
+        );
+    }
+
+    #[test]
+    fn an_info_line_reports_a_mate_score_in_moves() {
+        // three plies from checkmate reads as mate in two moves
+        let result = SearchResult {
+            nodes: 1500,
+            selective_depth: 4,
+            best_move: play_named("e2e4"),
+            score: 30_000 - 3,
+        };
+        let pv = PvLine::new(vec![play_named("e2e4")]);
+        assert_eq!(
+            format_info(4, &result, &pv, Duration::from_millis(20)),
+            "info depth 4 seldepth 4 nodes 1500 time 20 nps 75000 score mate 2 pv e2e4"
+        );
+    }
+
+    #[test]
+    fn a_search_faster_than_a_millisecond_still_reports_a_rate() {
+        let result = SearchResult {
+            nodes: 300,
+            selective_depth: 1,
+            best_move: play_named("e2e4"),
+            score: 0,
+        };
+        let pv = PvLine::new(vec![]);
+        assert_eq!(
+            format_info(1, &result, &pv, Duration::ZERO),
+            "info depth 1 seldepth 1 nodes 300 time 0 nps 300000 score cp 0 pv "
+        );
     }
 }


### PR DESCRIPTION
Moves the search/protocol seam to the crate edge: the library returns structured results, and `uci.rs` owns every byte of the wire format. Builds on #48.

## What changed

- `iterative_deepening_search(params, on_depth)` takes a callback invoked after each completed iteration with `(depth, &SearchResult, PvLine)`, so a GUI still sees `info` lines live during a long think — but the library itself never prints. Both `println!`s and the `print_info` flag are gone from `basic_engine`.
- The loop returns `SearchOutcome`, the same shape as a single `search()`: `Complete(result)` when it ran to depth, `GameOver` when the root has nothing to play, `Aborted(Some(result))` with the fallback already resolved by the loop's precedence rule, `Aborted(None)` when depth 1 never finished. UCI matches once to print `bestmove`.
- `lib.rs` now exports `SearchOutcome`, `SearchResult`, `PvLine`, `Play`, and `Score`. `SearchResult`'s fields go public the way `Board`'s are — it is plain data produced whole by the root loop — which is also what lets the format tests construct synthetic results.
- `uci.rs` formats the `info` line in one pure function taking elapsed time as a parameter, so tests pin the entire line deterministically. This settles the two old TODOs: the line now reports `time` and `nps`.
- The benchmark passes a no-op callback; it printed nothing before (`print_info: false`), so timings stay comparable.

## Behaviour notes

- `bestmove` output is byte-identical to before.
- `info` lines gain `time <ms> nps <n>` between `nodes` and `score` — the only intended output change.
- `info string no legal moves identified` now prints from `uci.rs` on `GameOver`, once.
- No search behaviour changes; the pinned node counts are untouched.

## Testing

- `cargo test --workspace --release` and `cargo test --workspace` (debug assertions): 89 library + 29 binary tests, all passing
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check`: clean
- New: three `format_info` pins (cp, mate, sub-millisecond nps), callback-per-depth, GameOver-reports-nothing, depth-zero, and the timed-out fallback asserting on `SearchOutcome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDKBhk4ej8qLdcPF44kLXT