### PR TITLE
Audit cleanup: idiom, comments, dead code and a fen validation fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,6 @@ name = "arche"
 version = "0.3.9"
 dependencies = [
  "basic_engine",
- "lazy_static",
  "regex",
 ]
 
@@ -43,7 +42,6 @@ name = "basic_engine"
 version = "0.3.9"
 dependencies = [
  "criterion",
- "lazy_static",
  "pretty_assertions",
  "proptest",
  "smallvec",
@@ -321,12 +319,6 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ authors = [
 ]
 
 [dependencies]
-lazy_static = "1.5.0"
 regex = "1"
 basic_engine = { path = "./basic_engine" }
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Andrew's Rust Chess Engine
 
 ## About
 
-This project is mostly indented for self-edification. The engine is not intended to be particularly novel or powerful.
+This project is mostly intended for self-edification. The engine is not intended to be particularly novel or powerful.
 
 The board is currently represented using only bitboards (with magic bitboards for move generation of sliding pieces).
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ docker/smoke_test.sh arche-lichess-bot
   - `ponderhit`, `debug` and `register` are not handled either
 - winboard
 - known issues
-  - fail low (alpha) nodes are never stored in the transposition table, only exact and beta nodes
+  - fail low nodes (upper bounds) are never stored in the transposition table, only exact
+    scores and fail highs
   - transposition table scores don't account for repetition or fifty move history, make_move_str
     clears the key for played moves as a workaround
   - a fen is only validated as far as what the search cannot survive, a king a side and the side

--- a/basic_engine/Cargo.toml
+++ b/basic_engine/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 bench = false #https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 
 [dependencies]
-lazy_static = "1.5.0"
 smallvec = "1.15.1"
 
 [dev-dependencies]

--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -1238,10 +1238,25 @@ impl Game for Board {
 
         // parse out the pieces on the board
         let mut rank = 8;
-        let mut file = File::A;
+        // counted as a number rather than held as a File, because a complete
+        // rank ends one square past the h file, which is not a File a square
+        // can have
+        let mut file = 0u8;
         for c in position.chars() {
             if rank < 1 {
                 return Err("Too many ranks found".to_string());
+            }
+            if c == '/' {
+                rank -= 1;
+                file = 0;
+                continue;
+            }
+            let step = match c {
+                '1'..='8' => c.to_digit(10).unwrap() as u8,
+                _ => 1,
+            };
+            if file + step > 8 {
+                return Err("Too many files found in rank".to_string());
             }
             // TODO change piece to PieceType and implement a Piece with from char and to char
             // methods
@@ -1252,7 +1267,6 @@ impl Game for Board {
                 'r' | 'R' => Some(Piece::Rook),
                 'q' | 'Q' => Some(Piece::Queen),
                 'k' | 'K' => Some(Piece::King),
-                '/' => None,
                 '1'..='8' => None,
                 _ => return Err("unexpected character in fen".to_string()),
             };
@@ -1262,19 +1276,9 @@ impl Game for Board {
                 } else {
                     Color::Black
                 };
-                board.set_piece(p, color, rank, file);
+                board.set_piece(p, color, rank, File::try_from(file)?);
             }
-
-            file = match c {
-                '1'..='8' => file.add(c.to_digit(10).unwrap()),
-                'r' | 'b' | 'n' | 'k' | 'q' | 'p' => file.add(1),
-                'R' | 'B' | 'N' | 'K' | 'Q' | 'P' => file.add(1),
-                '/' => {
-                    rank -= 1;
-                    File::A
-                }
-                _ => return Err("unexpected character in fen".to_string()),
-            };
+            file += step;
         }
         // Everything below assumes a position which could actually arise, and
         // crashes rather than playing badly when it could not. A king a side is
@@ -1911,14 +1915,20 @@ mod test_fen {
                 .is_err()
         );
     }
-    // TODO uncomment this test and fix
-    //#[test]
-    //fn test_invalid_extra_file() {
-    //    assert!(Board::from_fen(
-    //        "rnbqkbnr/ppppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1".to_string()
-    //    )
-    //    .is_err());
-    //}
+    /// A ninth file used to wrap back onto the a file and corrupt the square
+    /// it landed on, rather than fail to parse.
+    #[test]
+    fn test_invalid_extra_file() {
+        assert!(
+            Board::from_fen("rnbqkbnr/ppppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")
+                .is_err()
+        );
+        assert!(
+            Board::from_fen("rnbqkbnr/pppppppp/45/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")
+                .is_err(),
+            "digits which sum past the h file are the same mistake"
+        );
+    }
     #[test]
     fn test_invalid_bad_piece() {
         assert!(

--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -273,103 +273,22 @@ impl Board {
         Board::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap()
     }
 
+    /// The subset of generate_moves with a capture, in the same order, made
+    /// without generating the quiet moves only to filter them out.
     pub fn generate_captures(&self) -> MoveList {
-        let mut moves = MoveList::new();
-        let (color_mask, capture_mask) = match self.active_color {
-            Color::Black => (self.black, self.white),
-            Color::White => (self.white, self.black),
-        };
-        let all_pieces = self.black | self.white;
-        let attack_masks: &AttackMasks = &ATTACK_MASKS;
-        let magic: &Magic = &MAGIC;
-        // masking with the opponent's pieces keeps only the captures, so every
-        // to square here holds something to take
-        // knights
-        let mut knights = self.knights & color_mask;
-        while knights != 0 {
-            let from = pop_lsb(&mut knights);
-            let mut targets = attack_masks.knights[from as usize] & capture_mask;
-            while targets != 0 {
-                let to = pop_lsb(&mut targets);
-                let capture = self.get_piece_index(to);
-                moves.push(Play::new(from, to, capture, None, false, false));
-            }
-        }
-        // queens and rooks
-        let mut queens_and_rooks = (self.queens | self.rooks) & color_mask;
-        while queens_and_rooks != 0 {
-            let from = pop_lsb(&mut queens_and_rooks);
-            let mut targets = magic.get_straight_move(from, all_pieces) & capture_mask;
-            while targets != 0 {
-                let to = pop_lsb(&mut targets);
-                let capture = self.get_piece_index(to);
-                moves.push(Play::new(from, to, capture, None, false, false));
-            }
-        }
-        // queens and bishops
-        let mut queens_and_bishops = (self.queens | self.bishops) & color_mask;
-        while queens_and_bishops != 0 {
-            let from = pop_lsb(&mut queens_and_bishops);
-            let mut targets = magic.get_diagonal_move(from, all_pieces) & capture_mask;
-            while targets != 0 {
-                let to = pop_lsb(&mut targets);
-                let capture = self.get_piece_index(to);
-                moves.push(Play::new(from, to, capture, None, false, false));
-            }
-        }
-        // kings
-        let mut kings = self.kings & color_mask;
-        while kings != 0 {
-            let from = pop_lsb(&mut kings);
-            let mut targets = attack_masks.kings[from as usize] & capture_mask;
-            while targets != 0 {
-                let to = pop_lsb(&mut targets);
-                let capture = self.get_piece_index(to);
-                moves.push(Play::new(from, to, capture, None, false, false));
-            }
-        }
-        //pawns
-        let mut pawns = self.pawns & color_mask;
-        while pawns != 0 {
-            let from = pop_lsb(&mut pawns);
-            let (rank, _) = index_to_coordinate(from);
-            let can_promote = match self.active_color {
-                Color::White => rank == 7,
-                Color::Black => rank == 2,
-            };
-            // move diagonally and capture
-            let pmoves: u64 = match self.active_color {
-                Color::White => attack_masks.black_pawns[from as usize] & capture_mask,
-                Color::Black => attack_masks.white_pawns[from as usize] & capture_mask,
-            };
-            let mut targets = pmoves;
-            while targets != 0 {
-                let to = pop_lsb(&mut targets);
-                let capture = self.get_piece_index(to);
-                if can_promote {
-                    for p in PromotePiece::VARIANTS {
-                        moves.push(Play::new(from, to, capture, Some(p), false, false));
-                    }
-                } else {
-                    moves.push(Play::new(from, to, capture, None, false, false));
-                }
-            }
-            // en passant
-            if let Some(en_passant) = &self.en_passant {
-                let i = en_passant.as_index();
-                let can_en_passant = match self.active_color {
-                    Color::White => attack_masks.black_pawns[from as usize].is_bit_set(i),
-                    Color::Black => attack_masks.white_pawns[from as usize].is_bit_set(i),
-                };
-                if can_en_passant {
-                    moves.push(Play::new(from, i, Some(Piece::Pawn), None, true, false));
-                }
-            }
-        }
-        moves
+        self.generate::<true>()
     }
 
     pub fn generate_moves(&self) -> MoveList {
+        self.generate::<false>()
+    }
+
+    /// The one generator behind generate_moves and generate_captures. The
+    /// const parameter is settled at compile time, so each wrapper
+    /// monomorphises into what used to be its own hand-written copy: the
+    /// captures one masks every piece's targets with the opponent's pieces
+    /// and drops the quiet-only sections, with nothing tested per move.
+    fn generate<const CAPTURES_ONLY: bool>(&self) -> MoveList {
         let mut moves = MoveList::new();
         let (color_mask, capture_mask) = match self.active_color {
             Color::Black => (self.black, self.white),
@@ -378,50 +297,62 @@ impl Board {
         let all_pieces = self.black | self.white;
         let attack_masks: &AttackMasks = &ATTACK_MASKS;
         let magic: &Magic = &MAGIC;
-        // masking out our own pieces leaves quiet moves and captures both, and
-        // capture_on tells the two apart
+        // the captures list keeps only the squares the opponent stands on,
+        // the full list keeps every square our own pieces do not
+        let target_filter = if CAPTURES_ONLY {
+            capture_mask
+        } else {
+            !color_mask
+        };
+        // when every target is a capture there is nothing to ask per move
+        let capture_at = |to: u8| {
+            if CAPTURES_ONLY {
+                self.get_piece_index(to)
+            } else {
+                self.capture_on(to, capture_mask)
+            }
+        };
         // knights
         let mut knights = self.knights & color_mask;
         while knights != 0 {
             let from = pop_lsb(&mut knights);
-            let mut targets = attack_masks.knights[from as usize] & !color_mask;
+            let mut targets = attack_masks.knights[from as usize] & target_filter;
             while targets != 0 {
                 let to = pop_lsb(&mut targets);
-                let capture = self.capture_on(to, capture_mask);
-                moves.push(Play::new(from, to, capture, None, false, false));
+                moves.push(Play::new(from, to, capture_at(to), None, false, false));
             }
         }
         // queens and rooks
         let mut queens_and_rooks = (self.queens | self.rooks) & color_mask;
         while queens_and_rooks != 0 {
             let from = pop_lsb(&mut queens_and_rooks);
-            let mut targets = magic.get_straight_move(from, all_pieces) & !color_mask;
+            let mut targets = magic.get_straight_move(from, all_pieces) & target_filter;
             while targets != 0 {
                 let to = pop_lsb(&mut targets);
-                let capture = self.capture_on(to, capture_mask);
-                moves.push(Play::new(from, to, capture, None, false, false));
+                moves.push(Play::new(from, to, capture_at(to), None, false, false));
             }
         }
         // queens and bishops
         let mut queens_and_bishops = (self.queens | self.bishops) & color_mask;
         while queens_and_bishops != 0 {
             let from = pop_lsb(&mut queens_and_bishops);
-            let mut targets = magic.get_diagonal_move(from, all_pieces) & !color_mask;
+            let mut targets = magic.get_diagonal_move(from, all_pieces) & target_filter;
             while targets != 0 {
                 let to = pop_lsb(&mut targets);
-                let capture = self.capture_on(to, capture_mask);
-                moves.push(Play::new(from, to, capture, None, false, false));
+                moves.push(Play::new(from, to, capture_at(to), None, false, false));
             }
         }
         // kings
         let mut kings = self.kings & color_mask;
         while kings != 0 {
             let from = pop_lsb(&mut kings);
-            let mut targets = attack_masks.kings[from as usize] & !color_mask;
+            let mut targets = attack_masks.kings[from as usize] & target_filter;
             while targets != 0 {
                 let to = pop_lsb(&mut targets);
-                let capture = self.capture_on(to, capture_mask);
-                moves.push(Play::new(from, to, capture, None, false, false));
+                moves.push(Play::new(from, to, capture_at(to), None, false, false));
+            }
+            if CAPTURES_ONLY {
+                continue;
             }
             // 1. castle permission is available
             // 2. king is not in check
@@ -499,31 +430,33 @@ impl Board {
                     moves.push(Play::new(from, to, capture, None, false, false));
                 }
             }
-            // move forward
-            let to = match self.active_color {
-                Color::White => from as isize + 8,
-                Color::Black => from as isize - 8,
-            };
-            // can't make a forward move if the square is occupied
-            if (0..64).contains(&to) && !all_pieces.is_bit_set(to as u8) {
-                let to = to as u8;
-                if can_promote {
-                    for p in PromotePiece::VARIANTS {
-                        moves.push(Play::new(from, to, None, Some(p), false, false));
-                    }
-                } else {
-                    moves.push(Play::new(from, to, None, None, false, false));
-                    if match self.active_color {
-                        Color::White => rank == 2,
-                        Color::Black => rank == 7,
-                    } {
-                        let to = match self.active_color {
-                            Color::White => to as isize + 8,
-                            Color::Black => to as isize - 8,
-                        };
-                        // can't make a double forward move if the to square is occupied
-                        if !all_pieces.is_bit_set(to as u8) {
-                            moves.push(Play::new(from, to as u8, None, None, false, false));
+            if !CAPTURES_ONLY {
+                // move forward
+                let to = match self.active_color {
+                    Color::White => from as isize + 8,
+                    Color::Black => from as isize - 8,
+                };
+                // can't make a forward move if the square is occupied
+                if (0..64).contains(&to) && !all_pieces.is_bit_set(to as u8) {
+                    let to = to as u8;
+                    if can_promote {
+                        for p in PromotePiece::VARIANTS {
+                            moves.push(Play::new(from, to, None, Some(p), false, false));
+                        }
+                    } else {
+                        moves.push(Play::new(from, to, None, None, false, false));
+                        if match self.active_color {
+                            Color::White => rank == 2,
+                            Color::Black => rank == 7,
+                        } {
+                            let to = match self.active_color {
+                                Color::White => to as isize + 8,
+                                Color::Black => to as isize - 8,
+                            };
+                            // can't make a double forward move if the to square is occupied
+                            if !all_pieces.is_bit_set(to as u8) {
+                                moves.push(Play::new(from, to as u8, None, None, false, false));
+                            }
                         }
                     }
                 }

--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -10,6 +10,7 @@ use crate::pvt::PieceValueTables;
 use crate::zorbrist::Zorbrist;
 use smallvec::SmallVec;
 use std::fmt;
+use std::sync::LazyLock;
 
 pub type MoveList = SmallVec<[Play; 64]>;
 
@@ -73,11 +74,9 @@ const H8: u8 = 63;
 static PVT: PieceValueTables = PieceValueTables::TABLES;
 static ZORB: Zorbrist = Zorbrist::TABLE;
 
-lazy_static! {
-    static ref ATTACK_MASKS: AttackMasks = AttackMasks::new();
-    pub static ref BASE_CONVERSIONS: BaseConversions = BaseConversions::new();
-    static ref MAGIC: Magic = Magic::new();
-}
+static ATTACK_MASKS: LazyLock<AttackMasks> = LazyLock::new(AttackMasks::new);
+pub static BASE_CONVERSIONS: LazyLock<BaseConversions> = LazyLock::new(BaseConversions::new);
+static MAGIC: LazyLock<Magic> = LazyLock::new(Magic::new);
 
 // the squares that have to be empty for each castle
 const B1_C1_D1: u64 = 1 << B1 | 1 << C1 | 1 << D1;
@@ -270,7 +269,7 @@ impl Default for Board {
 impl Board {
     pub fn new() -> Board {
         // pay for the magic tables at startup rather than on the first search
-        lazy_static::initialize(&MAGIC);
+        LazyLock::force(&MAGIC);
         Board::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap()
     }
 

--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -77,33 +77,13 @@ lazy_static! {
     static ref ATTACK_MASKS: AttackMasks = AttackMasks::new();
     pub static ref BASE_CONVERSIONS: BaseConversions = BaseConversions::new();
     static ref MAGIC: Magic = Magic::new();
-    static ref B1_C1_D1: u64 = {
-        let mut mask = 0u64;
-        mask.set_bit(B1);
-        mask.set_bit(C1);
-        mask.set_bit(D1);
-        mask
-    };
-    static ref F1_G1: u64 = {
-        let mut mask = 0u64;
-        mask.set_bit(F1);
-        mask.set_bit(G1);
-        mask
-    };
-    static ref B8_C8_D8: u64 = {
-        let mut mask = 0u64;
-        mask.set_bit(B8);
-        mask.set_bit(C8);
-        mask.set_bit(D8);
-        mask
-    };
-    static ref F8_G8: u64 = {
-        let mut mask = 0u64;
-        mask.set_bit(F8);
-        mask.set_bit(G8);
-        mask
-    };
 }
+
+// the squares that have to be empty for each castle
+const B1_C1_D1: u64 = 1 << B1 | 1 << C1 | 1 << D1;
+const F1_G1: u64 = 1 << F1 | 1 << G1;
+const B8_C8_D8: u64 = 1 << B8 | 1 << C8 | 1 << D8;
+const F8_G8: u64 = 1 << F8 | 1 << G8;
 
 pub struct BaseConversions {
     pub base_64_to_100: [u8; 64],
@@ -277,21 +257,20 @@ pub struct Board {
     // adding the material difference on top, cannot overflow.
     psqt: i32,
 
-    //history: Vec<PlayState>,
     history: [Option<PlayState>; MAX_GAME_SIZE],
     pub key: u64,
 }
 
 impl Default for Board {
     fn default() -> Self {
-        lazy_static::initialize(&MAGIC); // TODO move this to engine/parse fen?
-        Board::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap()
+        Board::new()
     }
 }
 
 impl Board {
     pub fn new() -> Board {
-        lazy_static::initialize(&MAGIC); // TODO move this to engine/parse fen?
+        // pay for the magic tables at startup rather than on the first search
+        lazy_static::initialize(&MAGIC);
         Board::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap()
     }
 
@@ -304,15 +283,15 @@ impl Board {
         let all_pieces = self.black | self.white;
         let attack_masks: &AttackMasks = &ATTACK_MASKS;
         let magic: &Magic = &MAGIC;
+        // masking with the opponent's pieces keeps only the captures, so every
+        // to square here holds something to take
         // knights
         let mut knights = self.knights & color_mask;
         while knights != 0 {
             let from = pop_lsb(&mut knights);
-            // Only include moves which don't have another piece of our color at the to square
-            let kmoves = attack_masks.knights[from as usize] & (capture_mask);
-            let mut __m = kmoves;
-            while __m != 0 {
-                let to = pop_lsb(&mut __m);
+            let mut targets = attack_masks.knights[from as usize] & capture_mask;
+            while targets != 0 {
+                let to = pop_lsb(&mut targets);
                 let capture = self.get_piece_index(to);
                 moves.push(Play::new(from, to, capture, None, false, false));
             }
@@ -321,10 +300,9 @@ impl Board {
         let mut queens_and_rooks = (self.queens | self.rooks) & color_mask;
         while queens_and_rooks != 0 {
             let from = pop_lsb(&mut queens_and_rooks);
-            let move_mask = magic.get_straight_move(from, all_pieces) & capture_mask;
-            let mut __m = move_mask;
-            while __m != 0 {
-                let to = pop_lsb(&mut __m);
+            let mut targets = magic.get_straight_move(from, all_pieces) & capture_mask;
+            while targets != 0 {
+                let to = pop_lsb(&mut targets);
                 let capture = self.get_piece_index(to);
                 moves.push(Play::new(from, to, capture, None, false, false));
             }
@@ -333,10 +311,9 @@ impl Board {
         let mut queens_and_bishops = (self.queens | self.bishops) & color_mask;
         while queens_and_bishops != 0 {
             let from = pop_lsb(&mut queens_and_bishops);
-            let move_mask = magic.get_diagonal_move(from, all_pieces) & capture_mask;
-            let mut __m = move_mask;
-            while __m != 0 {
-                let to = pop_lsb(&mut __m);
+            let mut targets = magic.get_diagonal_move(from, all_pieces) & capture_mask;
+            while targets != 0 {
+                let to = pop_lsb(&mut targets);
                 let capture = self.get_piece_index(to);
                 moves.push(Play::new(from, to, capture, None, false, false));
             }
@@ -345,11 +322,9 @@ impl Board {
         let mut kings = self.kings & color_mask;
         while kings != 0 {
             let from = pop_lsb(&mut kings);
-            // Only include moves which don't have another piece of our color at the to square
-            let kmove = attack_masks.kings[from as usize] & capture_mask;
-            let mut __m = kmove;
-            while __m != 0 {
-                let to = pop_lsb(&mut __m);
+            let mut targets = attack_masks.kings[from as usize] & capture_mask;
+            while targets != 0 {
+                let to = pop_lsb(&mut targets);
                 let capture = self.get_piece_index(to);
                 moves.push(Play::new(from, to, capture, None, false, false));
             }
@@ -368,9 +343,9 @@ impl Board {
                 Color::White => attack_masks.black_pawns[from as usize] & capture_mask,
                 Color::Black => attack_masks.white_pawns[from as usize] & capture_mask,
             };
-            let mut __m = pmoves;
-            while __m != 0 {
-                let to = pop_lsb(&mut __m);
+            let mut targets = pmoves;
+            while targets != 0 {
+                let to = pop_lsb(&mut targets);
                 let capture = self.get_piece_index(to);
                 if can_promote {
                     for p in PromotePiece::VARIANTS {
@@ -404,15 +379,15 @@ impl Board {
         let all_pieces = self.black | self.white;
         let attack_masks: &AttackMasks = &ATTACK_MASKS;
         let magic: &Magic = &MAGIC;
+        // masking out our own pieces leaves quiet moves and captures both, and
+        // capture_on tells the two apart
         // knights
         let mut knights = self.knights & color_mask;
         while knights != 0 {
             let from = pop_lsb(&mut knights);
-            // Only include moves which don't have another piece of our color at the to square
-            let kmoves = attack_masks.knights[from as usize] & (!color_mask);
-            let mut __m = kmoves;
-            while __m != 0 {
-                let to = pop_lsb(&mut __m);
+            let mut targets = attack_masks.knights[from as usize] & !color_mask;
+            while targets != 0 {
+                let to = pop_lsb(&mut targets);
                 let capture = self.capture_on(to, capture_mask);
                 moves.push(Play::new(from, to, capture, None, false, false));
             }
@@ -421,10 +396,9 @@ impl Board {
         let mut queens_and_rooks = (self.queens | self.rooks) & color_mask;
         while queens_and_rooks != 0 {
             let from = pop_lsb(&mut queens_and_rooks);
-            let move_mask = magic.get_straight_move(from, all_pieces) & !color_mask;
-            let mut __m = move_mask;
-            while __m != 0 {
-                let to = pop_lsb(&mut __m);
+            let mut targets = magic.get_straight_move(from, all_pieces) & !color_mask;
+            while targets != 0 {
+                let to = pop_lsb(&mut targets);
                 let capture = self.capture_on(to, capture_mask);
                 moves.push(Play::new(from, to, capture, None, false, false));
             }
@@ -433,10 +407,9 @@ impl Board {
         let mut queens_and_bishops = (self.queens | self.bishops) & color_mask;
         while queens_and_bishops != 0 {
             let from = pop_lsb(&mut queens_and_bishops);
-            let move_mask = magic.get_diagonal_move(from, all_pieces) & !color_mask;
-            let mut __m = move_mask;
-            while __m != 0 {
-                let to = pop_lsb(&mut __m);
+            let mut targets = magic.get_diagonal_move(from, all_pieces) & !color_mask;
+            while targets != 0 {
+                let to = pop_lsb(&mut targets);
                 let capture = self.capture_on(to, capture_mask);
                 moves.push(Play::new(from, to, capture, None, false, false));
             }
@@ -445,11 +418,9 @@ impl Board {
         let mut kings = self.kings & color_mask;
         while kings != 0 {
             let from = pop_lsb(&mut kings);
-            // Only include moves which don't have another piece of our color at the to square
-            let kmove = attack_masks.kings[from as usize] & (!color_mask);
-            let mut __m = kmove;
-            while __m != 0 {
-                let to = pop_lsb(&mut __m);
+            let mut targets = attack_masks.kings[from as usize] & !color_mask;
+            while targets != 0 {
+                let to = pop_lsb(&mut targets);
                 let capture = self.capture_on(to, capture_mask);
                 moves.push(Play::new(from, to, capture, None, false, false));
             }
@@ -463,7 +434,7 @@ impl Board {
                 let check = self.square_attacked(E1, Color::Black);
                 if !check {
                     if self.castle.white_queen_side
-                        && (*B1_C1_D1 & all_pieces) == 0
+                        && (B1_C1_D1 & all_pieces) == 0
                         && [C1, D1]
                             .iter()
                             .all(|i| !self.square_attacked(*i, Color::Black))
@@ -471,7 +442,7 @@ impl Board {
                         moves.push(Play::new(from, C1, None, None, false, true));
                     }
                     if self.castle.white_king_side
-                        && (*F1_G1 & all_pieces) == 0
+                        && (F1_G1 & all_pieces) == 0
                         && [F1, G1]
                             .iter()
                             .all(|i| !self.square_attacked(*i, Color::Black))
@@ -485,7 +456,7 @@ impl Board {
                 let check = self.square_attacked(E8, Color::White);
                 if !check {
                     if self.castle.black_queen_side
-                        && (*B8_C8_D8 & all_pieces) == 0
+                        && (B8_C8_D8 & all_pieces) == 0
                         && [C8, D8]
                             .iter()
                             .all(|i| !self.square_attacked(*i, Color::White))
@@ -493,7 +464,7 @@ impl Board {
                         moves.push(Play::new(from, C8, None, None, false, true));
                     }
                     if self.castle.black_king_side
-                        && (*F8_G8 & all_pieces) == 0
+                        && (F8_G8 & all_pieces) == 0
                         && [F8, G8]
                             .iter()
                             .all(|i| !self.square_attacked(*i, Color::White))
@@ -517,9 +488,9 @@ impl Board {
                 Color::White => attack_masks.black_pawns[from as usize] & capture_mask,
                 Color::Black => attack_masks.white_pawns[from as usize] & capture_mask,
             };
-            let mut __m = pmoves;
-            while __m != 0 {
-                let to = pop_lsb(&mut __m);
+            let mut targets = pmoves;
+            while targets != 0 {
+                let to = pop_lsb(&mut targets);
                 let capture = self.get_piece_index(to);
                 if can_promote {
                     for p in PromotePiece::VARIANTS {
@@ -575,7 +546,6 @@ impl Board {
 
     #[inline]
     pub fn eval(&self) -> Score {
-        // TODO should this return white value & black value as separate numbers instead?
         let eval = self.white_value as i32 - self.black_value as i32;
 
         let eval = (eval + self.psqt) as Score;
@@ -847,21 +817,22 @@ impl Board {
         self.key ^= zorb.side;
         self.debug_assert_state_in_step();
         if self.square_attacked(king_index, opposing_color) {
-            self.undo_move().unwrap();
+            self.undo_move();
             false
         } else {
             true
         }
     }
 
-    pub fn undo_move(&mut self) -> Result<(), &str> {
+    pub fn undo_move(&mut self) {
         let previous = history_index(self.ply - 1);
         let history = self.history[previous].unwrap();
         self.history[previous] = None;
         let play = history.play;
 
         let opposing_color = !self.active_color;
-        // update castling permissions
+        // castle rights, en passant and the fifty move counter cannot be
+        // recomputed from the move alone, they come back from the history
         self.castle = history.castle;
         self.en_passant = history.en_passant;
         self.fifty_move_rule = history.fifty_move_rule;
@@ -871,15 +842,13 @@ impl Board {
             self.move_number -= 1;
         }
 
-        if self.pawns.is_bit_set(play.to) {
-            // pawn moves reset the fifty move rule
-            if play.en_passant {
-                let en_passant_index = match opposing_color {
-                    Color::White => play.to - 8,
-                    Color::Black => play.to + 8,
-                };
-                self.set_piece_index(en_passant_index, Piece::Pawn, self.active_color);
-            }
+        if play.en_passant {
+            // the captured pawn stood behind the to square, not on it
+            let en_passant_index = match opposing_color {
+                Color::White => play.to - 8,
+                Color::Black => play.to + 8,
+            };
+            self.set_piece_index(en_passant_index, Piece::Pawn, self.active_color);
         }
 
         // move piece
@@ -914,7 +883,6 @@ impl Board {
         // restore the position key exactly as it was before the move was made,
         // this guarantees make/undo can never let the key drift out of sync
         self.key = history.position_key;
-        Ok(())
     }
 
     #[inline]
@@ -963,6 +931,9 @@ impl Board {
         self.square_attacked(self.king_index(self.active_color), !self.active_color)
     }
 
+    /// Print every square this colour attacks as a grid. Nothing calls it: it
+    /// is a debugging aid kept to be reached for when square_attacked
+    /// misbehaves, the same standing debug_print has for bitboards.
     pub fn attacked_print(&self, color: Color) {
         println!("   a|b|c|d|e|f|g|h|");
         println!("  ----------------");
@@ -1060,7 +1031,6 @@ impl Board {
 
     #[inline]
     pub fn get_piece_index(&self, index: u8) -> Option<Piece> {
-        // TODO this should also return color
         let mask = 1u64 << index;
         if (self.pawns & mask) > 0 {
             Some(Piece::Pawn)
@@ -1107,18 +1077,8 @@ impl Board {
         Some((piece, color))
     }
 
-    fn get_piece(&self, rank: u8, file: File) -> (Option<Piece>, Option<Color>) {
-        let index = coordinate_to_index(rank, file);
-        let mask = 1u64 << index;
-        let color = if (self.black & mask) > 0 {
-            Some(Color::Black)
-        } else if (self.white & mask) > 0 {
-            Some(Color::White)
-        } else {
-            None
-        };
-        let piece = self.get_piece_index(index);
-        (piece, color)
+    fn get_piece(&self, rank: u8, file: File) -> Option<(Piece, Color)> {
+        self.get_piece_and_color_index(coordinate_to_index(rank, file))
     }
 
     fn material_value(&self) -> (u32, u32) {
@@ -1147,7 +1107,7 @@ impl Board {
     }
 
     pub fn perft(&mut self, depth: u8) -> u64 {
-        // Based on psedocode at https://www.chessprogramming.org/Perft
+        // Based on pseudocode at https://www.chessprogramming.org/Perft
         let mut nodes = 0;
 
         if depth == 0 {
@@ -1156,14 +1116,8 @@ impl Board {
 
         for m in &self.generate_moves() {
             if self.make_move(m) {
-                let branch = self.perft(depth - 1);
-                nodes += branch;
-                //println!("{}", m);
-                self.undo_move().unwrap();
-                // TODO remove this debug
-                //if depth == 2 {
-                //    println!("m {} => {}", m, branch); // perft divide
-                //};
+                nodes += self.perft(depth - 1);
+                self.undo_move();
             }
         }
         nodes
@@ -1258,25 +1212,15 @@ impl Game for Board {
             if file + step > 8 {
                 return Err("Too many files found in rank".to_string());
             }
-            // TODO change piece to PieceType and implement a Piece with from char and to char
-            // methods
-            let piece = match c {
-                'p' | 'P' => Some(Piece::Pawn),
-                'n' | 'N' => Some(Piece::Knight),
-                'b' | 'B' => Some(Piece::Bishop),
-                'r' | 'R' => Some(Piece::Rook),
-                'q' | 'Q' => Some(Piece::Queen),
-                'k' | 'K' => Some(Piece::King),
-                '1'..='8' => None,
-                _ => return Err("unexpected character in fen".to_string()),
-            };
-            if let Some(p) = piece {
+            if !('1'..='8').contains(&c) {
+                let piece = Piece::try_from(c)
+                    .map_err(|e| format!("unexpected character in fen: {}", e))?;
                 let color = if c.is_uppercase() {
                     Color::White
                 } else {
                     Color::Black
                 };
-                board.set_piece(p, color, rank, File::try_from(file)?);
+                board.set_piece(piece, color, rank, File::try_from(file)?);
             }
             file += step;
         }
@@ -1329,19 +1273,12 @@ impl fmt::Display for Board {
         for rank in (1..=8).rev() {
             write!(f, "{} |", rank)?;
             for file in File::VARIANTS {
-                let (piece, color) = self.get_piece(rank, file);
-                let c = match piece {
-                    Some(Piece::Pawn) => 'p',
-                    Some(Piece::Knight) => 'n',
-                    Some(Piece::Bishop) => 'b',
-                    Some(Piece::Rook) => 'r',
-                    Some(Piece::Queen) => 'q',
-                    Some(Piece::King) => 'k',
-                    None => '.',
-                };
-                match color {
-                    Some(Color::White) => write!(f, " {}", c.to_uppercase())?,
-                    _ => write!(f, " {}", c)?,
+                match self.get_piece(rank, file) {
+                    Some((piece, Color::White)) => {
+                        write!(f, " {}", char::from(piece).to_ascii_uppercase())?
+                    }
+                    Some((piece, Color::Black)) => write!(f, " {}", char::from(piece))?,
+                    None => write!(f, " .")?,
                 };
             }
             writeln!(f)?;
@@ -1386,7 +1323,7 @@ mod evaluate {
                         let opp_score = board.eval();
                         assert_eq!(score, -opp_score);
                         board.active_color = !board.active_color;
-                        board.undo_move().unwrap();
+                        board.undo_move();
                     }
                 }
             }
@@ -1479,7 +1416,7 @@ mod make_move {
                     let mut new = board.clone();
                     if new.make_move(m) {
                         assert_ne!(old, new);
-                        new.undo_move().unwrap();
+                        new.undo_move();
                         assert_eq!(old, new);
                     }
                 }
@@ -1592,7 +1529,7 @@ mod make_move {
             assert!(board.make_move(&Play::new(from, to, None, None, false, false)));
         }
         for _ in cycle {
-            board.undo_move().unwrap();
+            board.undo_move();
         }
         assert_eq!(board, start);
     }
@@ -1799,72 +1736,58 @@ mod perft {
     use super::Board;
     use super::Game;
     use pretty_assertions::assert_eq;
-    // TODO convert these tests to use macros
-    // Positions and perft results taken from https://www.chessprogramming.org/Perft_Results
 
-    #[test]
-    fn test_perft_starting() {
-        let mut board =
-            Board::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap();
-        assert_eq!(board.perft(1), 20);
-        assert_eq!(board.perft(2), 400);
-        assert_eq!(board.perft(3), 8902);
-    }
-
-    #[test]
-    fn test_perft_position_2() {
-        let mut board =
-            Board::from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1")
-                .unwrap();
-        assert_eq!(board.perft(1), 48);
-        assert_eq!(board.perft(2), 2039);
-        assert_eq!(board.perft(3), 97862);
-        assert_eq!(board.perft(4), 4085603);
-    }
-
-    #[test]
-    fn test_perft_position_3() {
-        let mut board = Board::from_fen("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1").unwrap();
-        assert_eq!(board.perft(1), 14);
-        assert_eq!(board.perft(2), 191);
-        assert_eq!(board.perft(3), 2812);
-        assert_eq!(board.perft(4), 43238);
-        assert_eq!(board.perft(5), 674624);
-        assert_eq!(board.perft(6), 11030083);
-    }
-
-    #[test]
-    fn test_perft_position_4() {
-        let mut board =
-            Board::from_fen("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1")
-                .unwrap();
-        assert_eq!(board.perft(1), 6);
-        assert_eq!(board.perft(2), 264);
-        assert_eq!(board.perft(3), 9467);
-        assert_eq!(board.perft(4), 422333);
-        assert_eq!(board.perft(5), 15833292);
-    }
-
-    #[test]
-    fn test_perft_position_5() {
-        let mut board =
-            Board::from_fen("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8").unwrap();
-        assert_eq!(board.perft(1), 44);
-        assert_eq!(board.perft(2), 1486);
-        assert_eq!(board.perft(3), 62379);
-        assert_eq!(board.perft(4), 2103487);
-    }
-
-    #[test]
-    fn test_perft_position_6() {
-        let mut board = Board::from_fen(
+    /// The six standard positions, with their counts from depth one up to the
+    /// depth the suite can afford. Positions and results taken from
+    /// https://www.chessprogramming.org/Perft_Results
+    const CASES: [(&str, &str, &[u64]); 6] = [
+        (
+            "the starting position",
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            &[20, 400, 8902],
+        ),
+        (
+            "position 2, kiwipete",
+            "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+            &[48, 2039, 97_862, 4_085_603],
+        ),
+        (
+            "position 3",
+            "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+            &[14, 191, 2812, 43_238, 674_624, 11_030_083],
+        ),
+        (
+            "position 4",
+            "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1",
+            &[6, 264, 9467, 422_333, 15_833_292],
+        ),
+        (
+            "position 5",
+            "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
+            &[44, 1486, 62_379, 2_103_487],
+        ),
+        (
+            "position 6",
             "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10",
-        )
-        .unwrap();
-        assert_eq!(board.perft(1), 46);
-        assert_eq!(board.perft(2), 2079);
-        assert_eq!(board.perft(3), 89890);
-        assert_eq!(board.perft(4), 3894594);
+            &[46, 2079, 89_890, 3_894_594],
+        ),
+    ];
+
+    #[test]
+    fn test_perft_standard_positions() {
+        for (description, fen, counts) in CASES {
+            let mut board = Board::from_fen(fen).unwrap();
+            for (i, &expected) in counts.iter().enumerate() {
+                let depth = i as u8 + 1;
+                assert_eq!(
+                    board.perft(depth),
+                    expected,
+                    "{} at depth {}",
+                    description,
+                    depth
+                );
+            }
+        }
     }
 }
 

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -1,5 +1,5 @@
 use crate::Game;
-use crate::board::Board;
+use crate::board::{Board, MoveList};
 use crate::misc::{Color, Score};
 use crate::play::Play;
 use std::fmt;
@@ -155,6 +155,18 @@ impl AlphaBeta {
         }
     }
 
+    /// MVV-LVA order, with the table's move for this position, if there is
+    /// one, ahead of everything else.
+    fn order_moves(&self, moves: &mut MoveList, pv_play: Option<Play>) {
+        moves.sort_by_cached_key(|m| {
+            let mut score = m.mvv_lva(&self.board);
+            if pv_play == Some(*m) {
+                score += 100_000;
+            }
+            -score
+        });
+    }
+
     fn quiescence(&mut self, mut alpha: Score, beta: Score) -> Result<Score, Aborted> {
         self.selective_depth = self.selective_depth.max(self.board.line_ply as u8);
         if self.board.line_ply >= MAX_DEPTH.into() {
@@ -173,18 +185,9 @@ impl AlphaBeta {
 
         let mut best_move: Option<Play> = None;
         let old_alpha = alpha;
-        let mut score: Score;
-        let pv_line = self.moves.get(self.board.key);
+        let pv_play = self.moves.get(self.board.key).map(|pv| pv.play);
         let mut moves = self.board.generate_captures();
-        moves.sort_by_cached_key(|m| {
-            let mut score = m.mvv_lva(&self.board);
-            if let Some(pv) = pv_line {
-                if pv.play == *m {
-                    score += 100000;
-                }
-            };
-            -score
-        });
+        self.order_moves(&mut moves, pv_play);
 
         for m in &moves {
             if self.board.make_move(m) {
@@ -192,7 +195,7 @@ impl AlphaBeta {
                 // the aborted line
                 let result = self.quiescence(-beta, -alpha);
                 self.board.undo_move();
-                score = -result?;
+                let score = -result?;
                 if score > alpha {
                     if score >= beta {
                         return Ok(beta);
@@ -210,7 +213,7 @@ impl AlphaBeta {
                     play: best_move.unwrap(),
                     score: score_to_tt(alpha, self.board.line_ply),
                     depth: 0, // Never use a quiescence move instead of evaluating, only for move ordering
-                    node: Node::Ordering,
+                    bound: Bound::Ordering,
                     ply: self.board.ply as u16,
                 },
             );
@@ -234,19 +237,19 @@ impl AlphaBeta {
         if let Some(pv) = pv {
             if pv.depth >= depth {
                 let score = score_from_tt(pv.score, self.board.line_ply);
-                match pv.node {
-                    Node::Exact => return (Some(pv.play), Some(score)),
-                    Node::Alpha => {
+                match pv.bound {
+                    Bound::Exact => return (Some(pv.play), Some(score)),
+                    Bound::Upper => {
                         if score <= alpha {
                             return (Some(pv.play), Some(score));
                         }
                     }
-                    Node::Beta => {
+                    Bound::Lower => {
                         if score >= beta {
                             return (Some(pv.play), Some(score));
                         }
                     }
-                    Node::Ordering => (),
+                    Bound::Ordering => (),
                 }
             }
             return (Some(pv.play), None);
@@ -283,7 +286,6 @@ impl AlphaBeta {
         }
 
         let old_alpha = alpha;
-        let mut score: Score;
         let mut found_legal_move = false;
         let mut best_move: Option<&Play> = None;
         let (pv_play, tt_score) = self.get_transposition(self.board.key, alpha, beta, depth);
@@ -292,15 +294,7 @@ impl AlphaBeta {
         }
 
         let mut moves = self.board.generate_moves();
-        moves.sort_by_cached_key(|m| {
-            let mut score = m.mvv_lva(&self.board);
-            if let Some(pv) = pv_play {
-                if pv == *m {
-                    score += 100_000;
-                }
-            };
-            -score
-        });
+        self.order_moves(&mut moves, pv_play);
 
         for m in &moves {
             if self.board.make_move(m) {
@@ -310,7 +304,7 @@ impl AlphaBeta {
                 // score of an aborted frame away from the stores below.
                 let result = self.alpha_beta(-beta, -alpha, depth - 1);
                 self.board.undo_move();
-                score = -result?;
+                let score = -result?;
                 if score > alpha {
                     best_move = Some(m);
                     if score >= beta {
@@ -320,7 +314,7 @@ impl AlphaBeta {
                                 play: *m,
                                 depth,
                                 score: score_to_tt(beta, self.board.line_ply),
-                                node: Node::Beta,
+                                bound: Bound::Lower,
                                 ply: self.board.ply as u16,
                             },
                         );
@@ -345,12 +339,221 @@ impl AlphaBeta {
                     play: *best_move.unwrap(),
                     depth,
                     score: score_to_tt(alpha, self.board.line_ply),
-                    node: Node::Exact,
+                    bound: Bound::Exact,
                     ply: self.board.ply as u16,
                 },
             );
         }
         Ok(alpha)
+    }
+
+    pub fn new(board: Board) -> Self {
+        AlphaBeta::with_table_bytes(board, DEFAULT_TABLE_BYTES)
+    }
+
+    pub fn configure(
+        &mut self,
+        start_time: time::Instant,
+        search_duration: Option<time::Duration>,
+    ) {
+        self.start_time = start_time;
+        self.search_duration = search_duration;
+    }
+
+    /// The root loop: the one node whose answer must include a play, which is
+    /// why it runs here rather than in alpha_beta. The root probes the
+    /// transposition table to order moves and stores its entry when done, but
+    /// never takes a stored score in place of searching: a stored score can
+    /// come from a line whose repetition and fifty move context differ from
+    /// the game being played, and the answer must not depend on one.
+    pub fn search(&mut self, depth: u8) -> SearchOutcome {
+        self.nodes = 0;
+        self.search_depth = depth;
+        self.selective_depth = depth;
+        self.board.line_ply = 0;
+
+        // the game is already drawn, there is no move to look for
+        if self.board.fifty_move_rule >= 100 {
+            return SearchOutcome::GameOver;
+        }
+
+        if self.poll_deadline().is_err() {
+            return SearchOutcome::Aborted(None);
+        }
+        self.nodes += 1;
+
+        let mut depth = depth;
+        if self.board.is_king_attacked() {
+            depth += 1;
+        }
+
+        let mut alpha = Score::MIN + 1;
+        let beta = Score::MAX - 1;
+        let mut best: Option<Play> = None;
+        let mut found_legal_move = false;
+
+        let pv_play = self.moves.get(self.board.key).map(|pv| pv.play);
+        let mut moves = self.board.generate_moves();
+        self.order_moves(&mut moves, pv_play);
+
+        for m in &moves {
+            if self.board.make_move(m) {
+                found_legal_move = true;
+                // undo before an abort can propagate, or the board would keep
+                // the aborted line
+                let result = self.alpha_beta(-beta, -alpha, depth - 1);
+                self.board.undo_move();
+                match result {
+                    Err(Aborted) => {
+                        return SearchOutcome::Aborted(
+                            best.map(|play| self.result_for(play, alpha)),
+                        );
+                    }
+                    Ok(s) => {
+                        let score = -s;
+                        if score > alpha {
+                            alpha = score;
+                            best = Some(*m);
+                        }
+                    }
+                }
+            }
+        }
+
+        if !found_legal_move {
+            // checkmate or stalemate: either way there is nothing to play
+            return SearchOutcome::GameOver;
+        }
+
+        let play = best.expect("any legal move's score beats the opening alpha of Score::MIN + 1");
+        self.moves.set(
+            self.board.key,
+            Pv {
+                play,
+                depth,
+                score: score_to_tt(alpha, self.board.line_ply),
+                bound: Bound::Exact,
+                ply: self.board.ply as u16,
+            },
+        );
+        SearchOutcome::Complete(self.result_for(play, alpha))
+    }
+
+    /// Replay the line the table holds on a copy of the board, one stored move
+    /// at a time. Walking the positions rather than following a key from one
+    /// entry to the next is what lets the line be checked as it is built: the
+    /// board says whether a stored move is legal here, and whether the line has
+    /// reached a position it would be a draw to play on from.
+    pub fn pv_line(&self) -> PvLine {
+        let mut line = Vec::new();
+        // Board is Copy, so the search's own board is untouched by this.
+        let mut board = self.board;
+        while line.len() < MAX_DEPTH as usize {
+            let Some(pv) = self.moves.get(board.key) else {
+                break;
+            };
+            if matches!(pv.bound, Bound::Ordering) {
+                // written by quiescence, which looks at captures alone, so the
+                // move is fit for ordering the next search and not for telling
+                // anyone what the engine intends to play
+                break;
+            }
+            let play = pv.play;
+            // a probe compares the whole key, so what still gets through is
+            // another position which hashed to the same one. Its move belongs
+            // to that position, and playing it here would print a line the
+            // rules do not allow
+            if !board.generate_moves().contains(&play) {
+                break;
+            }
+            if !board.make_move(&play) {
+                break;
+            }
+            line.push(play);
+            // the line is a draw from here, so whatever the table says comes
+            // next is a continuation that would never be played
+            if board.fifty_move_rule >= 100 || board.has_repeated() {
+                break;
+            }
+        }
+        PvLine { line }
+    }
+}
+
+impl Engine for AlphaBeta {
+    fn perft(&mut self, depth: u8) -> u64 {
+        self.board.perft(depth)
+    }
+
+    fn active_color(&self) -> Color {
+        self.board.active_color
+    }
+
+    fn parse_fen(&mut self, fen_string: &str) -> Result<(), String> {
+        self.nodes = 0;
+        self.board = Board::from_fen(fen_string)?;
+        Ok(())
+    }
+
+    fn new_game(&mut self) {
+        self.clear_cache();
+    }
+
+    fn iterative_deepening_search(
+        &mut self,
+        search_options: SearchParameters,
+        mut on_depth: impl FnMut(u8, &SearchResult, PvLine),
+    ) -> SearchOutcome {
+        let mut best: Option<SearchResult> = None;
+        let max_depth = match search_options.depth {
+            Some(depth) => depth,
+            None => MAX_DEPTH,
+        };
+        self.configure(search_options.start_time, search_options.search_duration);
+
+        for depth in 1..=max_depth {
+            match self.search(depth) {
+                SearchOutcome::Aborted(partial) => {
+                    // A completed shallower iteration outranks the interrupted
+                    // one's best-so-far, which may be a fail high that never
+                    // got re-searched. The partial only fills in when depth 1
+                    // itself ran out of time.
+                    return SearchOutcome::Aborted(best.or(partial));
+                }
+                SearchOutcome::GameOver => {
+                    // checkmate, stalemate or a rule draw: deeper searches
+                    // cannot change it, so don't run them
+                    return SearchOutcome::GameOver;
+                }
+                SearchOutcome::Complete(result) => {
+                    on_depth(depth, &result, self.pv_line());
+                    best = Some(result);
+                }
+            }
+        }
+        match best {
+            Some(result) => SearchOutcome::Complete(result),
+            // a depth of zero runs no iterations, so there is nothing to
+            // report beyond that no move was looked for
+            None => SearchOutcome::Aborted(None),
+        }
+    }
+
+    fn make_move_str(&mut self, play: &str) -> bool {
+        for p in self.board.generate_moves() {
+            let play_str = format!("{}", p).to_lowercase();
+            if play == play_str {
+                let result = self.board.make_move(&p);
+                self.moves.clear_key(self.board.key); // TODO this is a hack to try to fix bad
+                // cache hits, particularly for draws
+                return result; // TODO change this to return Result
+            };
+        }
+        false
+    }
+
+    fn display_board(&self) {
+        println!("{}", self.board);
     }
 }
 
@@ -362,18 +565,20 @@ struct Pv {
     // array, so neither needs a word. Both sit in the padding the key leaves
     // behind, which is why widening ply to u16 costs nothing.
     depth: u8,
-    node: Node,
+    bound: Bound,
     ply: u16,
 }
 
+/// What the stored score means: the searched window decides whether a score
+/// is the truth, a ceiling or a floor, and a reader can only use it for a
+/// cutoff its kind allows.
 #[derive(Copy, Clone, Debug)]
-// TODO better name for this
-enum Node {
+enum Bound {
     Exact,
     // fail low nodes are not stored yet, see the known issues in the readme
     #[allow(dead_code)]
-    Alpha,
-    Beta,
+    Upper,
+    Lower,
     Ordering,
 }
 
@@ -384,14 +589,12 @@ type Entry = Option<(Pv, u64)>;
 #[derive(Debug)]
 struct HashTable {
     table: Vec<Entry>,
-    capacity: usize,
 }
 
 impl HashTable {
     fn with_capacity(capacity: usize) -> Self {
         Self {
             table: vec![None; capacity],
-            capacity,
         }
     }
 
@@ -409,9 +612,9 @@ impl HashTable {
 
     #[inline]
     fn index_for(&self, key: u64) -> usize {
-        // multiply-shift: maps key uniformly onto 0..capacity without a 64 bit
+        // multiply-shift: maps key uniformly onto 0..len without a 64 bit
         // division on every probe
-        (((key as u128) * (self.capacity as u128)) >> 64) as usize
+        (((key as u128) * (self.table.len() as u128)) >> 64) as usize
     }
 
     fn get(&self, key: u64) -> Option<&Pv> {
@@ -440,8 +643,8 @@ impl HashTable {
                 }
                 if pv.depth == old_pv.depth
                     && old_key == key
-                    && matches!(old_pv.node, Node::Exact)
-                    && !matches!(pv.node, Node::Exact)
+                    && matches!(old_pv.bound, Bound::Exact)
+                    && !matches!(pv.bound, Bound::Exact)
                 {
                     return;
                 }
@@ -465,10 +668,8 @@ impl PvLine {
 
 impl fmt::Display for PvLine {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let out: Vec<String> = self.line.iter().map(|p| format!("{}", p)).collect();
-        let new = out.join(" ");
-        write!(f, "{}", new)?;
-        Ok(())
+        let moves: Vec<String> = self.line.iter().map(|p| p.to_string()).collect();
+        write!(f, "{}", moves.join(" "))
     }
 }
 
@@ -495,7 +696,7 @@ struct Aborted;
 
 #[derive(Debug)]
 pub struct SearchResult {
-    pub nodes: u64,          // The number of results examined as part of the search
+    pub nodes: u64,          // The number of positions visited during the search
     pub selective_depth: u8, // Selective search depth in plies
     pub best_move: Play,     // The best move found as part of the search
     pub score: Score,        // The estimated score for the best move if played
@@ -503,7 +704,7 @@ pub struct SearchResult {
 
 impl SearchResult {
     pub fn checkmate_in(&self) -> Option<Score> {
-        if (CHECKMATE_SCORE - self.score.abs()) < 300 {
+        if self.score.abs() > CHECKMATE_THRESHOLD {
             let mut mate = (CHECKMATE_SCORE - self.score.abs() + 1) / 2;
             if self.score < 0 {
                 mate = -mate;
@@ -520,7 +721,7 @@ mod test_search {
     use super::Board;
     use super::Engine;
     use super::Game;
-    use super::{Node, Play, Pv, SearchOutcome, SearchResult};
+    use super::{Bound, Play, Pv, SearchOutcome, SearchResult};
     use pretty_assertions::assert_eq;
     use std::time;
 
@@ -559,7 +760,7 @@ mod test_search {
             play,
             score: 0,
             depth: 5,
-            node: Node::Exact,
+            bound: Bound::Exact,
             ply: ply as u16,
         }
     }
@@ -859,7 +1060,7 @@ mod test_search {
                 play,
                 score: 0,
                 depth: 0,
-                node: Node::Ordering,
+                bound: Bound::Ordering,
                 ply: 0,
             },
         );
@@ -933,15 +1134,15 @@ mod test_search {
 
 #[cfg(test)]
 mod test_hash_table {
-    use super::{HashTable, Node, Play, Pv};
+    use super::{Bound, HashTable, Play, Pv};
     use pretty_assertions::assert_eq;
 
-    fn new_pv(node: Node, depth: u8, ply: u16) -> Pv {
+    fn new_pv(bound: Bound, depth: u8, ply: u16) -> Pv {
         Pv {
             play: Play::new(0, 1, None, None, false, false),
             score: 0,
             depth,
-            node,
+            bound,
             ply,
         }
     }
@@ -950,7 +1151,7 @@ mod test_hash_table {
     fn test_get_compares_key_not_just_slot() {
         // two different keys which map to the same slot must not be confused for each other
         let mut table = HashTable::with_capacity(1);
-        table.set(1, new_pv(Node::Exact, 1, 1));
+        table.set(1, new_pv(Bound::Exact, 1, 1));
         assert!(table.get(1).is_some());
         assert!(table.get(2).is_none());
     }
@@ -958,24 +1159,24 @@ mod test_hash_table {
     #[test]
     fn test_exact_entry_replaces_non_exact_entry() {
         let mut table = HashTable::with_capacity(1);
-        table.set(1, new_pv(Node::Beta, 1, 1));
-        table.set(1, new_pv(Node::Exact, 1, 1));
-        assert!(matches!(table.get(1).unwrap().node, Node::Exact));
+        table.set(1, new_pv(Bound::Lower, 1, 1));
+        table.set(1, new_pv(Bound::Exact, 1, 1));
+        assert!(matches!(table.get(1).unwrap().bound, Bound::Exact));
     }
 
     #[test]
     fn test_deeper_exact_entry_survives_shallower_exact_entry() {
         let mut table = HashTable::with_capacity(1);
-        table.set(1, new_pv(Node::Exact, 8, 1));
-        table.set(1, new_pv(Node::Exact, 2, 1));
+        table.set(1, new_pv(Bound::Exact, 8, 1));
+        table.set(1, new_pv(Bound::Exact, 2, 1));
         assert_eq!(table.get(1).unwrap().depth, 8);
     }
 
     #[test]
     fn test_deeper_entry_replaces_exact_entry_for_another_position() {
         let mut table = HashTable::with_capacity(1);
-        table.set(1, new_pv(Node::Exact, 1, 1));
-        table.set(2, new_pv(Node::Beta, 8, 1));
+        table.set(1, new_pv(Bound::Exact, 1, 1));
+        table.set(2, new_pv(Bound::Lower, 8, 1));
         assert!(table.get(2).is_some());
         assert!(table.get(1).is_none());
     }
@@ -983,242 +1184,25 @@ mod test_hash_table {
     #[test]
     fn test_shallower_entry_does_not_evict_deeper_entry_for_another_position() {
         let mut table = HashTable::with_capacity(1);
-        table.set(1, new_pv(Node::Beta, 8, 1));
-        table.set(2, new_pv(Node::Exact, 1, 1));
+        table.set(1, new_pv(Bound::Lower, 8, 1));
+        table.set(2, new_pv(Bound::Exact, 1, 1));
         assert_eq!(table.get(1).unwrap().depth, 8);
     }
 
     #[test]
     fn test_quiescence_entry_does_not_evict_searched_entry() {
         let mut table = HashTable::with_capacity(1);
-        table.set(1, new_pv(Node::Exact, 5, 1));
-        table.set(2, new_pv(Node::Ordering, 0, 1));
+        table.set(1, new_pv(Bound::Exact, 5, 1));
+        table.set(2, new_pv(Bound::Ordering, 0, 1));
         assert_eq!(table.get(1).unwrap().depth, 5);
     }
 
     #[test]
     fn test_stale_entry_is_replaced_regardless_of_depth() {
         let mut table = HashTable::with_capacity(1);
-        table.set(1, new_pv(Node::Exact, 8, 1));
-        table.set(2, new_pv(Node::Beta, 1, 100));
+        table.set(1, new_pv(Bound::Exact, 8, 1));
+        table.set(2, new_pv(Bound::Lower, 1, 100));
         assert!(table.get(2).is_some());
-    }
-}
-
-impl Engine for AlphaBeta {
-    fn perft(&mut self, depth: u8) -> u64 {
-        self.board.perft(depth)
-    }
-
-    fn active_color(&self) -> Color {
-        self.board.active_color
-    }
-
-    fn parse_fen(&mut self, fen_string: &str) -> Result<(), String> {
-        self.nodes = 0;
-        self.board = Board::from_fen(fen_string)?;
-        Ok(())
-    }
-
-    fn new_game(&mut self) {
-        self.clear_cache();
-    }
-
-    fn iterative_deepening_search(
-        &mut self,
-        search_options: SearchParameters,
-        mut on_depth: impl FnMut(u8, &SearchResult, PvLine),
-    ) -> SearchOutcome {
-        let mut best: Option<SearchResult> = None;
-        let max_depth = match search_options.depth {
-            Some(depth) => depth,
-            None => MAX_DEPTH,
-        };
-        self.configure(search_options.start_time, search_options.search_duration);
-
-        for depth in 1..=max_depth {
-            match self.search(depth) {
-                SearchOutcome::Aborted(partial) => {
-                    // A completed shallower iteration outranks the interrupted
-                    // one's best-so-far, which may be a fail high that never
-                    // got re-searched. The partial only fills in when depth 1
-                    // itself ran out of time.
-                    return SearchOutcome::Aborted(best.or(partial));
-                }
-                SearchOutcome::GameOver => {
-                    // checkmate, stalemate or a rule draw: deeper searches
-                    // cannot change it, so don't run them
-                    return SearchOutcome::GameOver;
-                }
-                SearchOutcome::Complete(result) => {
-                    on_depth(depth, &result, self.pv_line());
-                    best = Some(result);
-                }
-            }
-        }
-        match best {
-            Some(result) => SearchOutcome::Complete(result),
-            // a depth of zero runs no iterations, so there is nothing to
-            // report beyond that no move was looked for
-            None => SearchOutcome::Aborted(None),
-        }
-    }
-
-    fn make_move_str(&mut self, play: &str) -> bool {
-        for p in self.board.generate_moves() {
-            let play_str = format!("{}", p).to_lowercase();
-            if play == play_str {
-                let result = self.board.make_move(&p);
-                self.moves.clear_key(self.board.key); // TODO this is a hack to try to fix bad
-                // cache hits, particularly for draws
-                return result; // TODO change this to return Result
-            };
-        }
-        false
-    }
-
-    fn display_board(&self) {
-        println!("{}", self.board);
-    }
-}
-
-impl AlphaBeta {
-    pub fn new(board: Board) -> Self {
-        AlphaBeta::with_table_bytes(board, DEFAULT_TABLE_BYTES)
-    }
-
-    pub fn configure(
-        &mut self,
-        start_time: time::Instant,
-        search_duration: Option<time::Duration>,
-    ) {
-        self.start_time = start_time;
-        self.search_duration = search_duration;
-    }
-
-    /// The root loop: the one node whose answer must include a play, which is
-    /// why it runs here rather than in alpha_beta. The root probes the
-    /// transposition table to order moves and stores its entry when done, but
-    /// never takes a stored score in place of searching: a stored score can
-    /// come from a line whose repetition and fifty move context differ from
-    /// the game being played, and the answer must not depend on one.
-    pub fn search(&mut self, depth: u8) -> SearchOutcome {
-        self.nodes = 0;
-        self.search_depth = depth;
-        self.selective_depth = depth;
-        self.board.line_ply = 0;
-
-        // the game is already drawn, there is no move to look for
-        if self.board.fifty_move_rule >= 100 {
-            return SearchOutcome::GameOver;
-        }
-
-        if self.poll_deadline().is_err() {
-            return SearchOutcome::Aborted(None);
-        }
-        self.nodes += 1;
-
-        let mut depth = depth;
-        if self.board.is_king_attacked() {
-            depth += 1;
-        }
-
-        let mut alpha = Score::MIN + 1;
-        let beta = Score::MAX - 1;
-        let mut best: Option<Play> = None;
-        let mut found_legal_move = false;
-
-        let pv_play = self.moves.get(self.board.key).map(|pv| pv.play);
-        let mut moves = self.board.generate_moves();
-        moves.sort_by_cached_key(|m| {
-            let mut score = m.mvv_lva(&self.board);
-            if pv_play == Some(*m) {
-                score += 100_000;
-            }
-            -score
-        });
-
-        for m in &moves {
-            if self.board.make_move(m) {
-                found_legal_move = true;
-                // undo before an abort can propagate, or the board would keep
-                // the aborted line
-                let result = self.alpha_beta(-beta, -alpha, depth - 1);
-                self.board.undo_move();
-                match result {
-                    Err(Aborted) => {
-                        return SearchOutcome::Aborted(
-                            best.map(|play| self.result_for(play, alpha)),
-                        );
-                    }
-                    Ok(s) => {
-                        let score = -s;
-                        if score > alpha {
-                            alpha = score;
-                            best = Some(*m);
-                        }
-                    }
-                }
-            }
-        }
-
-        if !found_legal_move {
-            // checkmate or stalemate: either way there is nothing to play
-            return SearchOutcome::GameOver;
-        }
-
-        let play = best.expect("any legal move's score beats the opening alpha of Score::MIN + 1");
-        self.moves.set(
-            self.board.key,
-            Pv {
-                play,
-                depth,
-                score: score_to_tt(alpha, self.board.line_ply),
-                node: Node::Exact,
-                ply: self.board.ply as u16,
-            },
-        );
-        SearchOutcome::Complete(self.result_for(play, alpha))
-    }
-
-    /// Replay the line the table holds on a copy of the board, one stored move
-    /// at a time. Walking the positions rather than following a key from one
-    /// entry to the next is what lets the line be checked as it is built: the
-    /// board says whether a stored move is legal here, and whether the line has
-    /// reached a position it would be a draw to play on from.
-    pub fn pv_line(&self) -> PvLine {
-        let mut line = Vec::new();
-        // Board is Copy, so the search's own board is untouched by this.
-        let mut board = self.board;
-        while line.len() < MAX_DEPTH as usize {
-            let Some(pv) = self.moves.get(board.key) else {
-                break;
-            };
-            if matches!(pv.node, Node::Ordering) {
-                // written by quiescence, which looks at captures alone, so the
-                // move is fit for ordering the next search and not for telling
-                // anyone what the engine intends to play
-                break;
-            }
-            let play = pv.play;
-            // a probe compares the whole key, so what still gets through is
-            // another position which hashed to the same one. Its move belongs
-            // to that position, and playing it here would print a line the
-            // rules do not allow
-            if !board.generate_moves().contains(&play) {
-                break;
-            }
-            if !board.make_move(&play) {
-                break;
-            }
-            line.push(play);
-            // the line is a draw from here, so whatever the table says comes
-            // next is a continuation that would never be played
-            if board.fifty_move_rule >= 100 || board.has_repeated() {
-                break;
-            }
-        }
-        PvLine { line }
     }
 }
 

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -177,7 +177,7 @@ impl AlphaBeta {
         let pv_line = self.moves.get(self.board.key);
         let mut moves = self.board.generate_captures();
         moves.sort_by_cached_key(|m| {
-            let mut score = m.mmv_lva(&self.board);
+            let mut score = m.mvv_lva(&self.board);
             if let Some(pv) = pv_line {
                 if pv.play == *m {
                     score += 100000;
@@ -191,7 +191,7 @@ impl AlphaBeta {
                 // undo before an abort can propagate, or the board would keep
                 // the aborted line
                 let result = self.quiescence(-beta, -alpha);
-                self.board.undo_move().unwrap();
+                self.board.undo_move();
                 score = -result?;
                 if score > alpha {
                     if score >= beta {
@@ -293,7 +293,7 @@ impl AlphaBeta {
 
         let mut moves = self.board.generate_moves();
         moves.sort_by_cached_key(|m| {
-            let mut score = m.mmv_lva(&self.board);
+            let mut score = m.mvv_lva(&self.board);
             if let Some(pv) = pv_play {
                 if pv == *m {
                     score += 100_000;
@@ -309,7 +309,7 @@ impl AlphaBeta {
                 // the aborted line. Propagating also keeps the meaningless
                 // score of an aborted frame away from the stores below.
                 let result = self.alpha_beta(-beta, -alpha, depth - 1);
-                self.board.undo_move().unwrap();
+                self.board.undo_move();
                 score = -result?;
                 if score > alpha {
                     best_move = Some(m);
@@ -1131,7 +1131,7 @@ impl AlphaBeta {
         let pv_play = self.moves.get(self.board.key).map(|pv| pv.play);
         let mut moves = self.board.generate_moves();
         moves.sort_by_cached_key(|m| {
-            let mut score = m.mmv_lva(&self.board);
+            let mut score = m.mvv_lva(&self.board);
             if pv_play == Some(*m) {
                 score += 100_000;
             }
@@ -1144,7 +1144,7 @@ impl AlphaBeta {
                 // undo before an abort can propagate, or the board would keep
                 // the aborted line
                 let result = self.alpha_beta(-beta, -alpha, depth - 1);
-                self.board.undo_move().unwrap();
+                self.board.undo_move();
                 match result {
                     Err(Aborted) => {
                         return SearchOutcome::Aborted(

--- a/basic_engine/src/lib.rs
+++ b/basic_engine/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 mod bitboard;
 mod board;
 mod engine;

--- a/basic_engine/src/misc.rs
+++ b/basic_engine/src/misc.rs
@@ -100,15 +100,6 @@ pub struct CastlePermissions {
 }
 
 impl CastlePermissions {
-    #[allow(dead_code)]
-    pub fn new() -> Self {
-        CastlePermissions {
-            black_king_side: true,
-            black_queen_side: true,
-            white_king_side: true,
-            white_queen_side: true,
-        }
-    }
     pub fn from_fen(s: &str) -> Result<CastlePermissions, String> {
         let mut perms = CastlePermissions {
             black_king_side: false,
@@ -216,7 +207,7 @@ mod test_index_coordinate_conversion {
 
     proptest! {
         #[test]
-        fn round_trip(i in 1u8..=64) {
+        fn round_trip(i in 0u8..64) {
             let (rank, file) = index_to_coordinate(i);
             assert_eq!(i, coordinate_to_index(rank, file));
         }
@@ -270,6 +261,37 @@ impl Piece {
             Piece::Rook => 500,
             Piece::Queen => 900,
             Piece::King => 10000,
+        }
+    }
+}
+
+/// The piece's letter as fen and the board display write it, in lowercase.
+/// Case carries the colour, which is not the piece's to know.
+impl From<Piece> for char {
+    fn from(piece: Piece) -> Self {
+        match piece {
+            Piece::Pawn => 'p',
+            Piece::Knight => 'n',
+            Piece::Bishop => 'b',
+            Piece::Rook => 'r',
+            Piece::Queen => 'q',
+            Piece::King => 'k',
+        }
+    }
+}
+
+impl TryFrom<char> for Piece {
+    type Error = String;
+
+    fn try_from(c: char) -> Result<Self, Self::Error> {
+        match c.to_ascii_lowercase() {
+            'p' => Ok(Piece::Pawn),
+            'n' => Ok(Piece::Knight),
+            'b' => Ok(Piece::Bishop),
+            'r' => Ok(Piece::Rook),
+            'q' => Ok(Piece::Queen),
+            'k' => Ok(Piece::King),
+            _ => Err(format!("{} is not a piece", c)),
         }
     }
 }

--- a/basic_engine/src/misc.rs
+++ b/basic_engine/src/misc.rs
@@ -335,11 +335,6 @@ impl File {
         File::G,
         File::H,
     ];
-
-    pub fn add(self, value: u32) -> File {
-        let new_value = ((self as usize) + value as usize) % 8;
-        File::VARIANTS[new_value]
-    }
 }
 
 impl fmt::Display for File {

--- a/basic_engine/src/play.rs
+++ b/basic_engine/src/play.rs
@@ -33,7 +33,9 @@ impl Play {
         }
     }
 
-    pub fn mmv_lva(&self, board: &Board) -> i64 {
+    /// Most valuable victim, least valuable attacker: take the biggest piece
+    /// with the smallest one first.
+    pub fn mvv_lva(&self, board: &Board) -> i64 {
         let victim_score = match self.capture {
             None => return 0,
             Some(Piece::Pawn) => 100,
@@ -53,6 +55,8 @@ impl Play {
             Some(Piece::King) => 1,
         };
         let score = victim_score + attacker_score;
+        // a queen taking a defended piece is usually just losing the queen, so
+        // push it below the other captures rather than trying it first
         if attacker_score == 2 && board.square_attacked(self.to, !board.active_color) {
             return score - 300;
         }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -345,10 +345,11 @@ git push origin vX.Y.Z
 
 Pushing the tag is what triggers the release workflow, which runs the tests,
 creates the github release from the changelog, and then builds and uploads
-binaries for linux, macos and windows. It goes on to call two workflows that
+binaries for linux, macos and windows. It goes on to call three workflows that
 add to the release once it exists: **Docker** publishes the lichess-bot image
-and quotes it in the notes with its digest, and **Strength** plays the match
-and adds the elo estimate.
+and quotes it in the notes with its digest, **Strength** plays the match and
+adds the elo estimate, and **Calibrate** plays the gauntlet and adds the ccrl
+placement.
 
-Both edit the notes by reading them and writing them back, so they share a
-concurrency group and take turns rather than one landing on top of the other.
+All of them edit the notes by reading them and writing them back, so they share
+a concurrency group and take turns rather than one landing on top of the other.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,6 @@ mod uci;
 
 pub use uci::UCI;
 
-#[macro_use]
-extern crate lazy_static;
-
 use basic_engine::AlphaBeta;
 use basic_engine::Board;
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -6,21 +6,19 @@ use basic_engine::SearchParameters;
 use basic_engine::{PvLine, SearchResult};
 use regex::Regex;
 use std::io::BufRead;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 const START_FEN: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
-lazy_static! {
-    static ref WTIME_RE: Regex = Regex::new(r"wtime (\d+)").unwrap();
-    static ref BTIME_RE: Regex = Regex::new(r"btime (\d+)").unwrap();
-    static ref WINC_RE: Regex = Regex::new(r"winc (\d+)").unwrap();
-    static ref BINC_RE: Regex = Regex::new(r"binc (\d+)").unwrap();
-    static ref MOVES_TO_GO_RE: Regex = Regex::new(r"movestogo (\d+)").unwrap();
-    static ref MOVE_TIME: Regex = Regex::new(r"movetime (\d+)").unwrap();
-    static ref DEPTH_RE: Regex = Regex::new(r"depth (\d+)").unwrap();
-    static ref INFINITE_RE: Regex = Regex::new(r"infinite").unwrap();
-    static ref PERFT_RE: Regex = Regex::new(r"perft (\d+)").unwrap();
-}
+static WTIME_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"wtime (\d+)").unwrap());
+static BTIME_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"btime (\d+)").unwrap());
+static WINC_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"winc (\d+)").unwrap());
+static BINC_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"binc (\d+)").unwrap());
+static MOVES_TO_GO_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"movestogo (\d+)").unwrap());
+static MOVE_TIME: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"movetime (\d+)").unwrap());
+static DEPTH_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"depth (\d+)").unwrap());
+static PERFT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"perft (\d+)").unwrap());
 
 /// Reads the value that follows a keyword. The value is matched as digits, so
 /// the only way it can fail to parse is by being too large to hold, in which
@@ -51,7 +49,7 @@ fn time_control_from(line: &str, color: Color) -> TimeControl {
         },
         moves_to_go: capture(&MOVES_TO_GO_RE, line),
         move_time: capture(&MOVE_TIME, line),
-        infinite: INFINITE_RE.is_match(line),
+        infinite: line.contains("infinite"),
     }
 }
 
@@ -67,7 +65,7 @@ impl<T: Engine> UCI<T> {
     pub fn new_with_engine(engine: T) -> Self {
         Self {
             author: env!("CARGO_PKG_AUTHORS").to_string(),
-            name: env!("CARGO_PKG_NAME").to_string(), // TODO change based on engine?
+            name: env!("CARGO_PKG_NAME").to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
             engine,
         }


### PR DESCRIPTION
Applies the findings of a full-repo audit (idiomatic, readable, gotchas documented but not over-documented, TODOs accurate, DRY), with performance held constant: `test_node_counts_have_not_moved` passes untouched in every commit, so the search visits exactly the same tree as before.

## Commits

**`fix(board)`: Reject a fen with more than eight files on a rank** — the one behavior change, isolated so the changelog records it honestly. A ninth file used to wrap `File::add` back onto the a-file; a debug build died on an assertion and a release build silently corrupted the psqt and position key. The parser now counts files, the long-commented-out `test_invalid_extra_file` is enabled, and `File::add` (whose wrapping was never wanted) is gone.

**`refactor(board)`: Tidy the board, misc and play modules** — `mmv_lva` is spelled `mvv_lva`; the `__m` loop variables are `targets`; `generate_captures` no longer carries comments copy-pasted from `generate_moves` that describe the wrong mask; `undo_move` returns `()` instead of a `Result` it never made an `Err` of, and loses `make_move`'s fifty-move comment above a block that restores the counter from history; the castle masks are consts; `Piece`↔char conversions serve both `from_fen` and `Display`; the six standard perft tests are one data table in the style `perft_edge_cases` established; dead code, perft-divide leftovers and stale TODO musings are gone; the coordinate round-trip proptest covers `0..64` instead of the off-by-one `1..=64`. Also fixes a README typo and the release-flow doc, which listed two note-editing workflows when calibrate made it three.

**`refactor(search)`: Tidy the search module** — the file reads top to bottom (impls together, tests at the end instead of wedged between two halves of the impl); `Node` is `Bound` with `Upper`/`Lower` variants, resolving its naming TODO, with the README known-issue reworded to match; the three copies of the move-ordering sort are one `order_moves` helper; `checkmate_in` uses `CHECKMATE_THRESHOLD` rather than a second private definition of what counts as a mate score; `HashTable` drops a `capacity` field that duplicated `table.len()`.

**`refactor(deps)`: Replace lazy_static with the standard library** — `std::sync::LazyLock` (stable since 1.80, floor here is 1.85) replaces the macro in both crates and the dependency is removed; the regex that matched the literal word `infinite` is `line.contains`.

**`refactor(magic)`: Generate moves and captures from one function** — `generate_moves` and `generate_captures` were the same hundred lines twice. They are one generator with a `const CAPTURES_ONLY: bool` parameter now: each wrapper monomorphises into what used to be its own hand-written copy, so the captures list still pays no per-move test for the branches it does not take. Gated on the node-count test (identical move lists in identical order) and the benchmark job's comparison.

## Deliberately not included

One audit finding is parked for a follow-up: merging `material_value`/`recompute_material` (#15 in the audit notes).

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` clean at every commit
- `cargo test --workspace --release` green at every commit
- `cargo test --workspace` (debug profile, with the make/undo `debug_assert`s) run after the board changes
- node counts pinned: the search is provably unchanged apart from the fen rejection
- a strength match (PR head vs master, 50 games) was dispatched alongside as a regression smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhiJhdHPF8YDStbv8Wbsm9