### PR TITLE
perf(search): Try the table's move before generating any

### DIFF
--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -273,6 +273,102 @@ impl Board {
         Board::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap()
     }
 
+    /// Whether this move is one `generate_moves` would produce here.
+    ///
+    /// A probe checks the key a slot was stored under, so a hit is this
+    /// position and its move is one generated for it. Almost: a key is sixty
+    /// four bits, and a long search sees enough positions for two of them to
+    /// land on the same one. Anything that narrowed what a slot keeps of the
+    /// key would make an entry from elsewhere ordinary rather than rare.
+    ///
+    /// Ordering never had to care, because a move from another position
+    /// matches nothing in the generated list and is passed over. Playing one
+    /// does: `make_move` reads the capture, promotion and castling fields as a
+    /// description of this board, so a move belonging to a different one
+    /// corrupts the position rather than merely wasting a node.
+    ///
+    /// Answering no when the truth is yes is free: the caller falls back to
+    /// generating, which is what it would have done anyway. So the fiddly cases
+    /// are simply refused rather than checked, which keeps this cheap enough to
+    /// be worth asking on the way past.
+    pub fn is_pseudo_legal(&self, m: &Play) -> bool {
+        // castling, en passant and promotion each carry conditions of their own
+        // that this would have to restate. They are rare, so let them generate.
+        if m.castle || m.en_passant || m.promote.is_some() {
+            return false;
+        }
+
+        let color_mask = match self.active_color {
+            Color::Black => self.black,
+            Color::White => self.white,
+        };
+        // the piece has to be ours, and cannot land on top of another of ours
+        if !color_mask.is_bit_set(m.from) || color_mask.is_bit_set(m.to) {
+            return false;
+        }
+        let Some(piece) = self.get_piece_index(m.from) else {
+            return false;
+        };
+        // make_move clears exactly the piece the move names, so the move has to
+        // name what is actually standing there
+        if m.capture != self.get_piece_index(m.to) {
+            return false;
+        }
+
+        let all_pieces = self.black | self.white;
+        let attack_masks: &AttackMasks = &ATTACK_MASKS;
+        let magic: &Magic = &MAGIC;
+        match piece {
+            Piece::Knight => attack_masks.knights[m.from as usize].is_bit_set(m.to),
+            Piece::King => attack_masks.kings[m.from as usize].is_bit_set(m.to),
+            Piece::Rook => magic.get_straight_move(m.from, all_pieces).is_bit_set(m.to),
+            Piece::Bishop => magic.get_diagonal_move(m.from, all_pieces).is_bit_set(m.to),
+            Piece::Queen => {
+                magic.get_straight_move(m.from, all_pieces).is_bit_set(m.to)
+                    || magic.get_diagonal_move(m.from, all_pieces).is_bit_set(m.to)
+            }
+            Piece::Pawn => {
+                let (rank, _) = index_to_coordinate(m.from);
+                // a pawn one step from the far rank only ever promotes, and
+                // promotions were refused above
+                if match self.active_color {
+                    Color::White => rank == 7,
+                    Color::Black => rank == 2,
+                } {
+                    return false;
+                }
+                if m.capture.is_some() {
+                    // capture_mask was already established by the checks above
+                    return match self.active_color {
+                        Color::White => attack_masks.black_pawns[m.from as usize].is_bit_set(m.to),
+                        Color::Black => attack_masks.white_pawns[m.from as usize].is_bit_set(m.to),
+                    };
+                }
+                let one = match self.active_color {
+                    Color::White => m.from as isize + 8,
+                    Color::Black => m.from as isize - 8,
+                };
+                if !(0..64).contains(&one) || all_pieces.is_bit_set(one as u8) {
+                    return false;
+                }
+                if m.to as isize == one {
+                    return true;
+                }
+                // the double push, only from the rank it is allowed from and
+                // only when the square beyond is empty too
+                let from_start = match self.active_color {
+                    Color::White => rank == 2,
+                    Color::Black => rank == 7,
+                };
+                let two = match self.active_color {
+                    Color::White => one + 8,
+                    Color::Black => one - 8,
+                };
+                from_start && m.to as isize == two && !all_pieces.is_bit_set(two as u8)
+            }
+        }
+    }
+
     /// The subset of generate_moves with a capture, in the same order, made
     /// without generating the quiet moves only to filter them out.
     pub fn generate_captures(&self) -> MoveList {
@@ -2011,5 +2107,103 @@ mod perft_edge_cases {
                 depth
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod pseudo_legal {
+    use super::Board;
+    use super::Game;
+    use super::Play;
+    use crate::misc::Piece;
+
+    /// "d4" to the index the board uses, so the cases below read as squares
+    /// rather than as arithmetic.
+    fn sq(name: &str) -> u8 {
+        let mut c = name.chars();
+        let file = c.next().unwrap() as u8 - b'a';
+        let rank = c.next().unwrap() as u8 - b'1';
+        rank * 8 + file
+    }
+
+    fn quiet(from: &str, to: &str) -> Play {
+        Play::new(sq(from), sq(to), None, None, false, false)
+    }
+
+    fn takes(from: &str, to: &str, piece: Piece) -> Play {
+        Play::new(sq(from), sq(to), Some(piece), None, false, false)
+    }
+
+    const POSITIONS: [&str; 5] = [
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+        "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+        "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+        "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
+        "r2q1rk1/1b1nbppp/p2ppn2/1p6/3NPP2/1BN1B3/PPPQ2PP/2KR3R w - - 0 13",
+    ];
+
+    /// The point of the check is to accept what the generator produces: a move
+    /// refused here is one the search declines to play early and has to find
+    /// again the slow way. Castling, en passant and promotions are refused on
+    /// purpose, and this pins that they are the only ones.
+    #[test]
+    fn accepts_every_generated_move_but_the_refused_kinds() {
+        for fen in POSITIONS {
+            let board = Board::from_fen(fen).unwrap();
+            for m in &board.generate_moves() {
+                let refused_kind = m.castle || m.en_passant || m.promote.is_some();
+                assert_eq!(board.is_pseudo_legal(m), !refused_kind, "{} in {}", m, fen);
+            }
+        }
+    }
+
+    /// A move handed back for another position can say anything at all, and
+    /// make_move acts on what it says. These are the shapes that would corrupt
+    /// the board if they were played.
+    #[test]
+    fn refuses_a_move_that_does_not_belong_to_this_position() {
+        let board =
+            Board::from_fen("r2q1rk1/1b1nbppp/p2ppn2/1p6/3NPP2/1BN1B3/PPPQ2PP/2KR3R w - - 0 13")
+                .unwrap();
+
+        // d3 is empty, so there is nothing there to move
+        assert!(!board.is_pseudo_legal(&quiet("d3", "d5")));
+        // a6 is a black pawn and it is white to move
+        assert!(!board.is_pseudo_legal(&quiet("a6", "a5")));
+        // c1 is our king and d1 is our own rook
+        assert!(!board.is_pseudo_legal(&quiet("c1", "d1")));
+        // a knight on d4 does not reach d5
+        assert!(!board.is_pseudo_legal(&quiet("d4", "d5")));
+        // the rook on d1 cannot pass through the queen on d2
+        assert!(!board.is_pseudo_legal(&quiet("d1", "d5")));
+        // claiming a capture on an empty square
+        assert!(!board.is_pseudo_legal(&takes("d4", "f5", Piece::Queen)));
+        // and naming the wrong piece on an occupied one: e6 holds a pawn
+        assert!(!board.is_pseudo_legal(&takes("d4", "e6", Piece::Queen)));
+        // a capture that forgets to say it is one
+        assert!(!board.is_pseudo_legal(&quiet("d4", "e6")));
+
+        // and the moves those are variations of, so none of it passes vacuously
+        assert!(board.is_pseudo_legal(&quiet("d4", "f5")));
+        assert!(board.is_pseudo_legal(&takes("d4", "e6", Piece::Pawn)));
+    }
+
+    /// A pawn push is the one move whose legality turns on squares the move
+    /// itself never names.
+    #[test]
+    fn refuses_a_push_the_position_does_not_allow() {
+        let board =
+            Board::from_fen("rnbqkbnr/pppppppp/8/8/8/5N2/PPPPPPPP/RNBQKB1R w KQkq - 0 1").unwrap();
+        // the knight on f3 blocks both the single and the double push
+        assert!(!board.is_pseudo_legal(&quiet("f2", "f3")));
+        assert!(!board.is_pseudo_legal(&quiet("f2", "f4")));
+        // its neighbour is clear
+        assert!(board.is_pseudo_legal(&quiet("e2", "e4")));
+
+        // a pawn that has already moved cannot double push again
+        let moved =
+            Board::from_fen("rnbqkbnr/pppppppp/8/8/8/4P3/PPPP1PPP/RNBQKBNR w KQkq - 0 2").unwrap();
+        assert!(!moved.is_pseudo_legal(&quiet("e3", "e5")));
+        assert!(moved.is_pseudo_legal(&quiet("e3", "e4")));
     }
 }

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -157,6 +157,11 @@ impl AlphaBeta {
 
     /// MVV-LVA order, with the table's move for this position, if there is
     /// one, ahead of everything else.
+    ///
+    /// The search may already have played that move without generating, in
+    /// which case it skips it here. The bonus still earns its keep: a table
+    /// move it declined to play early was never searched, so it is still in
+    /// this list and still has to be the first one tried.
     fn order_moves(&self, moves: &mut MoveList, pv_play: Option<Play>) {
         moves.sort_by_cached_key(|m| {
             let mut score = m.mvv_lva(&self.board);
@@ -287,16 +292,54 @@ impl AlphaBeta {
 
         let old_alpha = alpha;
         let mut found_legal_move = false;
-        let mut best_move: Option<&Play> = None;
+        let mut best_move: Option<Play> = None;
         let (pv_play, tt_score) = self.get_transposition(self.board.key, alpha, beta, depth);
         if let Some(tt_score) = tt_score {
             return Ok(tt_score);
+        }
+
+        // The table's move sorts ahead of everything else below, and when there
+        // is one it takes the cutoff nine times in ten. Searching it before
+        // generating means the nodes it cuts never generate or sort at all.
+        // The order is the one the sort would have produced either way, so the
+        // tree searched is unchanged.
+        let mut tt_tried: Option<Play> = None;
+        if let Some(tt) = pv_play {
+            if self.board.is_pseudo_legal(&tt) {
+                tt_tried = Some(tt);
+                if self.board.make_move(&tt) {
+                    found_legal_move = true;
+                    let result = self.alpha_beta(-beta, -alpha, depth - 1);
+                    self.board.undo_move();
+                    let tt_score = -result?;
+                    if tt_score > alpha {
+                        best_move = Some(tt);
+                        if tt_score >= beta {
+                            self.moves.set(
+                                self.board.key,
+                                Pv {
+                                    play: tt,
+                                    depth,
+                                    score: score_to_tt(beta, self.board.line_ply),
+                                    bound: Bound::Lower,
+                                    ply: self.board.ply as u16,
+                                },
+                            );
+                            return Ok(beta);
+                        }
+                        alpha = tt_score;
+                    }
+                }
+            }
         }
 
         let mut moves = self.board.generate_moves();
         self.order_moves(&mut moves, pv_play);
 
         for m in &moves {
+            if tt_tried == Some(*m) {
+                continue;
+            }
             if self.board.make_move(m) {
                 found_legal_move = true;
                 // undo before an abort can propagate, or the board would keep
@@ -306,7 +349,7 @@ impl AlphaBeta {
                 self.board.undo_move();
                 let score = -result?;
                 if score > alpha {
-                    best_move = Some(m);
+                    best_move = Some(*m);
                     if score >= beta {
                         self.moves.set(
                             self.board.key,
@@ -336,7 +379,7 @@ impl AlphaBeta {
             self.moves.set(
                 self.board.key,
                 Pv {
-                    play: *best_move.unwrap(),
+                    play: best_move.unwrap(),
                     depth,
                     score: score_to_tt(alpha, self.board.line_ply),
                     bound: Bound::Exact,


### PR DESCRIPTION
A node that has a move in the transposition table already knows what to search first. The sort gives that move a +100,000 bonus, which no MVV-LVA score can reach, so it comes out in front every time. Generating and sorting the whole list beforehand is work the node only needs if that move fails to produce a cutoff.

Instrumenting a depth 9 search:

- **20.9%** of nodes reaching move generation have a table move
- when there is one, it produces a beta cutoff **99.9%** of the time
- 99.7% of all cutoffs happen on the first move searched

So at roughly a fifth of nodes, the engine generates every move, sorts the list, cuts on move one and discards the rest.

## The tree is unchanged

Searching the table move first and skipping it in the generated list produces exactly the sequence the sort produced. Node counts are identical to `master`:

| | master | this |
| --- | --- | --- |
| kiwipete depth 8 | 10,675,379 | 10,675,379 |
| kiwipete depth 9 | 50,349,221 | 50,349,221 |

`test_node_counts_have_not_moved` passes untouched, which is the point — this is a pure reordering of when work happens, not a change to what is searched.

The +100,000 bonus stays in the sort below. A move `is_pseudo_legal` declines to play early is never searched there, so it is still in the generated list and still has to hold the place ordering gave it.

## Why the move has to be checked

A probe checks the key a slot was stored under, so a hit is this position and its move is one generated for it. Almost: a key is sixty four bits, and a long search sees enough positions for two of them to land on the same one.

That has never mattered before, because the table's move is only ever compared against generated moves — one belonging to another position matches nothing and is passed over. Playing it is different. `make_move` reads the capture, promotion, en passant and castling fields as a description of this board, so a move that belongs to a different one corrupts the position rather than merely wasting a node.

`is_pseudo_legal` is cheap because it is allowed to be wrong in one direction. Answering no when the truth is yes costs only the shortcut — the caller falls back to generating, which is what it would have done anyway. So castling, en passant and promotion are refused outright rather than checked, since each would mean restating conditions from `generate_moves`. What remains is a colour test, a comparison of the capture field against the square, and one attack-mask or magic lookup. It refuses 10.7% of table moves on that basis and costs nothing measurable: a build without the check at all timed within noise of this one.

Three tests cover it. The important one asserts that **every** move `generate_moves` produces across five positions is accepted, except the three refused kinds — a check that refuses too much would silently give the shortcut back with nothing failing. The other two feed it moves from a position it is not looking at: an empty from-square, an opponent's piece, landing on our own piece, a knight move that is not a knight jump, a rook through a blocker, a capture claimed on an empty square, a capture naming the wrong piece, a capture that forgets to say it is one, and pushes the position does not allow.

## Measured

Depth 9 on kiwipete, interleaved with `master` over eight rounds: **6.69s to 6.10s, -8.8%, faster in all eight**.

Depths 1-7 under callgrind, against `master`:

| | master | this | |
| --- | --- | --- | --- |
| `generate_moves` | 471.9M | 363.0M | **-23.1%** |
| sort machinery | 950.6M | 726.1M | **-23.6%** |
| `alpha_beta` | 742.3M | 693.1M | -6.6% |
| `square_attacked` | 403.8M | 387.1M | -4.1% |
| make/unmake and piece updates | — | — | unchanged |

Generation and sorting each fall about 23%, against the ~21% of nodes predicted to take the shortcut. The make/unmake block is untouched, as it must be when the tree has not moved.

Full suite green in release and debug; `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Still worth doing

Node counts prove the same amount of work, not the same moves, so a strength match against `master` is the check worth running before this merges.

One forward note, which changes nothing here: if what a slot keeps of the key were ever narrowed, an entry from another position would become ordinary rather than rare. `is_pseudo_legal` already covers that, so this needs no revisiting if that happens.