### PR TITLE
fix(search): Show quiescence the promotions that capture nothing

### DIFF
--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -369,8 +369,9 @@ impl Board {
         }
     }
 
-    /// The subset of generate_moves with a capture, in the same order, made
-    /// without generating the quiet moves only to filter them out.
+    /// The subset of generate_moves that changes material, the captures and
+    /// the promoting pushes, in the same order, made without generating the
+    /// quiet moves only to filter them out.
     pub fn generate_captures(&self) -> MoveList {
         self.generate::<true>()
     }
@@ -526,8 +527,11 @@ impl Board {
                     moves.push(Play::new(from, to, capture, None, false, false));
                 }
             }
-            if !CAPTURES_ONLY {
-                // move forward
+            // move forward. A promotion changes the material on the board the
+            // way a capture does, so the captures list keeps the promoting
+            // pushes and drops only the quiet ones: quiescence would otherwise
+            // stand a pawn on the seventh and score it as a pawn
+            if !CAPTURES_ONLY || can_promote {
                 let to = match self.active_color {
                     Color::White => from as isize + 8,
                     Color::Black => from as isize - 8,
@@ -1485,11 +1489,14 @@ mod make_move {
         ($func:ident, $f:expr) => {
             #[test]
             fn $func() {
+                // the captures list is the material changing subset of the
+                // full list: the captures and the promoting pushes, in the
+                // same order
                 let board = Board::from_fen($f).unwrap();
                 let filtered_captures: super::MoveList = board
                     .generate_moves()
                     .iter()
-                    .filter(|c| c.capture.is_some())
+                    .filter(|c| c.capture.is_some() || c.promote.is_some())
                     .map(|c| c.clone())
                     .collect();
                 let captures = board.generate_captures();
@@ -1511,6 +1518,21 @@ mod make_move {
         "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10"
     );
     test_fen_captures!(position_3, "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1");
+
+    #[test]
+    fn a_quiet_promotion_is_in_the_captures_list() {
+        // a pawn on the seventh with an empty square ahead: the push captures
+        // nothing but changes material like a capture does, and it is the
+        // only material changing move here
+        let board = Board::from_fen("4k3/P7/8/8/8/8/8/4K3 w - - 0 1").unwrap();
+        let captures = board.generate_captures();
+        assert_eq!(captures.len(), 4, "one push for each promotion piece");
+        for m in &captures {
+            assert_eq!(format!("{}", m)[..4].to_string(), "a7a8");
+            assert!(m.promote.is_some());
+            assert!(m.capture.is_none());
+        }
+    }
 
     #[test]
     fn test_long_game_does_not_run_off_the_history() {

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -177,8 +177,8 @@ impl AlphaBeta {
     }
 
     fn quiescence(&mut self, mut alpha: Score, beta: Score) -> Result<Score, Aborted> {
-        // quiescence looks at captures alone and never checks for a repetition,
-        // so nothing it returns is path dependent
+        // quiescence looks at captures and promotions alone and never checks
+        // for a repetition, so nothing it returns is path dependent
         self.tainted = false;
         self.selective_depth = self.selective_depth.max(self.board.line_ply as u8);
         if self.board.line_ply >= MAX_DEPTH.into() {
@@ -537,7 +537,8 @@ impl AlphaBeta {
                 break;
             };
             if matches!(pv.bound, Bound::Ordering) {
-                // written by quiescence, which looks at captures alone, so the
+                // written by quiescence, which looks at captures and
+                // promotions alone, so the
                 // move is fit for ordering the next search and not for telling
                 // anyone what the engine intends to play
                 break;
@@ -931,6 +932,19 @@ mod test_search {
     }
 
     #[test]
+    fn test_the_horizon_sees_a_promotion_coming() {
+        // the rook can win the knight across the board or take the pawn one
+        // step from promoting. The pawn's push captures nothing, so
+        // quiescence used not to generate it: the knight looked free to take
+        // and the queen appeared only after the horizon. Taking the pawn is
+        // the move.
+        let game = Board::from_fen("4k3/8/8/R5n1/8/8/p5K1/8 w - - 0 1").unwrap();
+        let mut e = engine(game);
+        let result = completed(e.search(1));
+        assert_eq!(format!("{}", result.best_move), "a5a2");
+    }
+
+    #[test]
     fn test_a_shallow_search_still_sees_the_recapture() {
         // the queen can take a pawn which another pawn defends. A depth one
         // search ends on the capture, so only quiescence sees the recapture
@@ -1251,7 +1265,8 @@ mod test_search {
 
     #[test]
     fn test_pv_line_does_not_follow_a_quiescence_entry() {
-        // quiescence looks at captures alone, so its move is fit for ordering
+        // quiescence looks at captures and promotions alone, so its move is
+        // fit for ordering
         // the next search and not for saying what the engine means to play
         let mut e = engine(Board::new());
         let play = play_named(&e.board, "e2e4");
@@ -1547,9 +1562,9 @@ mod test_node_counts {
             counted,
             vec![
                 ("opening", 150_344),
-                ("kiwipete", 222_186),
-                ("pawn endgame", 175_279),
-                ("promotions", 109_349),
+                ("kiwipete", 230_576),
+                ("pawn endgame", 175_329),
+                ("promotions", 109_409),
                 ("middlegame", 188_234),
             ]
         );


### PR DESCRIPTION
## What

`generate_captures` (the list quiescence searches) only kept promotions that capture — the promoting *push* sat inside the quiet-moves-only block, so a pawn queening on an empty square was invisible at the horizon and a pawn on the seventh was scored as a pawn. Promotion races were misjudged by most of a queen.

The generator now includes promoting pushes when `CAPTURES_ONLY`: the captures list becomes exactly the material-changing subset of the full move list, in the same order. Quiet single and double pushes stay excluded.

## Tests

- The `test_fen_captures!` invariant macro now pins the new definition (`capture.is_some() || promote.is_some()`) — its existing `promotion` fixture position has a quiet g1-promotion available, so the macro itself exercises the change.
- `a_quiet_promotion_is_in_the_captures_list` — a lone pawn on the seventh: the captures list is exactly the four promoting pushes.
- `test_the_horizon_sees_a_promotion_coming` — the motivating position: a rook offered a knight on one wing while an enemy pawn sits one uncontested push from queening on the other. Verified to fail on master (it grabbed the knight); with the fix it takes the pawn.

Node counts move only where promotion races live in the tree (kiwipete +3.8%, since its h3xg2 lines now follow through to the promotion square; the pawn-heavy positions barely move), updated in the same commit. Full suite green in release and debug, clippy and fmt clean.

Follow-up candidate (not in this PR): `mvv_lva` still scores promotions as 0, so they order with the quiet dross rather than near the good captures — worth doing together with wider move-ordering work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYHZrAnmNtuKTFEw171ty6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYHZrAnmNtuKTFEw171ty6)_