### PR TITLE
Test tidy: shared fens, one move lookup, tables instead of macros, sentence names

### DIFF
--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -1344,55 +1344,88 @@ impl fmt::Display for Board {
     }
 }
 
+/// Positions the test modules share, named for what they bring within reach.
+/// Kept here so a fen appears once, and so a suite that wants, say, a position
+/// with promotions available does not grow another copy with a different move
+/// counter.
+#[cfg(test)]
+pub(crate) mod fens {
+    /// The starting position.
+    pub const START: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+    /// Kiwipete, the standard tactical middlegame: checks, pins, castling and
+    /// an en passant square all within a move or two.
+    pub const KIWIPETE: &str =
+        "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1";
+    /// A rook and pawn endgame, position 3 of the standard perft suite.
+    pub const PAWN_ENDGAME: &str = "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1";
+    /// Promotions for both sides on the next move, position 5 of the standard
+    /// perft suite.
+    pub const PROMOTIONS: &str = "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8";
+    /// A black pawn one push from promoting, with an en passant square set.
+    pub const EN_PASSANT_PROMOTION: &str =
+        "rnbqkbnr/pp1ppppp/8/2p5/3Pp3/8/PPPP1PpP/RNBQKB1R b KQkq e5 0 2";
+    /// A symmetric middlegame where both sides have castled, white to move.
+    /// Position 6 of the standard perft suite.
+    pub const MIDDLEGAME: &str =
+        "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10";
+    /// The same position with black to move, which the repetition tests
+    /// shuffle rooks in: a8b8 a1b1 b8a8 b1a1 comes straight back to it.
+    pub const SHUFFLE: &str =
+        "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 b - - 3 19";
+    /// The four positions the accumulator and reversibility suites iterate:
+    /// between them promotions, castling, en passant and a bare endgame are
+    /// all in reach.
+    pub const CORE: [&str; 4] = [START, EN_PASSANT_PROMOTION, MIDDLEGAME, PAWN_ENDGAME];
+}
+
+/// The move of this name in this position, so a test can name a line the way
+/// the rest of the world writes it.
+#[cfg(test)]
+pub(crate) fn play_named(board: &Board, name: &str) -> Play {
+    *board
+        .generate_moves()
+        .iter()
+        .find(|m| format!("{}", m) == name)
+        .unwrap_or_else(|| panic!("{} is not a move here", name))
+}
+
 #[cfg(test)]
 mod evaluate {
-    use super::Board;
-
-    use super::Game;
+    use super::fens;
+    use super::{Board, Game};
     use pretty_assertions::assert_eq;
 
-    macro_rules! test_fen {
-        ($func:ident, $f:expr) => {
-            #[test]
-            fn $func() {
-                let mut board = Board::from_fen($f).unwrap();
-                for m in &board.generate_moves() {
-                    if board.make_move(m) {
-                        assert_eq!(
-                            (board.white_value, board.black_value),
-                            board.material_value()
-                        );
-                        let score = board.eval();
-                        board.active_color = !board.active_color;
-                        let opp_score = board.eval();
-                        assert_eq!(score, -opp_score);
-                        board.active_color = !board.active_color;
-                        board.undo_move();
-                    }
+    /// After every legal move in the shared positions, the material
+    /// accumulators must equal a recount, and the score must be the exact
+    /// negative of the opponent's view of it.
+    #[test]
+    fn material_stays_counted_and_the_eval_stays_antisymmetric() {
+        for fen in fens::CORE {
+            let mut board = Board::from_fen(fen).unwrap();
+            for m in &board.generate_moves() {
+                if board.make_move(m) {
+                    assert_eq!(
+                        (board.white_value, board.black_value),
+                        board.material_value(),
+                        "{} in {}",
+                        m,
+                        fen
+                    );
+                    let score = board.eval();
+                    board.active_color = !board.active_color;
+                    assert_eq!(score, -board.eval(), "{} in {}", m, fen);
+                    board.active_color = !board.active_color;
+                    board.undo_move();
                 }
             }
-        };
+        }
     }
-
-    test_fen!(
-        initial_position,
-        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-    );
-    test_fen!(
-        promotion,
-        "rnbqkbnr/pp1ppppp/8/2p5/3Pp3/8/PPPP1PpP/RNBQKB1R b KQkq e5 0 2"
-    );
-    test_fen!(
-        castling,
-        "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10"
-    );
-    test_fen!(position_3, "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1");
 
     /// The assertions above hold whichever way up the piece square tables are,
     /// because both colours read them the same way and the symmetry survives.
     /// These say which way is up.
     #[test]
-    fn test_a_pawn_is_worth_more_the_closer_it_is_to_promoting() {
+    fn a_pawn_is_worth_more_the_closer_it_is_to_promoting() {
         let advanced = Board::from_fen("4k3/4P3/8/8/8/8/8/4K3 w - - 0 1").unwrap();
         let home = Board::from_fen("4k3/8/8/8/8/8/4P3/4K3 w - - 0 1").unwrap();
         assert!(
@@ -1404,7 +1437,7 @@ mod evaluate {
     }
 
     #[test]
-    fn test_a_pawn_is_worth_more_the_closer_it_is_to_promoting_for_black_too() {
+    fn a_pawn_is_worth_more_the_closer_it_is_to_promoting_for_black_too() {
         let advanced = Board::from_fen("4k3/8/8/8/8/8/4p3/4K3 b - - 0 1").unwrap();
         let home = Board::from_fen("4k3/4p3/8/8/8/8/8/4K3 b - - 0 1").unwrap();
         assert!(
@@ -1420,7 +1453,7 @@ mod evaluate {
     /// since that happens to both colours at once, but it does catch one colour
     /// being changed without the other.
     #[test]
-    fn test_a_mirrored_position_scores_the_same() {
+    fn a_mirrored_position_scores_the_same() {
         for (white, black) in [
             (
                 "4k3/4P3/8/8/8/8/8/4K3 w - - 0 1",
@@ -1444,80 +1477,43 @@ mod evaluate {
 
 #[cfg(test)]
 mod make_move {
-    use super::Board;
-    use super::Game;
-    use super::Play;
+    use super::fens;
     use super::{A1, A8, B1, B8, MAX_GAME_SIZE};
+    use super::{Board, Game, Play};
     use pretty_assertions::{assert_eq, assert_ne};
 
-    macro_rules! test_fen_reversible {
-        ($func:ident, $f:expr) => {
-            #[test]
-            fn $func() {
-                let board = Board::from_fen($f).unwrap();
-                for m in &board.generate_moves() {
-                    let old = board.clone();
-                    let mut new = board.clone();
-                    if new.make_move(m) {
-                        assert_ne!(old, new);
-                        new.undo_move();
-                        assert_eq!(old, new);
-                    }
+    /// Every legal move must change the position, and unmaking it must give
+    /// back a board equal in every field.
+    #[test]
+    fn every_move_unmakes_back_to_the_position_it_left() {
+        for fen in fens::CORE {
+            let board = Board::from_fen(fen).unwrap();
+            for m in &board.generate_moves() {
+                let mut played = board;
+                if played.make_move(m) {
+                    assert_ne!(board, played, "{} in {}", m, fen);
+                    played.undo_move();
+                    assert_eq!(board, played, "{} in {}", m, fen);
                 }
             }
-        };
+        }
     }
 
-    test_fen_reversible!(
-        initial_position_reversible,
-        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-    );
-    test_fen_reversible!(
-        promotion_reversible,
-        "rnbqkbnr/pp1ppppp/8/2p5/3Pp3/8/PPPP1PpP/RNBQKB1R b KQkq e5 0 2"
-    );
-    test_fen_reversible!(
-        castling_reversible,
-        "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10"
-    );
-    test_fen_reversible!(
-        position_3_reversible,
-        "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1"
-    );
-
-    macro_rules! test_fen_captures {
-        ($func:ident, $f:expr) => {
-            #[test]
-            fn $func() {
-                // the captures list is the material changing subset of the
-                // full list: the captures and the promoting pushes, in the
-                // same order
-                let board = Board::from_fen($f).unwrap();
-                let filtered_captures: super::MoveList = board
-                    .generate_moves()
-                    .iter()
-                    .filter(|c| c.capture.is_some() || c.promote.is_some())
-                    .map(|c| c.clone())
-                    .collect();
-                let captures = board.generate_captures();
-                assert_eq!(captures, filtered_captures);
-            }
-        };
+    /// The captures list is the material changing subset of the full list:
+    /// the captures and the promoting pushes, in the same order.
+    #[test]
+    fn the_captures_list_is_the_material_changing_subset() {
+        for fen in fens::CORE {
+            let board = Board::from_fen(fen).unwrap();
+            let filtered: super::MoveList = board
+                .generate_moves()
+                .iter()
+                .filter(|c| c.capture.is_some() || c.promote.is_some())
+                .copied()
+                .collect();
+            assert_eq!(board.generate_captures(), filtered, "in {}", fen);
+        }
     }
-
-    test_fen_captures!(
-        initial_position,
-        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-    );
-    test_fen_captures!(
-        promotion,
-        "rnbqkbnr/pp1ppppp/8/2p5/3Pp3/8/PPPP1PpP/RNBQKB1R b KQkq e5 0 2"
-    );
-    test_fen_captures!(
-        castling,
-        "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10"
-    );
-    test_fen_captures!(position_3, "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1");
 
     #[test]
     fn a_quiet_promotion_is_in_the_captures_list() {
@@ -1535,18 +1531,13 @@ mod make_move {
     }
 
     #[test]
-    fn test_long_game_does_not_run_off_the_history() {
+    fn a_long_game_does_not_run_off_the_history() {
         // games which reached about move 175 used to panic in is_repetition
         let mut board = Board::new();
         let cycle = ["g1f3", "b8c6", "f3g1", "c6b8"];
         for i in 0..400 {
-            let name = cycle[i % 4];
-            let m = *board
-                .generate_moves()
-                .iter()
-                .find(|m| format!("{}", m) == name)
-                .unwrap_or_else(|| panic!("move {} not found at ply {}", name, i));
-            assert!(board.make_move(&m));
+            let play = super::play_named(&board, cycle[i % 4]);
+            assert!(board.make_move(&play), "failed at ply {}", i);
             board.is_repetition();
         }
     }
@@ -1597,7 +1588,7 @@ mod make_move {
     }
 
     #[test]
-    fn test_is_repetition_with_fifty_move_count_beyond_history() {
+    fn a_fifty_move_count_beyond_the_history_is_not_a_repetition() {
         // the fifty move counter from the fen is larger than the history we hold
         let board = Board::from_fen("5k2/1p3p1p/p3pK1P/P1P1P3/4bP2/2B5/8/8 w - - 99 1").unwrap();
         assert_eq!(board.is_repetition(), false);
@@ -1607,16 +1598,14 @@ mod make_move {
     /// come back once, either side can take the draw, so there is nothing to be
     /// gained by spending four more plies of depth confirming it.
     #[test]
-    fn test_has_repeated_fires_a_cycle_before_is_repetition() {
-        let mut board = Board::from_fen(
-            "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 b - - 3 19",
-        )
-        .unwrap();
+    fn has_repeated_fires_a_cycle_before_is_repetition() {
+        let mut board = Board::from_fen(fens::SHUFFLE).unwrap();
         let cycle = [(A8, B8), (A1, B1), (B8, A8), (B1, A1)];
         assert_eq!(board.has_repeated(), false);
-        assert_eq!(board.is_repetition(), false);
 
         for (from, to) in cycle {
+            // and no false positives anywhere on the way round
+            assert_eq!(board.is_repetition(), false);
             board.make_move(&Play::new(from, to, None, None, false, false));
         }
         // first repeat: a draw is available, so the search stops here
@@ -1624,37 +1613,11 @@ mod make_move {
         assert_eq!(board.is_repetition(), false);
 
         for (from, to) in cycle {
+            assert_eq!(board.is_repetition(), false);
             board.make_move(&Play::new(from, to, None, None, false, false));
         }
         // second repeat: the game is actually drawn
         assert_eq!(board.has_repeated(), true);
-        assert_eq!(board.is_repetition(), true);
-    }
-
-    #[test]
-    fn test_is_repetition() {
-        let mut board = Board::from_fen(
-            "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 b - - 3 19",
-        )
-        .unwrap();
-        // Position 1
-        assert_eq!(board.is_repetition(), false);
-        board.make_move(&Play::new(A8, B8, None, None, false, false));
-        board.make_move(&Play::new(A1, B1, None, None, false, false));
-        assert_eq!(board.is_repetition(), false);
-        board.make_move(&Play::new(B8, A8, None, None, false, false));
-        assert_eq!(board.is_repetition(), false);
-        board.make_move(&Play::new(B1, A1, None, None, false, false));
-        assert_eq!(board.is_repetition(), false);
-        // Position 1 - (first repeat)
-        board.make_move(&Play::new(A8, B8, None, None, false, false));
-        assert_eq!(board.is_repetition(), false);
-        board.make_move(&Play::new(A1, B1, None, None, false, false));
-        assert_eq!(board.is_repetition(), false);
-        board.make_move(&Play::new(B8, A8, None, None, false, false));
-        assert_eq!(board.is_repetition(), false);
-        board.make_move(&Play::new(B1, A1, None, None, false, false));
-        // Position 1 - (second repeat)
         assert_eq!(board.is_repetition(), true);
     }
 }
@@ -1680,13 +1643,9 @@ mod position_key {
         board.debug_assert_state_in_step();
     }
 
-    fn play_move(board: &mut Board, mv: &str) {
-        let m = *board
-            .generate_moves()
-            .iter()
-            .find(|m| format!("{}", m) == mv)
-            .unwrap_or_else(|| panic!("move {} not found", mv));
-        assert!(board.make_move(&m));
+    fn play_move(board: &mut Board, name: &str) {
+        let play = super::play_named(board, name);
+        assert!(board.make_move(&play), "failed to play {}", name);
     }
 
     #[test]
@@ -1730,11 +1689,7 @@ mod position_key {
         // half of this that has to match make_move or the fix is worse than the
         // problem
         let mut played = Board::from_fen("4k3/7p/8/8/8/8/P7/4K3 w - - 0 1").unwrap();
-        let a2a4 = *played
-            .generate_moves()
-            .iter()
-            .find(|m| format!("{}", m) == "a2a4")
-            .expect("a2a4 is a move here");
+        let a2a4 = super::play_named(&played, "a2a4");
         assert!(played.make_move(&a2a4));
         let parsed = Board::from_fen("4k3/7p/8/8/P7/8/8/4K3 b - - 0 1").unwrap();
         assert_eq!(played.key, parsed.key);
@@ -1744,11 +1699,7 @@ mod position_key {
     #[test]
     fn a_double_push_which_can_be_answered_still_records_the_square() {
         let mut played = Board::from_fen("4k3/8/8/8/1p6/8/P7/4K3 w - - 0 1").unwrap();
-        let a2a4 = *played
-            .generate_moves()
-            .iter()
-            .find(|m| format!("{}", m) == "a2a4")
-            .expect("a2a4 is a move here");
+        let a2a4 = super::play_named(&played, "a2a4");
         assert!(played.make_move(&a2a4));
         let parsed = Board::from_fen("4k3/8/8/8/Pp6/8/8/4K3 b - a3 0 1").unwrap();
         assert_eq!(played.key, parsed.key);
@@ -1810,27 +1761,23 @@ mod position_key {
 
 #[cfg(test)]
 mod perft {
-    use super::Board;
-    use super::Game;
+    use super::fens;
+    use super::{Board, Game};
     use pretty_assertions::assert_eq;
 
     /// The six standard positions, with their counts from depth one up to the
     /// depth the suite can afford. Positions and results taken from
     /// https://www.chessprogramming.org/Perft_Results
     const CASES: [(&str, &str, &[u64]); 6] = [
-        (
-            "the starting position",
-            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
-            &[20, 400, 8902],
-        ),
+        ("the starting position", fens::START, &[20, 400, 8902]),
         (
             "position 2, kiwipete",
-            "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+            fens::KIWIPETE,
             &[48, 2039, 97_862, 4_085_603],
         ),
         (
             "position 3",
-            "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+            fens::PAWN_ENDGAME,
             &[14, 191, 2812, 43_238, 674_624, 11_030_083],
         ),
         (
@@ -1840,18 +1787,18 @@ mod perft {
         ),
         (
             "position 5",
-            "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
+            fens::PROMOTIONS,
             &[44, 1486, 62_379, 2_103_487],
         ),
         (
             "position 6",
-            "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10",
+            fens::MIDDLEGAME,
             &[46, 2079, 89_890, 3_894_594],
         ),
     ];
 
     #[test]
-    fn test_perft_standard_positions() {
+    fn the_standard_positions_count_exactly() {
         for (description, fen, counts) in CASES {
             let mut board = Board::from_fen(fen).unwrap();
             for (i, &expected) in counts.iter().enumerate() {
@@ -1869,9 +1816,9 @@ mod perft {
 }
 
 #[cfg(test)]
-mod test_fen {
-    use super::Board;
-    use super::Game;
+mod fen_parsing {
+    use super::fens;
+    use super::{Board, Game};
     use proptest::prelude::*;
 
     proptest! {
@@ -1887,14 +1834,12 @@ mod test_fen {
     }
 
     #[test]
-    fn test_starting() {
-        assert!(
-            Board::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").is_ok()
-        );
+    fn the_starting_position_parses() {
+        assert!(Board::from_fen(fens::START).is_ok());
     }
 
     #[test]
-    fn test_from_wikipedia() -> Result<(), String> {
+    fn the_wikipedia_examples_parse() -> Result<(), String> {
         Board::from_fen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")?;
         Board::from_fen("rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq c6 0 2")?;
         Board::from_fen("rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2")?;
@@ -1902,14 +1847,14 @@ mod test_fen {
     }
 
     #[test]
-    fn test_invalid_extra_ranks() {
+    fn too_many_ranks_are_rejected() {
         assert!(
             Board::from_fen("rnbqkbnr/pppppppp/8/8/8/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")
                 .is_err()
         );
     }
     #[test]
-    fn test_invalid_extra_slash() {
+    fn a_doubled_slash_is_rejected() {
         assert!(
             Board::from_fen("rnbqkbnr/pppppppp/8/8//4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")
                 .is_err()
@@ -1918,7 +1863,7 @@ mod test_fen {
     /// A ninth file used to wrap back onto the a file and corrupt the square
     /// it landed on, rather than fail to parse.
     #[test]
-    fn test_invalid_extra_file() {
+    fn a_ninth_file_is_rejected() {
         assert!(
             Board::from_fen("rnbqkbnr/ppppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")
                 .is_err()
@@ -1930,7 +1875,7 @@ mod test_fen {
         );
     }
     #[test]
-    fn test_invalid_bad_piece() {
+    fn an_unknown_piece_letter_is_rejected() {
         assert!(
             Board::from_fen("rnbqkbnar/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")
                 .is_err()
@@ -1966,8 +1911,8 @@ mod test_fen {
 
 #[cfg(test)]
 mod perft_edge_cases {
-    use super::Board;
-    use super::Game;
+    use super::fens;
+    use super::{Board, Game};
     use pretty_assertions::assert_eq;
 
     /// Positions that the six standard perft positions do not reach: the two
@@ -2061,7 +2006,7 @@ mod perft_edge_cases {
             "stalemate and checkmate again",
         ),
         (
-            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            fens::START,
             5,
             4_865_609,
             "the start, deeper than the other suite goes",
@@ -2117,7 +2062,7 @@ mod perft_edge_cases {
     ];
 
     #[test]
-    fn test_perft_edge_cases() {
+    fn every_edge_case_counts_exactly() {
         for (fen, depth, expected, description) in CASES {
             let mut board = Board::from_fen(fen).unwrap();
             assert_eq!(
@@ -2134,9 +2079,8 @@ mod perft_edge_cases {
 
 #[cfg(test)]
 mod pseudo_legal {
-    use super::Board;
-    use super::Game;
-    use super::Play;
+    use super::fens;
+    use super::{Board, Game, Play};
     use crate::misc::Piece;
 
     /// "d4" to the index the board uses, so the cases below read as squares
@@ -2157,10 +2101,10 @@ mod pseudo_legal {
     }
 
     const POSITIONS: [&str; 5] = [
-        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
-        "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
-        "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
-        "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
+        fens::START,
+        fens::KIWIPETE,
+        fens::PAWN_ENDGAME,
+        fens::PROMOTIONS,
         "r2q1rk1/1b1nbppp/p2ppn2/1p6/3NPP2/1BN1B3/PPPQ2PP/2KR3R w - - 0 13",
     ];
 
@@ -2232,18 +2176,18 @@ mod pseudo_legal {
 
 #[cfg(test)]
 mod random_games {
-    use super::Board;
-    use super::Game;
+    use super::fens;
+    use super::{Board, Game};
     use proptest::prelude::*;
 
     /// Walks start from positions with different machinery in reach: the
     /// opening with castling ahead of it, a tactical middlegame, a bare
     /// endgame, and a position full of promotions.
     const STARTS: [&str; 4] = [
-        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
-        "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
-        "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
-        "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
+        fens::START,
+        fens::KIWIPETE,
+        fens::PAWN_ENDGAME,
+        fens::PROMOTIONS,
     ];
 
     proptest! {

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -824,12 +824,13 @@ impl SearchResult {
 }
 
 #[cfg(test)]
-mod test_search {
+mod search {
     use super::AlphaBeta;
     use super::Board;
     use super::Engine;
     use super::Game;
     use super::{Bound, Play, Pv, SearchOutcome, SearchResult};
+    use crate::board::{fens, play_named};
     use pretty_assertions::assert_eq;
     use std::time;
 
@@ -843,6 +844,10 @@ mod test_search {
         AlphaBeta::with_table_bytes(board, TABLE_BYTES)
     }
 
+    /// A tactical middlegame the cache tests search over and over: sharp
+    /// enough that a wrongly reused score would move the verdict.
+    const SHARP_MIDDLEGAME: &str = "r1b2rk1/ppp1qppp/4pn2/6N1/Qn1P4/2NBP3/PP3PPP/R3K2R w KQ - 9 12";
+
     /// Unwrap the outcome these tests expect: a search that ran to the depth
     /// asked of it.
     fn completed(outcome: SearchOutcome) -> SearchResult {
@@ -850,16 +855,6 @@ mod test_search {
             SearchOutcome::Complete(result) => result,
             other => panic!("expected a completed search, got {:?}", other),
         }
-    }
-
-    /// The move of this name in this position, so that a test can name a line
-    /// the way the rest of the world does.
-    fn play_named(board: &Board, name: &str) -> Play {
-        *board
-            .generate_moves()
-            .iter()
-            .find(|m| format!("{}", m) == name)
-            .unwrap_or_else(|| panic!("{} is not a move here", name))
     }
 
     /// An entry of the kind a completed search leaves behind.
@@ -875,7 +870,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_regression_bad_cache() {
+    fn a_losing_position_is_still_losing_with_a_warm_table() {
         // This is a losing position but running a search on a previous position then the losing
         // position seems to cause hash/cache collisions in some cases.
         let game =
@@ -888,9 +883,7 @@ mod test_search {
             result.score
         );
 
-        let game =
-            Board::from_fen("r1b2rk1/ppp1qppp/4pn2/6N1/Qn1P4/2NBP3/PP3PPP/R3K2R w KQ - 9 12")
-                .unwrap();
+        let game = Board::from_fen(SHARP_MIDDLEGAME).unwrap();
         let mut e = engine(game);
         completed(e.search(7));
         let _ = e.parse_fen("r4rk1/pppb1ppp/4pn2/6N1/3P4/2qBP3/P4PPP/3R1R1K w - - 2 16");
@@ -899,7 +892,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_checkmate_in_2_white() {
+    fn checkmate_in_two_is_found_for_white() {
         let game =
             Board::from_fen("2rr3k/pp3pp1/1nnqbN1p/3pN3/2pP4/2P3Q1/PPB4P/R4RK1 w - - 0 0").unwrap();
         let mut e = engine(game);
@@ -909,7 +902,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_checkmate_in_2_white_warm_cache() {
+    fn the_mate_distance_survives_a_deeper_warm_search() {
         let game =
             Board::from_fen("2rr3k/pp3pp1/1nnqbN1p/3pN3/2pP4/2P3Q1/PPB4P/R4RK1 w - - 0 0").unwrap();
         let mut e = engine(game);
@@ -923,7 +916,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_checkmate_in_1_black() {
+    fn checkmate_in_one_is_found_for_black() {
         let game =
             Board::from_fen("2rr3k/pp3pp1/1nnqbNQp/3pN3/2pP4/2P5/PPB4P/R4RK1 b - - 1 1").unwrap();
         let mut e = engine(game);
@@ -932,7 +925,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_the_horizon_sees_a_promotion_coming() {
+    fn the_horizon_sees_a_promotion_coming() {
         // the rook can win the knight across the board or take the pawn one
         // step from promoting. The pawn's push captures nothing, so
         // quiescence used not to generate it: the knight looked free to take
@@ -945,7 +938,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_a_shallow_search_still_sees_the_recapture() {
+    fn a_shallow_search_still_sees_the_recapture() {
         // the queen can take a pawn which another pawn defends. A depth one
         // search ends on the capture, so only quiescence sees the recapture
         // that loses the queen for it. Shallow searches used to skip
@@ -957,7 +950,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_deepening_through_shallow_depths_matches_a_cold_search() {
+    fn deepening_through_shallow_depths_matches_a_cold_search() {
         // iterations shallower than four used to store scores whose leaves
         // were never quiesced, and deeper iterations then read those entries
         // back as if they had been: the same depth then answered differently
@@ -990,7 +983,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_fifty_move_rule_play_for_draw() {
+    fn a_losing_side_plays_for_the_fifty_move_draw() {
         // white is down material in this position so should play for fifty move draw
         let game = Board::from_fen("5k2/1p3p1p/p3pK1P/P1P1P3/4bP2/2B5/8/8 w - - 99 112").unwrap();
         let mut e = engine(game);
@@ -999,7 +992,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_fifty_move_rule_game_over() {
+    fn a_triggered_fifty_move_rule_is_game_over() {
         // The fifty move rule has been triggered - the game is already drawn,
         // there is no move to look for
         let game = Board::from_fen("5k2/1p3p1p/p3pK1P/P1P1P3/4bP2/2B5/8/8 w - - 100 112").unwrap();
@@ -1008,7 +1001,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_checkmated_root_is_game_over() {
+    fn a_checkmated_root_is_game_over() {
         // fool's mate: white to move with no reply
         let game = Board::from_fen("rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 1 3")
             .unwrap();
@@ -1017,21 +1010,21 @@ mod test_search {
     }
 
     #[test]
-    fn test_stalemated_root_is_game_over() {
+    fn a_stalemated_root_is_game_over() {
         let game = Board::from_fen("k7/8/1Q6/8/8/8/8/7K b - - 0 1").unwrap();
         let mut e = engine(game);
         assert!(matches!(e.search(3), SearchOutcome::GameOver));
     }
 
     #[test]
-    fn test_search_with_no_time_budget_aborts_without_a_move() {
+    fn a_search_with_no_time_budget_aborts_without_a_move() {
         let mut e = engine(Board::new());
         e.configure(time::Instant::now(), Some(time::Duration::ZERO));
         assert!(matches!(e.search(5), SearchOutcome::Aborted(None)));
     }
 
     #[test]
-    fn test_timed_out_deepening_still_returns_a_move() {
+    fn timed_out_deepening_still_returns_a_move() {
         // The budget runs out long before MAX_DEPTH can complete, so the
         // deepening loop ends on an Aborted outcome and must fall back to a
         // completed iteration's move
@@ -1047,7 +1040,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_deepening_reports_each_completed_depth() {
+    fn deepening_reports_each_completed_depth() {
         use super::SearchParameters;
         let mut e = engine(Board::new());
         let mut depths = Vec::new();
@@ -1063,7 +1056,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_deepening_stops_reporting_at_game_over() {
+    fn deepening_stops_reporting_at_game_over() {
         use super::SearchParameters;
         // fool's mate again: there is nothing to report and nothing to play
         let game = Board::from_fen("rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 1 3")
@@ -1077,7 +1070,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_deepening_to_depth_zero_finds_nothing() {
+    fn deepening_to_depth_zero_finds_nothing() {
         use super::SearchParameters;
         let mut e = engine(Board::new());
         let outcome =
@@ -1086,7 +1079,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_draw_taint_is_still_recorded_and_never_trusted() {
+    fn draw_taint_is_still_recorded_and_never_trusted() {
         // The pawn endgame carries the most draw traffic of the pinned
         // positions, so it is the one that exercises both halves of the graph
         // history work. tainted_stores going to zero means taint propagation
@@ -1111,7 +1104,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_warm_cache_matches_cold_across_draw_context() {
+    fn a_warm_cache_matches_cold_across_draw_context() {
         // The same pieces hash to the same key whatever the fifty move counter
         // says, so a search made a few plies from the draw fills the table
         // with scores that are true of that path only. A fresh game reaching
@@ -1134,7 +1127,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_warm_cache_matches_cold_search() {
+    fn a_warm_cache_matches_a_cold_search() {
         // Searching a position with a cache warmed by unrelated positions must give the same
         // result as searching it with an empty cache
         let fens = [
@@ -1164,9 +1157,9 @@ mod test_search {
     }
 
     #[test]
-    fn test_small_table_matches_large_table() {
+    fn a_small_table_matches_a_large_table() {
         // a table small enough to force constant collisions must not change the result
-        let fen = "r1b2rk1/ppp1qppp/4pn2/6N1/Qn1P4/2NBP3/PP3PPP/R3K2R w KQ - 9 12";
+        let fen = SHARP_MIDDLEGAME;
         let mut big = engine(Board::from_fen(fen).unwrap());
         let expected = completed(big.search(5));
         let mut small = AlphaBeta::with_table_bytes(Board::from_fen(fen).unwrap(), 8 * 1024);
@@ -1175,11 +1168,8 @@ mod test_search {
     }
 
     #[test]
-    fn test_search_at_repetition_returns_a_move() {
-        let game = Board::from_fen(
-            "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 b - - 3 19",
-        )
-        .unwrap();
+    fn a_search_at_a_repetition_still_returns_a_move() {
+        let game = Board::from_fen(fens::SHUFFLE).unwrap();
         let mut e = engine(game);
         for m in [
             "a8b8", "a1b1", "b8a8", "b1a1", "a8b8", "a1b1", "b8a8", "b1a1",
@@ -1191,8 +1181,8 @@ mod test_search {
     }
 
     #[test]
-    fn test_new_game_forgets_the_previous_game() {
-        let fen = "r1b2rk1/ppp1qppp/4pn2/6N1/Qn1P4/2NBP3/PP3PPP/R3K2R w KQ - 9 12";
+    fn a_new_game_forgets_the_previous_game() {
+        let fen = SHARP_MIDDLEGAME;
         let mut e = engine(Board::from_fen(fen).unwrap());
         completed(e.search(4));
         assert!(e.moves.get(e.board.key).is_some(), "nothing was stored");
@@ -1204,22 +1194,19 @@ mod test_search {
     }
 
     #[test]
-    fn test_pv_line_without_cache_entry() {
+    fn the_pv_line_is_empty_without_a_cache_entry() {
         let game = Board::new();
         let e = engine(game);
         assert_eq!(format!("{}", e.pv_line()), "");
     }
 
     #[test]
-    fn test_pv_line_stops_at_a_repetition() {
+    fn the_pv_line_stops_at_a_repetition() {
         // a shuffle both sides are content with leaves the table holding a line
         // that goes round for ever. The line stops once the position comes back,
         // because from there it is a draw either side can take, rather than
         // reporting a continuation nobody would go on to play.
-        let game = Board::from_fen(
-            "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 b - - 3 19",
-        )
-        .unwrap();
+        let game = Board::from_fen(fens::SHUFFLE).unwrap();
         let mut e = engine(game);
         let cycle = ["a8b8", "a1b1", "b8a8", "b1a1"];
         let mut board = e.board;
@@ -1233,7 +1220,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_pv_line_stops_when_the_fifty_move_counter_runs_out() {
+    fn the_pv_line_stops_when_the_fifty_move_counter_runs_out() {
         let game = Board::from_fen("5k2/1p3p1p/p3pK1P/P1P1P3/4bP2/2B5/8/8 w - - 99 112").unwrap();
         let mut e = engine(game);
         let mut board = e.board;
@@ -1250,7 +1237,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_pv_line_does_not_follow_a_move_which_is_illegal_here() {
+    fn the_pv_line_does_not_follow_a_move_which_is_illegal_here() {
         // two positions which hash to the same key share an entry, so the move
         // a probe comes back with is not always a move of the position asked
         // about
@@ -1264,7 +1251,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_pv_line_does_not_follow_a_quiescence_entry() {
+    fn the_pv_line_does_not_follow_a_quiescence_entry() {
         // quiescence looks at captures and promotions alone, so its move is
         // fit for ordering
         // the next search and not for saying what the engine means to play
@@ -1286,7 +1273,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_pv_line_does_not_follow_a_move_which_leaves_the_king_in_check() {
+    fn the_pv_line_does_not_follow_a_move_which_leaves_the_king_in_check() {
         // moves are generated pseudo legally, so a pinned piece's move is in
         // the list for this position and still cannot be played. Asking whether
         // the move belongs to this position is not enough on its own, which is
@@ -1300,7 +1287,7 @@ mod test_search {
     }
 
     #[test]
-    fn test_pv_line_is_bounded_by_the_search_depth() {
+    fn the_pv_line_is_bounded_by_the_search_depth() {
         // pawns only, so no position comes up twice and the fifty move counter
         // keeps being reset: nothing stops this line but the bound
         let mut names = Vec::new();
@@ -1326,8 +1313,8 @@ mod test_search {
     }
 
     #[test]
-    fn test_stopped_search_does_not_poison_cache() {
-        let fen = "r1b2rk1/ppp1qppp/4pn2/6N1/Qn1P4/2NBP3/PP3PPP/R3K2R w KQ - 9 12";
+    fn a_stopped_search_does_not_poison_the_cache() {
+        let fen = SHARP_MIDDLEGAME;
         let game = Board::from_fen(fen).unwrap();
         let mut cold = engine(game);
         let expected = completed(cold.search(6));
@@ -1350,7 +1337,7 @@ mod test_search {
 }
 
 #[cfg(test)]
-mod test_hash_table {
+mod hash_table {
     use super::{Bound, HashTable, Play, Pv};
     use pretty_assertions::assert_eq;
 
@@ -1366,7 +1353,7 @@ mod test_hash_table {
     }
 
     #[test]
-    fn test_get_compares_key_not_just_slot() {
+    fn get_compares_the_key_not_just_the_slot() {
         // two different keys which map to the same slot must not be confused for each other
         let mut table = HashTable::with_capacity(1);
         table.set(1, new_pv(Bound::Exact, 1, 1));
@@ -1375,7 +1362,7 @@ mod test_hash_table {
     }
 
     #[test]
-    fn test_exact_entry_replaces_non_exact_entry() {
+    fn an_exact_entry_replaces_a_non_exact_entry() {
         let mut table = HashTable::with_capacity(1);
         table.set(1, new_pv(Bound::Lower, 1, 1));
         table.set(1, new_pv(Bound::Exact, 1, 1));
@@ -1383,7 +1370,7 @@ mod test_hash_table {
     }
 
     #[test]
-    fn test_deeper_exact_entry_survives_shallower_exact_entry() {
+    fn a_deeper_exact_entry_survives_a_shallower_one() {
         let mut table = HashTable::with_capacity(1);
         table.set(1, new_pv(Bound::Exact, 8, 1));
         table.set(1, new_pv(Bound::Exact, 2, 1));
@@ -1391,7 +1378,7 @@ mod test_hash_table {
     }
 
     #[test]
-    fn test_deeper_entry_replaces_exact_entry_for_another_position() {
+    fn a_deeper_entry_replaces_an_exact_entry_for_another_position() {
         let mut table = HashTable::with_capacity(1);
         table.set(1, new_pv(Bound::Exact, 1, 1));
         table.set(2, new_pv(Bound::Lower, 8, 1));
@@ -1400,7 +1387,7 @@ mod test_hash_table {
     }
 
     #[test]
-    fn test_shallower_entry_does_not_evict_deeper_entry_for_another_position() {
+    fn a_shallower_entry_does_not_evict_a_deeper_one_for_another_position() {
         let mut table = HashTable::with_capacity(1);
         table.set(1, new_pv(Bound::Lower, 8, 1));
         table.set(2, new_pv(Bound::Exact, 1, 1));
@@ -1408,7 +1395,7 @@ mod test_hash_table {
     }
 
     #[test]
-    fn test_quiescence_entry_does_not_evict_searched_entry() {
+    fn a_quiescence_entry_does_not_evict_a_searched_entry() {
         let mut table = HashTable::with_capacity(1);
         table.set(1, new_pv(Bound::Exact, 5, 1));
         table.set(2, new_pv(Bound::Ordering, 0, 1));
@@ -1416,7 +1403,7 @@ mod test_hash_table {
     }
 
     #[test]
-    fn test_stale_entry_is_replaced_regardless_of_depth() {
+    fn a_stale_entry_is_replaced_regardless_of_depth() {
         let mut table = HashTable::with_capacity(1);
         table.set(1, new_pv(Bound::Exact, 8, 1));
         table.set(2, new_pv(Bound::Lower, 1, 100));
@@ -1425,10 +1412,11 @@ mod test_hash_table {
 }
 
 #[cfg(test)]
-mod test_node_counts {
+mod node_counts {
     use super::AlphaBeta;
     use super::Board;
     use super::Game;
+    use crate::board::fens;
     use pretty_assertions::assert_eq;
 
     /// Pinned, because how often the transposition table collides decides how
@@ -1439,31 +1427,11 @@ mod test_node_counts {
     /// opening, a tactical middlegame, a pawn endgame, a position full of
     /// captures, and one with castling and promotions available.
     const POSITIONS: [(&str, &str, u8); 5] = [
-        (
-            "opening",
-            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
-            6,
-        ),
-        (
-            "kiwipete",
-            "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
-            5,
-        ),
-        (
-            "pawn endgame",
-            "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
-            7,
-        ),
-        (
-            "promotions",
-            "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
-            5,
-        ),
-        (
-            "middlegame",
-            "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10",
-            5,
-        ),
+        ("opening", fens::START, 6),
+        ("kiwipete", fens::KIWIPETE, 5),
+        ("pawn endgame", fens::PAWN_ENDGAME, 7),
+        ("promotions", fens::PROMOTIONS, 5),
+        ("middlegame", fens::MIDDLEGAME, 5),
     ];
 
     /// Widens the way the engine does when it plays, so the table is warm from
@@ -1553,7 +1521,7 @@ mod test_node_counts {
     /// in the same commit: the diff is then a statement of how much less, or
     /// more, of the tree the engine now looks at.
     #[test]
-    fn test_node_counts_have_not_moved() {
+    fn node_counts_have_not_moved() {
         let counted: Vec<(&str, u64)> = POSITIONS
             .iter()
             .map(|(name, fen, depth)| (*name, nodes(fen, *depth)))

--- a/basic_engine/src/misc.rs
+++ b/basic_engine/src/misc.rs
@@ -67,7 +67,7 @@ impl Coordinate {
 }
 
 #[cfg(test)]
-mod test_coordinate {
+mod coordinate {
     use super::Coordinate;
 
     #[test]
@@ -148,7 +148,7 @@ impl CastlePermissions {
 }
 
 #[cfg(test)]
-mod test_castle_permissions {
+mod castle_permissions {
     use super::CastlePermissions;
 
     #[test]
@@ -200,7 +200,7 @@ pub fn index_to_coordinate(index: u8) -> (u8, File) {
 }
 
 #[cfg(test)]
-mod test_index_coordinate_conversion {
+mod index_conversion {
     use super::coordinate_to_index;
     use super::index_to_coordinate;
     use proptest::prelude::*;

--- a/basic_engine/src/zorbrist.rs
+++ b/basic_engine/src/zorbrist.rs
@@ -95,7 +95,7 @@ impl Zorbrist {
 }
 
 #[cfg(test)]
-mod test_zorbrist {
+mod keys {
     use super::Zorbrist;
     use pretty_assertions::assert_eq;
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -125,7 +125,7 @@ both on the same runner. It writes the comparison to the job summary. It only
 reports and will not fail a build, for the same reason: even measured back to
 back on one machine, criterion calls single digit differences significant.
 
-What does hold search behaviour still is `test_node_counts_have_not_moved` in
+What does hold search behaviour still is `node_counts_have_not_moved` in
 `basic_engine/src/engine.rs`. The number of nodes a search visits is exact
 rather than timed, so it says the same thing on any machine. A deliberate change
 to the search is expected to move it, and the numbers are updated in the same


### PR DESCRIPTION
Item 5 from the test audit, in two commits — a net −88 lines of test code with slightly more actually asserted, and no change to the engine itself.

## `test(board)`: Share the fens and the move lookup, table the macros

- A `fens` module now holds the positions the suites share, each named for what it brings within reach (`START`, `KIWIPETE`, `PAWN_ENDGAME`, `PROMOTIONS`, `EN_PASSANT_PROMOTION`, `MIDDLEGAME`, `SHUFFLE`), plus a `CORE` array of the four the accumulator and reversibility suites iterate. The perft table, `pseudo_legal`, `random_games` and the node-count suite read the same constants instead of keeping their own copies with their own move counters.
- The three test macros are gone: material accounting, eval antisymmetry, reversibility and the captures subset are plain loops over `fens::CORE`, so the twelve macro-generated tests become three whose names state the property being asserted rather than the position it runs on.
- The find-a-move-by-name lookup that was pasted across three files is one `play_named` helper next to the fens.
- The one deliberate assertion change: `test_is_repetition`'s long manual walk is folded into `has_repeated_fires_a_cycle_before_is_repetition` as a no-false-positives check on every step of the cycle, then deleted — same coverage, one telling of the story.

## `test(search)`: Adopt the shared fens and drop the test_ prefixes

The search tests use the shared `play_named` and `fens`; the middlegame the cache tests search four times over gets a name (`SHARP_MIDDLEGAME`) instead of four pasted fen strings; and the naming convergence lands: every `test_`-prefixed function across both crates now reads as a sentence, the way the newer suites were already written (e.g. `test_regression_bad_cache` → `a_losing_position_is_still_losing_with_a_warm_table`). Test modules follow suit (`test_search` → `search`, `test_fen` → `fen_parsing`, and so on), and `docs/DEVELOPMENT.md` follows the node-count test to its new name.

## Verification

- No `test_` prefixes remain anywhere in the workspace.
- `cargo test --workspace --release` green; the full debug-profile suite (state-in-step asserts) green.
- `node_counts_have_not_moved` untouched — no engine code changed.
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhiJhdHPF8YDStbv8Wbsm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhiJhdHPF8YDStbv8Wbsm9)_