### PR TITLE
Test the helper scripts and gate them in CI

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -1,0 +1,31 @@
+name: Scripts
+
+# The helper scripts parse other tools' output — fastchess results, criterion
+# comparisons, pgn files — so they rot silently when a format shifts. These
+# tests are the only thing standing between that and a release note quoting
+# the wrong number.
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+# a new push to a pull request makes the run in progress redundant
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run the script tests
+        run: |
+          python3 -m pip install --quiet pytest
+          python3 -m pytest scripts/tests -q

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -31,6 +31,15 @@ nothing about them.
 cargo test --workspace
 ```
 
+The helper scripts have tests of their own, run with pytest and gated in ci by
+the Scripts workflow. They pin the output formats the scripts parse — a
+fastchess result, a criterion comparison, a pgn — so an upstream that changes
+shape fails a test instead of quietly publishing the wrong number:
+
+```
+python3 -m pytest scripts/tests
+```
+
 ## Lints
 
 Both of these are gated in ci:

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -8,7 +8,11 @@ version="${1:?usage: changelog.sh <version>}"
 # Everything since the last full release rather than since the last tag, so that
 # a release preceded by candidates still lists all of its changes. git-cliff has
 # --ignore-tags, but it does not affect the range --unreleased picks.
-previous=$(git tag --list 'v[0-9]*' --sort=-v:refname | grep -v -- '-' | head -1)
+#
+# The || true is what keeps pipefail from killing the script when there is no
+# full release yet: grep exits 1 on finding nothing, and the empty answer is
+# the answer.
+previous=$(git tag --list 'v[0-9]*' --sort=-v:refname | grep -v -- '-' | head -1 || true)
 
 # A candidate does get a section, because the github release is created from the
 # section matching the tag and there is nothing to create it from otherwise. It

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,0 +1,8 @@
+"""The scripts are plain files rather than a package, so put their directory
+on the path and each test imports the one it covers as a module."""
+
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS))

--- a/scripts/tests/test_benchmark_summary.py
+++ b/scripts/tests/test_benchmark_summary.py
@@ -1,0 +1,86 @@
+"""Tests for the criterion comparison table.
+
+The parser reads criterion's human output, which criterion does not promise to
+keep stable. These fixtures are copies of the real shape, so a criterion
+upgrade that changes it fails here rather than publishing an empty table.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import benchmark_summary
+
+SCRIPT = Path(benchmark_summary.__file__)
+
+# criterion prints the id on its own line, then the measurements indented,
+# with the verdict last; the minus sign is U+2212, not a hyphen
+COMPARISON = """\
+Benchmarking generate_moves/start
+Benchmarking generate_moves/start: Collecting 100 samples in estimated 5s
+generate_moves/start
+                        time:   [88.123 ns 89.136 ns 90.312 ns]
+                        change: [+0.5000% +1.8959% +3.2000%] (p = 0.03 < 0.05)
+                        Performance has regressed.
+perft_3/start
+                        time:   [400.00 µs 410.00 µs 420.00 µs]
+                        change: [−2.0000% −1.0000% +0.1000%] (p = 0.20 > 0.05)
+                        No change in performance detected.
+brand_new_bench/start
+                        time:   [1.0000 ms 1.1000 ms 1.2000 ms]
+"""
+
+
+def test_each_benchmark_yields_time_change_and_verdict():
+    records = list(benchmark_summary.parse(COMPARISON.splitlines()))
+    assert records == [
+        (
+            "generate_moves/start",
+            "89.136 ns",
+            "+1.8959%",
+            "Performance has regressed",
+        ),
+        ("perft_3/start", "410.00 µs", "-1.0000%", "No change in performance detected"),
+        ("brand_new_bench/start", "1.1000 ms", None, "new"),
+    ]
+
+
+def test_criterions_minus_sign_becomes_a_hyphen():
+    records = list(benchmark_summary.parse(COMPARISON.splitlines()))
+    assert records[1][2] == "-1.0000%"
+    assert "−" not in records[1][2]
+
+
+def run(text):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        input=text,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_the_table_counts_regressions_and_sorts_worst_first():
+    result = run(COMPARISON)
+    assert result.returncode == 0
+    assert "1 of 3 benchmarks are slower." in result.stdout
+    rows = [line for line in result.stdout.splitlines() if line.startswith("| `")]
+    assert rows == [
+        "| `generate_moves/start` | 89.136 ns | +1.8959% | slower |",
+        "| `perft_3/start` | 410.00 µs | -1.0000% | no change |",
+        "| `brand_new_bench/start` | 1.1000 ms | no baseline | new |",
+    ]
+
+
+def test_nothing_slower_is_said_outright():
+    result = run(
+        COMPARISON.replace("Performance has regressed", "Performance has improved")
+    )
+    assert "None of the 3 benchmarks are slower." in result.stdout
+
+
+def test_empty_input_fails_rather_than_prints_an_empty_table():
+    result = run("")
+    assert result.returncode == 1
+    assert "No benchmark comparison was produced." in result.stdout

--- a/scripts/tests/test_changelog.py
+++ b/scripts/tests/test_changelog.py
@@ -1,0 +1,156 @@
+"""Tests for the changelog pre-release hook.
+
+git-cliff is replaced by a shim that records how it was called and prepends a
+marker section, so what is under test is everything the script itself decides:
+which sections survive, what range the changelog is generated over, and that
+running the hook twice leaves the same bytes as running it once.
+"""
+
+import os
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "changelog.sh"
+
+CHANGELOG = textwrap.dedent(
+    """\
+    # Changelog
+
+    ## [0.2.0-rc.1] - 2026-01-15
+
+    - candidate preview
+
+    ## [0.1.0] - 2025-12-01
+
+    - the first release
+    """
+)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A git repo one commit past its v0.1.0 release, with a git-cliff shim
+    on the path that logs its arguments and prepends a marker section."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args):
+        subprocess.run(
+            ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+
+    git("init", "-q")
+    (repo / "README").write_text("hi\n")
+    git("add", ".")
+    git("commit", "-qm", "init")
+    git("tag", "v0.1.0")
+    (repo / "README").write_text("hi again\n")
+    git("commit", "-aqm", "more")
+    (repo / "CHANGELOG.md").write_text(CHANGELOG)
+
+    shim_dir = tmp_path / "bin"
+    shim_dir.mkdir()
+    shim = shim_dir / "git-cliff"
+    shim.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import os
+            import sys
+            from pathlib import Path
+
+            args = sys.argv[1:]
+            Path(os.environ["CLIFF_LOG"]).write_text(" ".join(args) + "\\n")
+            tag = args[args.index("--tag") + 1]
+            target = Path(args[args.index("--prepend") + 1])
+            old = target.read_text() if target.exists() else ""
+            section = f"## [{tag}] - 2026-02-02\\n\\n- something new\\n\\n"
+            # the real git-cliff knows the changelog's header and prepends
+            # sections below it, so the shim inserts before the first section
+            # rather than at the top of the file
+            at = old.find("## [")
+            at = len(old) if at == -1 else at
+            target.write_text(old[:at] + section + old[at:])
+            """
+        )
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC)
+    return repo
+
+
+def run(repo, version):
+    env = dict(
+        os.environ,
+        PATH=f"{repo.parent / 'bin'}{os.pathsep}{os.environ['PATH']}",
+        CLIFF_LOG=str(repo.parent / "cliff_args"),
+    )
+    return subprocess.run(
+        [str(SCRIPT), version],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_candidates_are_superseded_and_full_releases_kept(repo):
+    result = run(repo, "0.2.0")
+    assert result.returncode == 0, result.stderr
+    changelog = (repo / "CHANGELOG.md").read_text()
+    assert "0.2.0-rc.1" not in changelog, "the candidate section should be gone"
+    assert "## [0.1.0] - 2025-12-01" in changelog, (
+        "a full release must survive: the dashes in its date must not read"
+        " as a pre-release marker"
+    )
+    assert changelog.count("## [0.2.0]") == 1
+
+
+def test_the_range_starts_at_the_last_full_release(repo):
+    # an rc tag newer than the release must not shorten the range, or the
+    # release after a run of candidates would only list what changed since
+    # the last candidate
+    subprocess.run(
+        ["git", "tag", "v0.2.0-rc.1"], cwd=repo, check=True, capture_output=True
+    )
+    result = run(repo, "0.2.0")
+    assert result.returncode == 0, result.stderr
+    args = (repo.parent / "cliff_args").read_text()
+    assert "v0.1.0..HEAD" in args
+
+
+def test_running_twice_leaves_the_same_bytes_as_running_once(repo):
+    # the hook has to be safe to run twice over, so the section it wrote last
+    # time is dropped and rewritten rather than duplicated
+    run(repo, "0.2.0")
+    once = (repo / "CHANGELOG.md").read_bytes()
+    result = run(repo, "0.2.0")
+    assert result.returncode == 0, result.stderr
+    assert (repo / "CHANGELOG.md").read_bytes() == once
+
+
+def test_no_release_yet_covers_everything(repo):
+    # with no full release tagged there is no range to cut, the whole history
+    # is the changelog
+    subprocess.run(
+        ["git", "tag", "-d", "v0.1.0"], cwd=repo, check=True, capture_output=True
+    )
+    result = run(repo, "0.1.0")
+    assert result.returncode == 0, result.stderr
+    assert "no previous release" in result.stdout
+    args = (repo.parent / "cliff_args").read_text()
+    assert ".." not in args
+
+
+def test_a_missing_changelog_is_created_rather_than_an_error(repo):
+    (repo / "CHANGELOG.md").unlink()
+    result = run(repo, "0.2.0")
+    assert result.returncode == 0, result.stderr
+    assert "## [0.2.0]" in (repo / "CHANGELOG.md").read_text()

--- a/scripts/tests/test_match_summary.py
+++ b/scripts/tests/test_match_summary.py
@@ -1,0 +1,68 @@
+"""Tests for the one line match summary.
+
+The input is fastchess's result block, so the fixtures are copies of real
+output: what this guards against is the parse quietly matching the wrong
+number when that format shifts.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import match_summary
+
+SCRIPT = Path(match_summary.__file__)
+
+# the shape fastchess prints after every round, tail of a real run
+RESULT = """\
+--------------------------------------------------
+Results of new vs old (10+0.1, NULL, NULL, 8moves_v3.pgn):
+Elo: 6.95 +/- 45.36, nElo: 14.84 +/- 96.30
+LOS: 61.87 %, DrawRatio: 68.00 %, PairsRatio: 1.00
+Games: 50, Wins: 15, Losses: 14, Draws: 21, Points: 25.5 (51.00 %)
+Ptnml(0-2): [0, 4, 17, 3, 1], WL/DD Ratio: 1.43
+--------------------------------------------------
+"""
+
+
+def run(tmp_path, text):
+    result_file = tmp_path / "result.txt"
+    result_file.write_text(text)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(result_file)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_the_elo_line_is_read_and_rounded(tmp_path):
+    result = run(tmp_path, RESULT)
+    assert result.returncode == 0
+    assert result.stdout == "+7 ±45 Elo (50 games)\n"
+
+
+def test_the_elo_figure_is_not_confused_with_nelo(tmp_path):
+    # nElo sits on the same line with a much larger margin, the lookbehind is
+    # what keeps the parse off it
+    assert match_summary.ELO.findall(RESULT) == [("6.95", "45.36")]
+
+
+def test_the_last_block_wins(tmp_path):
+    # fastchess prints an interim block every few games, only the final one
+    # describes the whole match
+    interim = RESULT.replace("6.95 +/- 45.36", "-40.00 +/- 80.00").replace(
+        "Games: 50", "Games: 10"
+    )
+    result = run(tmp_path, interim + RESULT)
+    assert result.stdout == "+7 ±45 Elo (50 games)\n"
+
+
+def test_a_losing_result_keeps_its_sign(tmp_path):
+    result = run(tmp_path, RESULT.replace("6.95", "-12.60"))
+    assert result.stdout == "-13 ±45 Elo (50 games)\n"
+
+
+def test_output_without_a_result_block_fails_rather_than_invents(tmp_path):
+    result = run(tmp_path, "fastchess crashed before printing anything\n")
+    assert result.returncode != 0

--- a/scripts/tests/test_rating_estimate.py
+++ b/scripts/tests/test_rating_estimate.py
@@ -1,0 +1,202 @@
+"""Tests for the gauntlet rating estimate.
+
+The fixed points here are chess statistics rather than implementation detail:
+the logistic model says what score a rating difference earns, so the fit can be
+checked against numbers computed by hand.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import rating_estimate
+
+SCRIPT = Path(rating_estimate.__file__)
+
+
+def game(white, black, result):
+    """One pgn game record, shaped the way fastchess writes them."""
+    return (
+        f'[Event "gauntlet"]\n'
+        f'[White "{white}"]\n'
+        f'[Black "{black}"]\n'
+        f'[Result "{result}"]\n'
+        f"\n1. e4 e5 {result}\n\n"
+    )
+
+
+class TestExpectedAndImplied:
+    def test_equal_ratings_expect_an_even_score(self):
+        assert rating_estimate.expected(1600, 1600) == 0.5
+
+    def test_the_stronger_side_expects_more(self):
+        assert rating_estimate.expected(1700, 1600) > 0.5
+        assert rating_estimate.expected(1500, 1600) < 0.5
+
+    def test_an_even_score_implies_the_opponent_rating(self):
+        assert rating_estimate.implied(1600, 5, 10) == pytest.approx(1600)
+
+    def test_three_quarters_implies_the_textbook_gap(self):
+        # 75% is the logistic model's worked example: 400 * log10(3) ≈ 191
+        assert rating_estimate.implied(1600, 7.5, 10) == pytest.approx(1790.85, abs=0.1)
+
+    def test_a_sweep_is_capped_rather_than_infinite(self):
+        assert rating_estimate.implied(1600, 10, 10) == 1600 + 1200
+        assert rating_estimate.implied(1600, 0, 10) == 1600 - 1200
+
+
+class TestReadLadder:
+    def test_names_and_ratings_are_parsed(self):
+        assert rating_estimate.read_ladder("a:1500,b:1600") == {"a": 1500, "b": 1600}
+
+    def test_whitespace_and_empty_entries_are_tolerated(self):
+        assert rating_estimate.read_ladder(" a:1500 , ,b:1600,") == {
+            "a": 1500,
+            "b": 1600,
+        }
+
+    def test_a_name_containing_a_colon_splits_on_the_last_one(self):
+        assert rating_estimate.read_ladder("stash:v10:1620") == {"stash:v10": 1620}
+
+    def test_malformed_entries_stop_the_run(self):
+        for spec in ["", "1600", "name:", "name:notanumber"]:
+            with pytest.raises(SystemExit):
+                rating_estimate.read_ladder(spec)
+
+
+class TestFit:
+    def test_an_even_score_fits_the_opponent_rating(self):
+        estimate, note = rating_estimate.fit([("a", 1600, 10, 0, 10)])
+        assert estimate.rating == pytest.approx(1600, abs=0.5)
+        assert note == ""
+
+    def test_three_quarters_fits_the_textbook_gap(self):
+        estimate, _ = rating_estimate.fit([("a", 1600, 15, 0, 5)])
+        assert estimate.rating == pytest.approx(1790.85, abs=0.5)
+        assert 0 < estimate.margin < 400
+
+    def test_a_sweep_is_reported_as_a_bound_not_a_number(self):
+        estimate, _ = rating_estimate.fit([("a", 1600, 10, 0, 0), ("b", 1700, 4, 0, 0)])
+        assert str(estimate) == "above 1700 on the ccrl blitz scale (14 games)"
+
+    def test_losing_every_game_bounds_from_below(self):
+        estimate, _ = rating_estimate.fit([("a", 1600, 0, 0, 10), ("b", 1500, 0, 0, 4)])
+        assert str(estimate) == "below 1500 on the ccrl blitz scale (14 games)"
+
+    def test_all_draws_still_carry_a_margin(self):
+        # every game alike leaves no observed spread, the fallback to the
+        # modelled spread is what keeps the margin from reading as zero doubt
+        estimate, _ = rating_estimate.fit([("a", 1600, 0, 20, 0)])
+        assert estimate.rating == pytest.approx(1600, abs=0.5)
+        assert estimate.margin > 0
+
+    def test_draws_shrink_the_margin_decisive_games_do_not(self):
+        # both scored 50%, but a drawish 50% wobbles less than a decisive one,
+        # which is the point of using the observed variance over the modelled
+        drawish, _ = rating_estimate.fit([("a", 1600, 5, 10, 5)])
+        decisive, _ = rating_estimate.fit([("a", 1600, 10, 0, 10)])
+        assert drawish.margin < decisive.margin
+
+    def test_opponents_that_disagree_are_called_out(self):
+        _, note = rating_estimate.fit([("a", 1600, 10, 0, 0), ("b", 1600, 0, 0, 10)])
+        assert "disagree" in note
+
+    def test_consistent_opponents_raise_no_note(self):
+        _, note = rating_estimate.fit([("a", 1600, 6, 0, 4), ("b", 1700, 4, 0, 6)])
+        assert note == ""
+
+    def test_the_chi_square_cutoff_matches_the_table(self):
+        # 3.841 at one degree of freedom; the approximation is allowed a
+        # couple of percent, which is what its docstring promises
+        assert rating_estimate.chi_square_95(1) == pytest.approx(3.841, rel=0.03)
+
+
+LADDER = {"stash-v11": 1690.0, "stash-v12": 1886.0}
+
+
+class TestReadPairings:
+    def read(self, tmp_path, text):
+        pgn = tmp_path / "gauntlet.pgn"
+        pgn.write_text(text)
+        return rating_estimate.read_pairings(pgn, "arche", dict(LADDER))
+
+    def test_results_are_tallied_from_both_colours(self, tmp_path, capsys):
+        pairings = self.read(
+            tmp_path,
+            game("arche", "stash-v11", "1-0")
+            + game("stash-v11", "arche", "1-0")
+            + game("arche", "stash-v11", "1/2-1/2")
+            + game("stash-v12", "arche", "0-1"),
+        )
+        assert pairings == [
+            ("stash-v11", 1690.0, 1, 1, 1),
+            ("stash-v12", 1886.0, 1, 0, 0),
+        ]
+        assert capsys.readouterr().err == ""
+
+    def test_games_between_other_engines_are_ignored(self, tmp_path, capsys):
+        pairings = self.read(
+            tmp_path,
+            game("stash-v11", "stash-v12", "1-0") + game("arche", "stash-v11", "1-0"),
+        )
+        assert pairings == [("stash-v11", 1690.0, 1, 0, 0)]
+
+    def test_a_rung_with_no_games_is_dropped_and_said(self, tmp_path, capsys):
+        pairings = self.read(tmp_path, game("arche", "stash-v11", "1-0"))
+        assert [name for name, *_ in pairings] == ["stash-v11"]
+        assert "stash-v12 played no games" in capsys.readouterr().err
+
+    def test_an_unfinished_game_is_counted_out_loud_not_fitted(self, tmp_path, capsys):
+        pairings = self.read(
+            tmp_path,
+            game("arche", "stash-v11", "*") + game("arche", "stash-v11", "1-0"),
+        )
+        assert pairings == [("stash-v11", 1690.0, 1, 0, 0)]
+        assert "1 game with no result" in capsys.readouterr().err
+
+    def test_a_truncated_game_cannot_borrow_the_next_result(self, tmp_path, capsys):
+        # a game cut off before its result tag once paired its players with
+        # the following game's result, which dropped a rung from the fit
+        truncated = (
+            '[Event "gauntlet"]\n[White "arche"]\n[Black "stash-v11"]\n\n1. e4\n\n'
+        )
+        pairings = self.read(tmp_path, truncated + game("arche", "stash-v12", "1-0"))
+        assert pairings == [("stash-v12", 1886.0, 1, 0, 0)]
+        assert "1 game with no result" in capsys.readouterr().err
+
+
+class TestCommandLine:
+    def run(self, tmp_path, text, *args):
+        pgn = tmp_path / "gauntlet.pgn"
+        pgn.write_text(text)
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), str(pgn), "arche", "stash-v11:1690", *args],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    GAMES = (
+        game("arche", "stash-v11", "1-0")
+        + game("stash-v11", "arche", "0-1")
+        + game("arche", "stash-v11", "1/2-1/2")
+        + game("stash-v11", "arche", "1-0")
+    )
+
+    def test_the_table_and_the_estimate_are_printed(self, tmp_path):
+        result = self.run(tmp_path, self.GAMES)
+        assert result.returncode == 0
+        assert "| stash-v11 | 1690 | 2-1-1 | 62.5% |" in result.stdout
+        assert "on the ccrl blitz scale (4 games)" in result.stdout
+
+    def test_line_mode_prints_the_estimate_alone(self, tmp_path):
+        result = self.run(tmp_path, self.GAMES, "--line")
+        assert result.returncode == 0
+        assert result.stdout.count("\n") == 1
+        assert "on the ccrl blitz scale (4 games)" in result.stdout
+
+    def test_no_games_for_the_engine_is_an_error(self, tmp_path):
+        result = self.run(tmp_path, game("a", "b", "1-0"))
+        assert result.returncode != 0
+        assert "no games for arche" in result.stderr

--- a/scripts/tests/test_resolve_ref.py
+++ b/scripts/tests/test_resolve_ref.py
@@ -1,0 +1,97 @@
+"""Tests for the workflow ref resolver.
+
+The fixture is a local upstream standing in for github, so every form a
+workflow input can take is resolved offline: a commit already present, a
+branch or tag that has to be fetched, and a bare number meaning a pull
+request's head.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "resolve_ref.sh"
+
+
+def git(cwd, *args):
+    return subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def clone(tmp_path):
+    """A clone of a local upstream that has a release tag, a branch created
+    after the clone was taken, and a pull request head ref."""
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    git(upstream, "init", "-q")
+    (upstream / "README").write_text("one\n")
+    git(upstream, "add", ".")
+    git(upstream, "commit", "-qm", "first")
+    git(upstream, "tag", "v1.0.0")
+
+    clone = tmp_path / "clone"
+    git(tmp_path, "clone", "-q", str(upstream), str(clone))
+
+    # everything after the clone only exists upstream, like a push made
+    # after a workflow's checkout
+    (upstream / "README").write_text("two\n")
+    git(upstream, "commit", "-aqm", "second")
+    git(upstream, "branch", "-q", "feature")
+    git(upstream, "update-ref", "refs/pull/7/head", "HEAD")
+    return clone
+
+
+def resolve(clone, ref):
+    return subprocess.run(
+        [str(SCRIPT), ref],
+        cwd=clone,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def head_of(clone, upstream_ref):
+    return git(clone, "ls-remote", "origin", upstream_ref).split()[0]
+
+
+def test_a_commit_already_here_resolves_without_fetching(clone):
+    sha = git(clone, "rev-parse", "HEAD")
+    result = resolve(clone, sha)
+    assert result.returncode == 0
+    assert result.stdout.strip() == sha
+
+
+def test_a_tag_resolves_to_its_commit(clone):
+    result = resolve(clone, "v1.0.0")
+    assert result.returncode == 0
+    assert result.stdout.strip() == git(clone, "rev-parse", "HEAD")
+
+
+def test_a_branch_only_upstream_is_fetched_by_name(clone):
+    result = resolve(clone, "feature")
+    assert result.returncode == 0
+    assert result.stdout.strip() == head_of(clone, "refs/heads/feature")
+
+
+def test_a_number_means_a_pull_request_head(clone):
+    result = resolve(clone, "7")
+    assert result.returncode == 0
+    assert result.stdout.strip() == head_of(clone, "refs/pull/7/head")
+
+
+def test_a_ref_that_exists_nowhere_fails(clone):
+    result = resolve(clone, "no-such-ref")
+    assert result.returncode != 0
+
+
+def test_a_number_with_no_pull_request_fails(clone):
+    result = resolve(clone, "999")
+    assert result.returncode != 0


### PR DESCRIPTION
Item 1 from the test audit: the helper scripts parse other tools' output — fastchess results, criterion comparisons, pgn files — so they rot silently when a format shifts, and until now nothing ran them at all. This adds 47 pytest tests under `scripts/tests/` and a small **Scripts** workflow that runs them on every PR and push to master (a few seconds of runtime).

## What the tests pin

- **rating_estimate** — the logistic fit against hand-computed values (75% score → +191 Elo), sweeps reported as one-sided bounds rather than numbers, the all-draws modelled-variance fallback, draws shrinking the margin relative to decisive games, the chi-square disagreement note firing (and not firing on consistent data), ladder parsing errors, and the two regressions this script has already had in its life: a truncated game borrowing the next game's result, and unfinished games being counted out loud.
- **match_summary** — the `Elo:` figure read without snagging on `nElo:` beside it, the final result block beating interim ones, sign handling, and input with no result block failing rather than inventing a number.
- **benchmark_summary** — criterion's real output shape (id line, indented time/change/verdict, the U+2212 minus sign), new benchmarks flagged, regressions counted and sorted worst first, empty input exiting 1.
- **changelog** — `git-cliff` is replaced by a shim that records its arguments and mimics header-aware prepending, so what's under test is everything the script itself decides: rc-section supersession (with full releases' dashed dates untouched), the range starting at the last *full* release past any rc tags, byte-identical idempotency, and both the tag and no-tag branches.
- **resolve_ref** — a local upstream stands in for GitHub, covering a commit already present, a tag, a branch that has to be fetched, a pull-request number, and two failure modes, all offline.

The fixtures are copies of real output on purpose: when an upstream format changes, the failing test is the one that names what broke.

## A bug the tests found

`fix(release)`: the pipeline in `changelog.sh` that finds the last full release ends in `grep`, which exits 1 on finding nothing — and under `set -euo pipefail` that killed the script before its "no previous release, covering everything" branch could ever run. It never bit because this repository has always had a release tag, but a clone taken without tags (or a fresh project) died on the first line. Reproduced directly before fixing; both branches are covered now.

## Verification

- `python3 -m pytest scripts/tests` — 47 passed
- `ruff check` and `ruff format` clean (the pre-commit hooks' settings)
- `shellcheck` unaffected (no committed shell changes beyond the one-line fix; the git-cliff shim is generated inside the test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhiJhdHPF8YDStbv8Wbsm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhiJhdHPF8YDStbv8Wbsm9)_