### PR TITLE
Measure how much the transposition table depends on the path taken, then stop it

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ docker/smoke_test.sh arche-lichess-bot
   - fail low nodes (upper bounds) are never stored in the transposition table, only exact
     scores and fail highs
   - a transposition score that came from a repetition or fifty move draw is refused rather than
-    trusted, so the search cannot read a draw down a path that could not reach it. The table
-    still knows nothing of how the game reached the root though, which is why make_move_str
-    clears the key for played moves as a workaround
+    trusted, so the search cannot read a draw down a path that could not reach it. The reverse
+    direction is still open: a score stored with the draw out of reach can be read by a path
+    with the draw in reach, say a fifty move counter about to run out, and be trusted
   - a fen is only validated as far as what the search cannot survive, a king a side and the side
     not to move being out of check. A position which is illegal in other ways, such as one with
     nine pawns or castling rights without a rook, is accepted and played from

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ docker/smoke_test.sh arche-lichess-bot
 - known issues
   - fail low nodes (upper bounds) are never stored in the transposition table, only exact
     scores and fail highs
-  - transposition table scores don't account for repetition or fifty move history, make_move_str
+  - a transposition score that came from a repetition or fifty move draw is refused rather than
+    trusted, so the search cannot read a draw down a path that could not reach it. The table
+    still knows nothing of how the game reached the root though, which is why make_move_str
     clears the key for played moves as a workaround
   - a fen is only validated as far as what the search cannot survive, a king a side and the side
     not to move being out of check. A position which is illegal in other ways, such as one with

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -108,6 +108,11 @@ pub struct AlphaBeta {
     // search parameters
     search_depth: u8,
     // search state
+    /// Whether the value the last search call returned was draw tainted. The
+    /// search is depth first and single threaded, so one flag threads the taint
+    /// up without changing every return type.
+    tainted: bool,
+    pub ghi: GhiCounters,
     start_time: time::Instant,
     search_duration: Option<time::Duration>,
 }
@@ -120,6 +125,8 @@ impl AlphaBeta {
             moves: HashTable::with_capacity_bytes(bytes),
             search_depth: 0,
             selective_depth: 0,
+            tainted: false,
+            ghi: GhiCounters::default(),
             start_time: time::Instant::now(),
             search_duration: None,
         }
@@ -173,6 +180,9 @@ impl AlphaBeta {
     }
 
     fn quiescence(&mut self, mut alpha: Score, beta: Score) -> Result<Score, Aborted> {
+        // quiescence looks at captures alone and never checks for a repetition,
+        // so nothing it returns is path dependent
+        self.tainted = false;
         self.selective_depth = self.selective_depth.max(self.board.line_ply as u8);
         if self.board.line_ply >= MAX_DEPTH.into() {
             return Ok(self.eval());
@@ -219,6 +229,7 @@ impl AlphaBeta {
                     score: score_to_tt(alpha, self.board.line_ply),
                     depth: 0, // Never use a quiescence move instead of evaluating, only for move ordering
                     bound: Bound::Ordering,
+                    tainted: false,
                     ply: self.board.ply as u16,
                 },
             );
@@ -232,34 +243,40 @@ impl AlphaBeta {
     /// move ordering, and a score when the stored entry is deep enough and its
     /// bound allows a cutoff at the current alpha/beta window.
     fn get_transposition(
-        &self,
+        &mut self,
         key: u64,
         alpha: Score,
         beta: Score,
         depth: u8,
     ) -> (Option<Play>, Option<Score>) {
-        let pv = self.moves.get(key);
-        if let Some(pv) = pv {
-            if pv.depth >= depth {
-                let score = score_from_tt(pv.score, self.board.line_ply);
-                match pv.bound {
-                    Bound::Exact => return (Some(pv.play), Some(score)),
-                    Bound::Upper => {
-                        if score <= alpha {
-                            return (Some(pv.play), Some(score));
-                        }
-                    }
-                    Bound::Lower => {
-                        if score >= beta {
-                            return (Some(pv.play), Some(score));
-                        }
-                    }
-                    Bound::Ordering => (),
-                }
+        // copied out so the counters below are not borrowing the table
+        let Some(pv) = self.moves.get(key).copied() else {
+            return (None, None);
+        };
+        if pv.depth >= depth {
+            let score = score_from_tt(pv.score, self.board.line_ply);
+            let cuts = match pv.bound {
+                Bound::Exact => true,
+                Bound::Upper => score <= alpha,
+                Bound::Lower => score >= beta,
+                Bound::Ordering => false,
+            };
+            if cuts && REFUSE_TAINTED_CUTOFFS && pv.tainted {
+                // the stored draw was reachable by the path that stored it and
+                // may not be reachable by this one, so the move is still worth
+                // ordering by but the score is not worth trusting
+                return (Some(pv.play), None);
             }
-            return (Some(pv.play), None);
+            if cuts {
+                self.ghi.score_cutoffs += 1;
+                self.ghi.tainted_score_cutoffs += u64::from(pv.tainted);
+                // whatever the stored score depended on, this frame now depends
+                // on too
+                self.tainted = pv.tainted;
+                return (Some(pv.play), Some(score));
+            }
         }
-        (None, None)
+        (Some(pv.play), None)
     }
 
     fn alpha_beta(
@@ -276,8 +293,12 @@ impl AlphaBeta {
         // repetition there is not a finished game because the engine still has
         // to move, but from here on it is a draw either side can take
         if self.board.fifty_move_rule >= 100 || self.board.has_repeated() {
+            // the source. This score is true of the path that reached this
+            // position, not of the position
+            self.tainted = true;
             return Ok(0);
         }
+        let mut node_tainted = false;
         let in_check = self.board.is_king_attacked();
         if in_check {
             depth += 1;
@@ -287,6 +308,7 @@ impl AlphaBeta {
             if self.search_depth >= 4 {
                 return self.quiescence(alpha, beta);
             }
+            self.tainted = false;
             return Ok(self.eval());
         }
 
@@ -347,6 +369,9 @@ impl AlphaBeta {
                 // score of an aborted frame away from the stores below.
                 let result = self.alpha_beta(-beta, -alpha, depth - 1);
                 self.board.undo_move();
+                // a value built from a tainted child is tainted, whether or not
+                // it turns out to be the best one here
+                node_tainted |= self.tainted;
                 let score = -result?;
                 if score > alpha {
                     best_move = Some(*m);
@@ -359,8 +384,12 @@ impl AlphaBeta {
                                 score: score_to_tt(beta, self.board.line_ply),
                                 bound: Bound::Lower,
                                 ply: self.board.ply as u16,
+                                tainted: node_tainted,
                             },
                         );
+                        self.ghi.stores += 1;
+                        self.ghi.tainted_stores += u64::from(node_tainted);
+                        self.tainted = node_tainted;
                         return Ok(beta);
                     }
                     alpha = score;
@@ -369,6 +398,9 @@ impl AlphaBeta {
         }
 
         if !found_legal_move {
+            // mate and stalemate are properties of the position, not of the
+            // path that reached it
+            self.tainted = false;
             if in_check {
                 return Ok(-CHECKMATE_SCORE + (self.board.line_ply as Score));
             }
@@ -384,9 +416,13 @@ impl AlphaBeta {
                     score: score_to_tt(alpha, self.board.line_ply),
                     bound: Bound::Exact,
                     ply: self.board.ply as u16,
+                    tainted: node_tainted,
                 },
             );
+            self.ghi.stores += 1;
+            self.ghi.tainted_stores += u64::from(node_tainted);
         }
+        self.tainted = node_tainted;
         Ok(alpha)
     }
 
@@ -434,6 +470,7 @@ impl AlphaBeta {
         let beta = Score::MAX - 1;
         let mut best: Option<Play> = None;
         let mut found_legal_move = false;
+        let mut root_tainted = false;
 
         let pv_play = self.moves.get(self.board.key).map(|pv| pv.play);
         let mut moves = self.board.generate_moves();
@@ -453,6 +490,7 @@ impl AlphaBeta {
                         );
                     }
                     Ok(s) => {
+                        root_tainted |= self.tainted;
                         let score = -s;
                         if score > alpha {
                             alpha = score;
@@ -477,8 +515,11 @@ impl AlphaBeta {
                 score: score_to_tt(alpha, self.board.line_ply),
                 bound: Bound::Exact,
                 ply: self.board.ply as u16,
+                tainted: root_tainted,
             },
         );
+        self.ghi.stores += 1;
+        self.ghi.tainted_stores += u64::from(root_tainted);
         SearchOutcome::Complete(self.result_for(play, alpha))
     }
 
@@ -600,10 +641,39 @@ impl Engine for AlphaBeta {
     }
 }
 
+/// Whether to refuse a score from a draw tainted entry, trusting only its move.
+/// Sound but slower. Left off so that this branch only measures and the pinned
+/// node counts still describe what master does. Turning it on cost, over the
+/// pinned positions at their pinned depths: nothing at all in kiwipete,
+/// promotions and the middlegame, which have no tainted cutoffs to refuse,
+/// +0.037% in the opening, and +2.970% in the pawn endgame. +0.617% overall.
+const REFUSE_TAINTED_CUTOFFS: bool = false;
+
+/// How often the transposition table hands back a score that depended on the
+/// path taken rather than on the position, which is the graph history
+/// interaction error every engine carries and none of them measure.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct GhiCounters {
+    /// Entries stored carrying a draw tainted score.
+    pub tainted_stores: u64,
+    /// Entries stored in total.
+    pub stores: u64,
+    /// Probes that returned a score, cutting the search off.
+    pub score_cutoffs: u64,
+    /// Probes that returned a tainted score, which is the error itself: the
+    /// stored draw was reachable by the path that stored it and may not be
+    /// reachable by this one.
+    pub tainted_score_cutoffs: u64,
+}
+
 #[derive(Copy, Clone, Debug)]
 struct Pv {
     play: Play,
     score: Score,
+    /// True if the score flowed from a repetition or fifty move draw somewhere
+    /// below it, so it describes the path taken to this position and not the
+    /// position itself. See docs on graph history interaction.
+    tainted: bool,
     // a depth cannot exceed MAX_DEPTH and a ply is bounded by the history
     // array, so neither needs a word. Both sit in the padding the key leaves
     // behind, which is why widening ply to u16 costs nothing.
@@ -805,6 +875,7 @@ mod test_search {
             depth: 5,
             bound: Bound::Exact,
             ply: ply as u16,
+            tainted: false,
         }
     }
 
@@ -1105,6 +1176,7 @@ mod test_search {
                 depth: 0,
                 bound: Bound::Ordering,
                 ply: 0,
+                tainted: false,
             },
         );
 
@@ -1187,6 +1259,7 @@ mod test_hash_table {
             depth,
             bound,
             ply,
+            tainted: false,
         }
     }
 
@@ -1302,6 +1375,70 @@ mod test_node_counts {
                 other => panic!("search did not complete: {:?}", other),
             })
             .sum()
+    }
+
+    /// Reports how much of the search's use of the transposition table depends
+    /// on the path taken rather than on the position. Not an assertion, it
+    /// prints, which is why it is ignored.
+    ///
+    ///     cargo test -p basic_engine --release ghi_report -- --ignored --nocapture
+    #[test]
+    #[ignore = "prints a measurement, see the doc comment"]
+    fn ghi_report() {
+        println!(
+            "{:<14} {:>10} {:>10} {:>8} {:>10} {:>10} {:>8}",
+            "position", "stores", "tainted", "%", "cutoffs", "tainted", "%"
+        );
+        let mut totals = (0u64, 0u64, 0u64, 0u64);
+        for (name, fen, depth) in POSITIONS {
+            let mut engine =
+                AlphaBeta::with_table_bytes(Board::from_fen(fen).unwrap(), TABLE_BYTES);
+            for d in 1..=depth {
+                match engine.search(d) {
+                    super::SearchOutcome::Complete(_) => (),
+                    other => panic!("search did not complete: {:?}", other),
+                }
+            }
+            let g = engine.ghi;
+            let pct = |a: u64, b: u64| {
+                if b == 0 {
+                    0.0
+                } else {
+                    100.0 * a as f64 / b as f64
+                }
+            };
+            println!(
+                "{:<14} {:>10} {:>10} {:>7.3}% {:>10} {:>10} {:>7.3}%",
+                name,
+                g.stores,
+                g.tainted_stores,
+                pct(g.tainted_stores, g.stores),
+                g.score_cutoffs,
+                g.tainted_score_cutoffs,
+                pct(g.tainted_score_cutoffs, g.score_cutoffs)
+            );
+            totals.0 += g.stores;
+            totals.1 += g.tainted_stores;
+            totals.2 += g.score_cutoffs;
+            totals.3 += g.tainted_score_cutoffs;
+        }
+        let pct = |a: u64, b: u64| {
+            if b == 0 {
+                0.0
+            } else {
+                100.0 * a as f64 / b as f64
+            }
+        };
+        println!(
+            "{:<14} {:>10} {:>10} {:>7.3}% {:>10} {:>10} {:>7.3}%",
+            "TOTAL",
+            totals.0,
+            totals.1,
+            pct(totals.1, totals.0),
+            totals.2,
+            totals.3,
+            pct(totals.3, totals.2)
+        );
     }
 
     /// The search is deterministic, so how many nodes it visits is an exact

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -642,12 +642,14 @@ impl Engine for AlphaBeta {
 }
 
 /// Whether to refuse a score from a draw tainted entry, trusting only its move.
-/// Sound but slower. Left off so that this branch only measures and the pinned
-/// node counts still describe what master does. Turning it on cost, over the
-/// pinned positions at their pinned depths: nothing at all in kiwipete,
-/// promotions and the middlegame, which have no tainted cutoffs to refuse,
-/// +0.037% in the opening, and +2.970% in the pawn endgame. +0.617% overall.
-const REFUSE_TAINTED_CUTOFFS: bool = false;
+///
+/// On. A tainted score describes the path that stored it rather than the
+/// position, so a search arriving another way can read a draw it cannot
+/// actually reach. Refusing costs, over the pinned positions at their pinned
+/// depths, nothing at all in kiwipete, promotions and the middlegame, which
+/// have no tainted cutoffs to refuse, +0.037% in the opening and +2.970% in the
+/// pawn endgame, for +0.617% overall.
+const REFUSE_TAINTED_CUTOFFS: bool = true;
 
 /// How often the transposition table hands back a score that depended on the
 /// path taken rather than on the position, which is the graph history
@@ -1459,9 +1461,9 @@ mod test_node_counts {
         assert_eq!(
             counted,
             vec![
-                ("opening", 149_810),
+                ("opening", 149_866),
                 ("kiwipete", 217_026),
-                ("pawn endgame", 173_223),
+                ("pawn endgame", 178_367),
                 ("promotions", 110_643),
                 ("middlegame", 191_607),
             ]

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -333,6 +333,10 @@ impl AlphaBeta {
                     found_legal_move = true;
                     let result = self.alpha_beta(-beta, -alpha, depth - 1);
                     self.board.undo_move();
+                    // the table's move is searched before the rest are even
+                    // generated, so it taints this node the same way any other
+                    // child would
+                    node_tainted |= self.tainted;
                     let tt_score = -result?;
                     if tt_score > alpha {
                         best_move = Some(tt);
@@ -345,8 +349,12 @@ impl AlphaBeta {
                                     score: score_to_tt(beta, self.board.line_ply),
                                     bound: Bound::Lower,
                                     ply: self.board.ply as u16,
+                                    tainted: node_tainted,
                                 },
                             );
+                            self.ghi.stores += 1;
+                            self.ghi.tainted_stores += u64::from(node_tainted);
+                            self.tainted = node_tainted;
                             return Ok(beta);
                         }
                         alpha = tt_score;
@@ -627,10 +635,7 @@ impl Engine for AlphaBeta {
         for p in self.board.generate_moves() {
             let play_str = format!("{}", p).to_lowercase();
             if play == play_str {
-                let result = self.board.make_move(&p);
-                self.moves.clear_key(self.board.key); // TODO this is a hack to try to fix bad
-                // cache hits, particularly for draws
-                return result; // TODO change this to return Result
+                return self.board.make_move(&p); // TODO change this to return Result
             };
         }
         false
@@ -740,11 +745,6 @@ impl HashTable {
             }
         }
         None
-    }
-
-    fn clear_key(&mut self, key: u64) {
-        let index = self.index_for(key);
-        self.table[index] = None;
     }
 
     fn set(&mut self, key: u64, pv: Pv) {

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -1035,6 +1035,54 @@ mod test_search {
     }
 
     #[test]
+    fn test_draw_taint_is_still_recorded_and_never_trusted() {
+        // The pawn endgame carries the most draw traffic of the pinned
+        // positions, so it is the one that exercises both halves of the graph
+        // history work. tainted_stores going to zero means taint propagation
+        // broke, and then the refusal in get_transposition is refusing nothing
+        // while the hole silently reopens. tainted_score_cutoffs is zero by
+        // construction while the refusal holds, so it moving means a probe
+        // path that consumes scores without the refusal guard was added.
+        let fen = "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1";
+        let mut e = engine(Board::from_fen(fen).unwrap());
+        for depth in 1..=7 {
+            completed(e.search(depth));
+        }
+        assert!(e.ghi.stores > 0, "the search stored nothing");
+        assert!(
+            e.ghi.tainted_stores > 0,
+            "no draw taint was recorded: propagation is broken"
+        );
+        assert_eq!(
+            e.ghi.tainted_score_cutoffs, 0,
+            "a path dependent score was trusted"
+        );
+    }
+
+    #[test]
+    fn test_warm_cache_matches_cold_across_draw_context() {
+        // The same pieces hash to the same key whatever the fifty move counter
+        // says, so a search made a few plies from the draw fills the table
+        // with scores that are true of that path only. A fresh game reaching
+        // the same position must not read them: its search has the whole
+        // clock ahead of it.
+        let near_draw = "5k2/1p3p1p/p3pK1P/P1P1P3/4bP2/2B5/8/8 w - - 96 112";
+        let fresh = "5k2/1p3p1p/p3pK1P/P1P1P3/4bP2/2B5/8/8 w - - 0 1";
+        let mut warm = engine(Board::from_fen(near_draw).unwrap());
+        completed(warm.search(6));
+        warm.parse_fen(fresh).unwrap();
+        let result = completed(warm.search(6));
+
+        let mut cold = engine(Board::from_fen(fresh).unwrap());
+        let expected = completed(cold.search(6));
+        assert_eq!(result.score, expected.score);
+        assert_eq!(
+            format!("{}", result.best_move),
+            format!("{}", expected.best_move),
+        );
+    }
+
+    #[test]
     fn test_warm_cache_matches_cold_search() {
         // Searching a position with a cache warmed by unrelated positions must give the same
         // result as searching it with an empty cache


### PR DESCRIPTION
A score that came from a repetition or fifty move draw is true of the *path* that reached the position, not of the position. A later search arriving another way can read that draw and be wrong. This is graph history interaction — Campbell described it in 1985, Kishimoto and Müller solved it for proof number search in 2004, and classical engines largely shrug at it. It is in this repo's known issues already.

Nobody appears to publish how big the error is. Four commits: measure it, stop it, retire the workaround it replaces, and pin both directions.

## 1. Measure it

A taint bit on the score threads up through the search and into the stored entry: the repetition/fifty move `return Ok(0)` is the source, a value built from a tainted child is tainted, and mate, stalemate, evaluations and quiescence are not. The probe counts how often a cutoff consumes one.

Over the pinned positions at their pinned depths:

| position | stores | tainted | % | score cutoffs | tainted | % |
| --- | --- | --- | --- | --- | --- | --- |
| opening | 15,241 | 41 | 0.269% | 5,386 | 6 | 0.111% |
| kiwipete | 7,186 | 0 | 0.000% | 1,343 | 0 | 0.000% |
| pawn endgame | 18,038 | 334 | 1.852% | 7,207 | 229 | 3.177% |
| promotions | 4,391 | 0 | 0.000% | 1,374 | 0 | 0.000% |
| middlegame | 6,686 | 0 | 0.000% | 2,553 | 0 | 0.000% |
| **TOTAL** | 51,542 | 375 | 0.728% | 17,863 | 235 | **1.316%** |

Concentrated exactly where repetition threatens, and absent from the tactical positions — the shape you would predict, and some evidence the instrument measures the right thing.

**This is an upper bound, not the error.** A tainted score is only wrong when the draw it came from is unreachable by the path now reading it, and one bit cannot tell those apart. It is also five positions at one depth, so read it as a proof of instrument rather than as this engine's rate. Running it over positions from the bot's own games is the obvious way to make it a real figure.

The bit sits in the padding the key already leaves behind, so the table holds the same number of entries and this commit moves no node counts at all.

## 2. Stop it

The second commit refuses a score from a tainted entry, still using its move for ordering.

The price, straight from the pinned counts:

| position | before | after | change |
| --- | --- | --- | --- |
| opening | 149,810 | 149,866 | +0.037% |
| kiwipete | 217,026 | 217,026 | 0.000% |
| pawn endgame | 173,223 | 178,367 | +2.970% |
| promotions | 110,643 | 110,643 | 0.000% |
| middlegame | 191,607 | 191,607 | 0.000% |
| **TOTAL** | 842,309 | 847,509 | **+0.617%** |

The three positions with no tainted cutoffs to refuse moved by exactly zero nodes, which is a consistency check on both halves.

## 3. Retire the workaround

`make_move_str` cleared the played position's entry to keep a stale draw score from being trusted. That defence is now redundant in the direction it could actually see: the root reads only the stored *move* for ordering and never a score, and the refusal above covers the interior nodes for taint that flowed from a draw.

To be precise about what is not covered, since the commit retires a defence: `clear_key` also incidentally covered the **reverse** direction at that one position — a score stored with the draw out of reach, read later by a path with the draw in reach. The taint bit cannot see that, because the stored subtree never met a draw. So this is not "the problem is solved", it is "the half the workaround could see is now handled properly, and the other half was only ever covered at a single entry". The known issue is rewritten to describe the reverse direction rather than the workaround, and `HashTable::clear_key` goes with the call.

## 4. Pin both directions

With the refusal on, refused probes return before the counters, so `tainted_score_cutoffs == 0` is true *by construction* — asserting it alone would be a tautology. The load-bearing assertion is the other one: **`tainted_stores > 0`** in the draw-heaviest pinned position. If taint propagation ever breaks, the refusal goes on refusing nothing while the hole silently reopens, and that is the only assertion which would notice. The cutoff assertion stays as a tripwire for any future probe path added without the refusal guard.

There is also an answer-level test: search a position four plies from the fifty move draw, filling the table with path-true scores, then re-search the same pieces with a fresh counter and require the answer to match a cold engine's. **Verified to have teeth** — flipping the constant off makes exactly this test fail, and `parse_fen` does not clear the table, so the warm entries genuinely survive.

## Not tested for elo, deliberately

Six tenths of a percent of nodes is worth well under one elo, and `docs/DEVELOPMENT.md` puts the smallest difference five thousand games can distinguish at about eleven. A match would come back inconclusive after a day of runner time and the decision would then be made on principle anyway. So it is made on principle now, with the cost stated exactly in nodes rather than guessed at.

## Why now rather than later

Null move pruning is next on the TODO and interacts with repetition directly — a null move changes the side to move without changing the position, so it can manufacture apparent repetitions. With the instrument already in place the taint rate will move when null move lands, which turns folklore about that interaction into a number.

Worth noting from the last rebase: `perf(search): Try the table's move before generating any` added a second recursion site, and it needs the taint threading like any other child. A future search change that adds a recursion or a store has to do the same, which the `tainted_stores > 0` test is there to catch.

## Checks

- `cargo test --workspace --release` — 124 passed
- `cargo test --workspace` (debug assertions) — 124 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean