### PR TITLE
perf(search): Halve the default transposition table to 256MB

### DIFF
--- a/.github/workflows/calibrate.yml
+++ b/.github/workflows/calibrate.yml
@@ -135,10 +135,10 @@ jobs:
           engines=(-engine name=arche cmd=./arche)
           for rung in ${LADDER//,/ }; do
             tag=${rung%%:*}
-            # The engine's own table is 500MB and is not settable over uci, so
-            # the sides cannot be matched. 256MB is what ccrl gives an engine
-            # and the closest the opponents get, which leaves the engine a small
-            # advantage in exactly the direction that flatters the estimate.
+            # 256MB is what ccrl gives an engine, and now what this one
+            # gives itself, so both sides of the gauntlet hold the same number
+            # of positions. The engine's table is still not settable over uci,
+            # so that match is by coincidence rather than by configuration.
             engines+=(-engine "name=stash-${tag}" "cmd=./stash-${tag}" option.Hash=256)
           done
           # the engine allocates its table before it answers uci, which takes it

--- a/.github/workflows/strength.yml
+++ b/.github/workflows/strength.yml
@@ -163,7 +163,7 @@ jobs:
           # only fastchess and the book are cached, but a rerun on the same
           # runner would still find the last attempt's results lying here
           rm -f result.txt config.json
-          # the engine allocates a 500MB transposition table before it answers
+          # the engine allocates a 256MB transposition table before it answers
           # uci, which four copies starting at once can take longer over than
           # the ten second default allows
           ./fastchess \

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Binaries for linux, macos and windows are attached to each
 cargo build --release
 ```
 
-The binary is written to `target/release/arche`. Note that the engine allocates a 500MB
+The binary is written to `target/release/arche`. Note that the engine allocates a 256MB
 transposition table on startup and that the size is not yet configurable over UCI.
 
 ## Strength
@@ -58,7 +58,7 @@ docker run -e LICHESS_BOT_TOKEN=<token> ghcr.io/aywrite/arche-lichess-bot:master
 ```
 
 The token is a lichess API token for a bot account with the `bot:play` scope. The engine
-allocates a 500MB transposition table, so give the container at least 1GB of memory. To change
+allocates a 256MB transposition table, so give the container at least 512MB of memory. To change
 any other setting, mount a replacement over `/lichess-bot/config.yml`; the defaults are in
 `docker/config.yml`.
 
@@ -85,7 +85,7 @@ docker/smoke_test.sh arche-lichess-bot
 - read an opening book in the engine, only the lichess-bot image has one at the moment and it is
   lichess-bot that reads it rather than the engine
 - the rest of the uci protocol
-  - `setoption` is not handled and no options are advertised, so the 500MB transposition table
+  - `setoption` is not handled and no options are advertised, so the 256MB transposition table
     can only be changed in code
   - `stop` is not handled, which rules out pondering and `go infinite`
   - `ponderhit`, `debug` and `register` are not handled either

--- a/basic_engine/benches/benchmark.rs
+++ b/basic_engine/benches/benchmark.rs
@@ -41,7 +41,7 @@ bench_board_fen!(perft_3, b, {
     b.perft(3);
 });
 
-// The engine defaults to a 500MB transposition table, which is far more than a
+// The engine defaults to a 256MB transposition table, which is still far more than a
 // depth 5 search needs and makes clearing it between iterations cost more than
 // the search itself.
 const BENCH_TABLE_BYTES: usize = 16 * 1024 * 1024;

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -8,7 +8,7 @@ use std::time;
 
 const CHECKMATE_SCORE: Score = 30_000;
 const MAX_DEPTH: u8 = 20;
-const DEFAULT_TABLE_BYTES: usize = 500 * 1024 * 1024;
+const DEFAULT_TABLE_BYTES: usize = 256 * 1024 * 1024;
 // Any score this close to CHECKMATE_SCORE is a forced mate. Regular evals are
 // bounded by the material on the board, which cannot come near it.
 const CHECKMATE_THRESHOLD: Score = CHECKMATE_SCORE - 1000;

--- a/docker/config.yml
+++ b/docker/config.yml
@@ -31,7 +31,7 @@ engine:
     offer_draw_enabled: false
 
 challenge:
-  # Each engine process allocates a 500MB transposition table, so playing several
+  # Each engine process allocates a 256MB transposition table, so playing several
   # games at once needs a correspondingly larger memory limit on the container.
   concurrency: 1
   sort_by: "best"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -144,11 +144,12 @@ fastchess \
 
 Notes on the flags:
 
-- `-startup-ms 20000` is needed because the engine allocates its 500MB
+- `-startup-ms 20000` is needed because the engine allocates its 256MB
   transposition table before it answers `uci`, which four copies starting at
   once can take longer over than the ten second default allows. Generating the
   magic bitboards used to dominate this and no longer does, they are constants
-  now, so the allowance does not need to be anywhere near as generous as it was.
+  now, and the table is half what it once was, so the allowance is far more
+  generous than it still needs to be.
 - `-repeat` plays each opening twice with the colours reversed, which removes most
   of the advantage of drawing a good opening. It takes no argument, it is a spelling
   of `-games 2`.


### PR DESCRIPTION
Half a gigabyte was never sized against anything. It is more than the search can fill at the depths this engine reaches, and the part it cannot fill is not free: the table is probed at a random index at every node, so a larger one spreads those probes across more pages than the caches and the TLB can cover.

## Measured

Kiwipete at `go depth 9`, interleaved over **fourteen rounds**, current `master`:

| | 500MB | 256MB |
| --- | --- | --- |
| time | 6.02s | **5.81s** |
| rounds won | 0 | **14** |
| nodes to depth 9 | 50,349,221 | 50,603,608 |

It searches **0.5% more nodes** to reach the same depth. That is the smaller table holding fewer positions, and it is exactly the cost this change was expected to have — it just turns out locality more than pays for it.

Startup and footprint halve with it:

| | 500MB | 256MB |
| --- | --- | --- |
| time to answer `uci` | 0.16s | **0.08s** |
| peak RSS | 517,432 KB | **267,164 KB** |

Those probably matter more than the search figure. The table is written out in full before the engine answers `uci`, the strength workflow starts four copies of it at once, and the lichess image asks for a container sized to whatever this number says.

## Documentation

Every place that quoted 500MB as a fact is updated: the README build note, its Docker memory guidance (1GB down to 512MB) and its known-issues entry, `docker/config.yml`, the `-startup-ms` rationale in `docs/DEVELOPMENT.md`, the same rationale in `strength.yml`, and the benchmark comment. The two historical references in `CHANGELOG.md` and the commit-convention example in `DEVELOPMENT.md` are quoting past commit messages and are left alone.

One of those needed more than a number. `calibrate.yml` gives the gauntlet's opponents `option.Hash=256` because that is what ccrl gives an engine, and its comment apologised for the mismatch — the engine's own 500MB left it an advantage "in exactly the direction that flatters the estimate". Both sides now hold the same number of positions, so that apology is gone. It is still coincidence rather than configuration until the size is settable over uci, and the comment says so.

## Note

`test_node_counts_have_not_moved` is untouched, because the node-count tests size their own table rather than using this default.

There is an unmerged `uci-hash-option` branch which also changes this constant, to 128MB, alongside adding a UCI `Hash` option. This PR and that one will conflict on `DEFAULT_TABLE_BYTES` and on several of the same comments. Whichever lands second wants a rebase rather than a merge, and the choice of number should be made once rather than in two places.