### PR TITLE
test(board): Assert the en passant rule itself, not just the key

### DIFF
--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -598,6 +598,15 @@ impl Board {
             "material out of step"
         );
         debug_assert_eq!(self.key, self.recompute_key(), "key out of step");
+        // the recompute reads the en passant field as it stands, so the check
+        // above cannot tell a field set against the rule: assert the rule
+        // itself, that a recorded square is one the side to move can take on
+        if let Some(en_passant) = self.en_passant {
+            debug_assert!(
+                self.pawn_can_capture_on(en_passant.as_index(), self.active_color),
+                "en passant square no pawn can take"
+            );
+        }
     }
 
     /// The position key computed from the board rather than maintained as moves
@@ -1314,6 +1323,9 @@ impl Game for Board {
             }
         }
         (board.white_value, board.black_value) = board.material_value();
+        // a parsed position must satisfy the same invariants a played one
+        // does, or the two ways of reaching a position drift apart
+        board.debug_assert_state_in_step();
         Ok(board)
     }
 }
@@ -1661,6 +1673,21 @@ mod position_key {
     use super::Board;
     use super::Game;
     use pretty_assertions::{assert_eq, assert_ne};
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "en passant square no pawn can take")]
+    fn an_en_passant_square_no_pawn_can_take_fails_the_state_check() {
+        use super::{Coordinate, ZORB};
+        let mut board = Board::new();
+        // e6 is out of reach of every white pawn at the start. Hash the bogus
+        // square into the key as well as the field, so the key still matches
+        // its recompute and only the rule itself can object: this is exactly
+        // the corruption the recompute comparison is blind to.
+        board.en_passant = Coordinate::from_string("e6").unwrap();
+        board.key ^= ZORB.en_passant_key(board.en_passant.unwrap().as_index());
+        board.debug_assert_state_in_step();
+    }
 
     fn play_move(board: &mut Board, mv: &str) {
         let m = *board

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -20,10 +20,12 @@ cargo test --workspace --release
 ```
 
 The perft tests dominate the runtime, which is why the release profile is the
-usual choice. Run them at least once without `--release` before changing
-anything that indexes into the history or does arithmetic on ply counts, the
-debug profile keeps the overflow checks and debug assertions that catch that
-class of bug:
+usual choice for a quick pass. The debug run is the one that checks the most,
+so run it before landing a change: the debug profile keeps the overflow checks
+and the board's state-in-step assertions, which verify the position key, the
+eval accumulators and the en passant rule against a recompute on every move
+made. Release compiles all of that out, so a green release run alone says
+nothing about them.
 
 ```
 cargo test --workspace


### PR DESCRIPTION
Closes the last structural gap from the architecture review's en-passant finding. The recent ring-buffer and FEN-rejection commits already covered the rest of that candidate; this is the remaining sliver.

## What changed

- **`debug_assert_state_in_step` now asserts the en passant rule itself.** The existing check compares `key` against `recompute_key()`, but the recompute *reads* the `en_passant` field as it stands — so a field set against the rule (a recorded square no pawn can take) slips through with the key and its recompute in perfect agreement. The new assertion checks `pawn_can_capture_on` directly, so the corruption fails on the next move made in a debug build.
- **The new test proves the blind spot existed**: it corrupts the field *and* hashes the bogus square into the key, so the recompute comparison alone stays silent, and only the new rule assertion trips. Debug-only (`#[cfg(debug_assertions)]` + `#[should_panic]`).
- **`from_fen` runs the same state check before returning**, so a parsed position answers to the same invariants as a played one — the two entry points can no longer drift apart silently in debug builds.
- **`DEVELOPMENT.md` now says what the debug run checks that release cannot**: the state-in-step assertions compile out of `--release`, so a green release run alone says nothing about them. The advice to run debug is no longer scoped to ply arithmetic only.

## Testing

- `cargo test --workspace` (debug): 93 + 31 passing, including the new should-panic test and the `from_fen` assert against every FEN in the suite
- `cargo test --workspace --release`: 92 + 31 passing (the new test is debug-only by design)
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check`: clean
- No search or output changes; node-count pins untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDKBhk4ej8qLdcPF44kLXT