### PR TITLE
Add SPRT support for sequential hypothesis testing in strength workflow

### DIFF
--- a/.github/workflows/strength.yml
+++ b/.github/workflows/strength.yml
@@ -10,6 +10,13 @@ name: Strength
 # Fifty games only separates versions that differ by a hundred elo or so. A
 # change worth a handful needs thousands, so raise the count and shorten the
 # time control when the answer matters.
+#
+# Or ask the narrower question instead: sprt runs a sequential test that stops
+# the moment the games so far settle whether the candidate is stronger, rather
+# than playing a count chosen in advance. games then caps the match instead of
+# sizing it, so it can be set generously, and a match that reaches the cap, or
+# the time cap below, reports inconclusive rather than pretending the games it
+# played were enough.
 
 on:
   workflow_dispatch:
@@ -21,13 +28,25 @@ on:
         description: What to measure it against. Same forms. Defaults to the last full release.
         type: string
       games:
-        description: Games to play, rounded down to an even number
+        description: Games to play, rounded down to an even number. With sprt this is the cap, not the size, so set it generously.
         type: number
         default: 50
       time_control:
         description: Passed to fastchess as tc
         type: string
         default: 10+0.1
+      sprt:
+        description: Stop as soon as the games settle whether the candidate is stronger, instead of playing them all
+        type: boolean
+        default: false
+      elo0:
+        description: SPRT null hypothesis, in elo. Accepting it (H0) means the candidate is not stronger.
+        type: number
+        default: 0
+      elo1:
+        description: SPRT alternative, in elo. Accepting it (H1) means the candidate is stronger by about this much or more.
+        type: number
+        default: 10
   workflow_call:
     inputs:
       candidate:
@@ -42,6 +61,15 @@ on:
       time_control:
         type: string
         default: 10+0.1
+      sprt:
+        type: boolean
+        default: false
+      elo0:
+        type: number
+        default: 0
+      elo1:
+        type: number
+        default: 10
       publish:
         description: Append the result to the release notes for this tag
         type: boolean
@@ -123,6 +151,13 @@ jobs:
     env:
       GAMES: ${{ inputs.games }}
       TIME_CONTROL: ${{ inputs.time_control }}
+      SPRT: ${{ inputs.sprt }}
+      ELO0: ${{ inputs.elo0 }}
+      ELO1: ${{ inputs.elo1 }}
+      # the wall clock cap on play alone. It sits inside the job's timeout with
+      # room for the builds before it and the summary after, so a match stopped
+      # by the clock still reports the games it did play
+      MAX_MATCH_MINUTES: 150
       CANDIDATE: ${{ needs.resolve.outputs.candidate_name }}
       CANDIDATE_SHA: ${{ needs.resolve.outputs.candidate_sha }}
       PREVIOUS: ${{ needs.resolve.outputs.baseline_name }}
@@ -163,16 +198,36 @@ jobs:
           # only fastchess and the book are cached, but a rerun on the same
           # runner would still find the last attempt's results lying here
           rm -f result.txt config.json
+          sprt=()
+          if [ "$SPRT" = "true" ]; then
+            # logistic keeps the bounds in the same elo the summary reports.
+            # Alpha and beta are the error rates the verdicts are accepted at:
+            # a wrong H1 one run in twenty, a wrong H0 the same
+            sprt=(-sprt "elo0=$ELO0" "elo1=$ELO1" alpha=0.05 beta=0.05 model=logistic)
+          fi
           # the engine allocates a 256MB transposition table before it answers
           # uci, which four copies starting at once can take longer over than
-          # the ten second default allows
-          ./fastchess \
+          # the ten second default allows.
+          #
+          # INT is the signal fastchess takes as a request to stop, report the
+          # games played so far and exit, and 124 is how timeout says it had to
+          # send it. An sprt match that never settles is stopped by the games
+          # cap or this clock, whichever arrives first; either way the summary
+          # step still runs on what was played
+          status=0
+          timeout -k 60 -s INT "${MAX_MATCH_MINUTES}m" ./fastchess \
             -engine "name=$CANDIDATE" cmd=./new \
             -engine "name=$PREVIOUS" cmd=./old \
             -each proto=uci "tc=$TIME_CONTROL" -startup-ms 20000 \
             -openings file=8moves_v3.pgn format=pgn order=random \
             -rounds "$((GAMES / 2))" -repeat -concurrency 2 -recover \
-            | tee result.txt
+            "${sprt[@]}" \
+            | tee result.txt || status=$?
+          if [ "$status" = "124" ]; then
+            echo "::warning::The match hit the ${MAX_MATCH_MINUTES} minute cap before the game count"
+          elif [ "$status" != "0" ]; then
+            exit "$status"
+          fi
 
       - name: Summarise the result
         id: summary
@@ -188,7 +243,11 @@ jobs:
             echo
             echo "$line"
             echo
-            echo "At ${GAMES} games only a difference of about $(python3 -c "print(int(800/(${GAMES}**0.5)))") elo can be told from none."
+            if [ "$SPRT" = "true" ]; then
+              echo "SPRT stops when the games settle the question at a five percent error rate each way: H1 accepted means stronger by about ${ELO1} elo or more, H0 accepted means not, and inconclusive means the cap of ${GAMES} games or ${MAX_MATCH_MINUTES} minutes arrived first."
+            else
+              echo "At ${GAMES} games only a difference of about $(python3 -c "print(int(800/(${GAMES}**0.5)))") elo can be told from none."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
   release-notes:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -197,6 +197,35 @@ arbitrary commits compared by naming both.
 The release workflow calls the same workflow with fifty games, and that run is
 the only one that appends its result to the release notes.
 
+### Asking whether instead of how much
+
+A fixed count answers "how big is the difference", and the table above says how
+badly. The question a change usually poses is the narrower "is there one", and
+that is what the `sprt` input asks. With it enabled, fastchess runs a
+[sequential probability ratio test](https://en.wikipedia.org/wiki/Sequential_probability_ratio_test):
+after every game it weighs the score so far as evidence between two hypotheses,
+and stops the moment either is accepted. A change worth well more than `elo1`
+settles in tens of games, one worth nothing settles almost as fast, and only a
+difference near the bounds needs the games a fixed match would have spent
+anyway. The verdicts are wrong at the accepted error rates, five percent each
+way.
+
+- `elo0` and `elo1` are the hypotheses, in the same elo the summary reports.
+  The defaults ask "is this worth ten elo, or nothing" — about the size of
+  change worth an afternoon at this engine's strength. Bounds closer together
+  resolve smaller differences and pay for it in games.
+- `games` stops sizing the match and becomes its cap, so set it in the
+  hundreds or thousands: the test stops itself long before a cap it can settle
+  inside of. Play is also capped at 150 minutes of wall clock, inside the
+  job's own three hour timeout, so a test that would not have finished still
+  reports the games it played.
+- A match stopped by either cap says `inconclusive` next to its estimate,
+  which is the honest reading: the games played did not settle the question.
+
+The same test can be run locally by adding
+`-sprt elo0=0 elo1=10 alpha=0.05 beta=0.05 model=logistic` to the fastchess
+command above, with `-rounds` raised to serve as the cap.
+
 ## Placing the engine on the ccrl scale
 
 A match against the previous version says which of the two is better. It cannot

--- a/scripts/match_summary.py
+++ b/scripts/match_summary.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Print the elo estimate from a fastchess result file."""
+"""Print the elo estimate, and any sprt verdict, from a fastchess result file."""
 
 import re
 import sys
@@ -8,13 +8,43 @@ from pathlib import Path
 # the lookbehind keeps this from matching the nElo figure on the same line
 ELO = re.compile(r"(?<![A-Za-z])Elo:\s*(-?[\d.]+)\s*\+/-\s*([\d.]+)")
 GAMES = re.compile(r"Games:\s*(\d+)")
+POINTS = re.compile(r"Points:\s*[\d.]+\s*\(([\d.]+)\s*%\)")
+# fastchess only prints an LLR line when it was run under -sprt, so the line
+# doubles as the sign that there is a verdict to look for
+LLR = re.compile(r"LLR:.*(\[[^\]]+\])")
+# printed the moment the log likelihood ratio crosses a bound. A match that
+# hits a cap first stops without printing one
+VERDICT = re.compile(r"SPRT \(\[[^\]]+\]\) completed - (H[01]) was accepted")
+
+
+def estimate(text: str) -> str:
+    games = GAMES.findall(text)[-1]
+    found = ELO.findall(text)
+    if not found:
+        # every game pair went the same way: fastchess prints the elo as inf,
+        # and the score is all there is to report
+        score = POINTS.findall(text)[-1]
+        return f"{score}% score ({games} games)"
+    elo, margin = found[-1]
+    return f"{round(float(elo)):+d} ±{round(float(margin))} Elo ({games} games)"
+
+
+def verdict(text: str) -> str:
+    """The sprt verdict, or nothing for a match that was not run under -sprt."""
+    bounds = LLR.findall(text)
+    if not bounds:
+        return ""
+    accepted = VERDICT.findall(text)
+    if not accepted:
+        return f", SPRT {bounds[-1]} inconclusive"
+    hypothesis = accepted[-1]
+    reading = "stronger" if hypothesis == "H1" else "not stronger"
+    return f", SPRT {bounds[-1]} accepted {hypothesis}: {reading}"
 
 
 def main() -> None:
     text = Path(sys.argv[1]).read_text()
-    elo, margin = ELO.findall(text)[-1]
-    games = GAMES.findall(text)[-1]
-    print(f"{round(float(elo)):+d} ±{round(float(margin))} Elo ({games} games)")
+    print(f"{estimate(text)}{verdict(text)}")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_match_summary.py
+++ b/scripts/tests/test_match_summary.py
@@ -66,3 +66,66 @@ def test_a_losing_result_keeps_its_sign(tmp_path):
 def test_output_without_a_result_block_fails_rather_than_invents(tmp_path):
     result = run(tmp_path, "fastchess crashed before printing anything\n")
     assert result.returncode != 0
+
+
+# the tail of a real run under -sprt: the LLR line is only printed then, and
+# the verdict line only once the log likelihood ratio crosses a bound
+SPRT_H0 = """\
+--------------------------------------------------
+Results of new vs old (1+0.01 - 5 plies, NULL, NULL):
+Elo: -inf +/- -nan, nElo: -inf +/- -nan
+LOS: 0.00 %, DrawRatio: 0.00 %, PairsRatio: 0.00
+Games: 142, Wins: 0, Losses: 142, Draws: 0, Points: 0.0 (0.00 %)
+Ptnml(0-2): [71, 0, 0, 0, 0], WL/DD Ratio: -nan
+LLR: -2.95 (-100.1%) (-2.94, 2.94) [0.00, 10.00]
+--------------------------------------------------
+SPRT ([0.00, 10.00]) completed - H0 was accepted
+"""
+
+# the same run stopped by a cap instead: fastchess reports the games played
+# and exits without a verdict line
+SPRT_CAPPED = """\
+--------------------------------------------------
+Results of new vs old (1+0.01, NULL, NULL):
+Elo: 58.45 +/- 81.32, nElo: 65.66 +/- 87.91
+LOS: 92.84 %, DrawRatio: 53.33 %, PairsRatio: 2.50
+Games: 60, Wins: 34, Losses: 24, Draws: 2, Points: 35.0 (58.33 %)
+Ptnml(0-2): [4, 0, 16, 2, 8], WL/DD Ratio: inf
+LLR: 0.31 (10.6%) (-2.94, 2.94) [0.00, 10.00]
+--------------------------------------------------
+Tournament was interrupted. To resume the tournament, run: ./fastchess -config file=config.json
+"""
+
+
+def test_an_accepted_h1_reads_as_stronger(tmp_path):
+    accepted = SPRT_CAPPED.replace(
+        "Tournament was interrupted. To resume the tournament, run: ./fastchess -config file=config.json",
+        "SPRT ([0.00, 10.00]) completed - H1 was accepted",
+    )
+    result = run(tmp_path, accepted)
+    assert result.stdout == (
+        "+58 ±81 Elo (60 games), SPRT [0.00, 10.00] accepted H1: stronger\n"
+    )
+
+
+def test_an_accepted_h0_reads_as_not_stronger(tmp_path):
+    # a sweep as well as a verdict: every game pair went the same way, so
+    # fastchess prints the elo as inf and only the score can be reported
+    result = run(tmp_path, SPRT_H0)
+    assert result.stdout == (
+        "0.00% score (142 games), SPRT [0.00, 10.00] accepted H0: not stronger\n"
+    )
+
+
+def test_a_capped_sprt_match_is_inconclusive(tmp_path):
+    result = run(tmp_path, SPRT_CAPPED)
+    assert result.stdout == (
+        "+58 ±81 Elo (60 games), SPRT [0.00, 10.00] inconclusive\n"
+    )
+
+
+def test_a_fixed_match_gets_no_sprt_annotation(tmp_path):
+    # the LLR line is the marker of an sprt run, a plain match must not grow
+    # a verdict
+    result = run(tmp_path, RESULT)
+    assert "SPRT" not in result.stdout


### PR DESCRIPTION
## Summary
This PR adds support for Sequential Probability Ratio Testing (SPRT) to the strength measurement workflow, allowing faster determination of whether a candidate engine is stronger than a baseline by stopping as soon as statistical evidence settles the question, rather than playing a fixed number of games.

## Key Changes

- **Workflow inputs**: Added three new optional inputs to both `workflow_dispatch` and `workflow_call`:
  - `sprt` (boolean, default: false): Enable sequential testing
  - `elo0` (number, default: 0): Null hypothesis threshold in elo
  - `elo1` (number, default: 10): Alternative hypothesis threshold in elo
  - Updated `games` parameter description to clarify it becomes a cap rather than a fixed size when SPRT is enabled

- **Match execution**: Modified the fastchess invocation to:
  - Conditionally build SPRT arguments based on the `sprt` input flag
  - Add a 150-minute wall clock timeout using `timeout` command with INT signal handling
  - Properly capture exit status to distinguish between timeout (124) and other failures
  - Log a warning when the match hits the time cap

- **Result summary**: Enhanced the summary step to:
  - Display SPRT-specific messaging when enabled, explaining the verdict interpretation
  - Show the original fixed-game elo uncertainty calculation when SPRT is disabled
  - Report whether the test was conclusive or hit a cap

- **Result parsing**: Updated `match_summary.py` to:
  - Extract and report SPRT verdicts (H0/H1 acceptance or inconclusive)
  - Handle edge cases where all games go the same way (infinite elo)
  - Display both the elo estimate and SPRT verdict in a single line

- **Documentation**: Added comprehensive section in `DEVELOPMENT.md` explaining:
  - The difference between fixed-count and sequential testing approaches
  - How to interpret SPRT results and error rates
  - Guidance on setting `elo0`, `elo1`, and `games` parameters
  - Instructions for running SPRT locally

## Implementation Details

- SPRT uses logistic model with 5% error rates (alpha and beta) for both hypotheses
- The 150-minute play cap sits inside the job's 3-hour timeout to allow time for builds and summary
- Timeout sends INT signal to fastchess, which gracefully stops and reports games played so far
- A match hitting either the games cap or time cap reports "inconclusive" rather than claiming statistical significance

https://claude.ai/code/session_01KYHZrAnmNtuKTFEw171ty6