### PR TITLE
UCI replies made testable, plus a tightened bitboard assert

### DIFF
--- a/basic_engine/src/bitboard.rs
+++ b/basic_engine/src/bitboard.rs
@@ -15,16 +15,17 @@ pub trait BitBoard {
 impl BitBoard for u64 {
     #[inline(always)]
     fn set_bit(&mut self, index: u8) {
-        debug_assert!(index <= 64);
+        debug_assert!(index < 64);
         *self |= 1u64 << index;
     }
     #[inline(always)]
     fn clear_bit(&mut self, index: u8) {
-        debug_assert!(index <= 64);
+        debug_assert!(index < 64);
         *self &= !(1u64 << index);
     }
     #[inline(always)]
     fn is_bit_set(&self, index: u8) -> bool {
+        debug_assert!(index < 64);
         (self & (1u64 << index)) > 0
     }
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -137,7 +137,10 @@ impl<T: Engine, W: Write> UCI<T, W> {
         } else if line.starts_with("perft") {
             let depth = perft_depth(line);
             let nodes = self.engine.perft(depth);
-            self.say(format_args!("info string perft depth {} nodes {}", depth, nodes));
+            self.say(format_args!(
+                "info string perft depth {} nodes {}",
+                depth, nodes
+            ));
         } else {
             self.say(format_args!("info string unrecognised command: {}", line));
         }
@@ -317,6 +320,76 @@ mod tests {
         // ever, so reaching the end of this call is the assertion
         let mut uci = uci();
         uci.run(Cursor::new("uci\nisready\nposition startpos\ngo depth 1\n"));
+    }
+
+    #[test]
+    fn the_handshake_identifies_the_engine_and_ends_with_uciok() {
+        let mut uci = uci();
+        uci.handle("uci");
+        let said = said(&uci);
+        let lines: Vec<&str> = said.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].starts_with("id name arche "));
+        assert!(lines[1].starts_with("id author "));
+        assert_eq!(lines[2], "uciok");
+    }
+
+    #[test]
+    fn isready_is_answered_with_readyok_alone() {
+        let mut uci = uci();
+        uci.handle("isready");
+        assert_eq!(said(&uci), "readyok\n");
+    }
+
+    #[test]
+    fn a_search_reports_each_depth_and_then_its_move() {
+        let mut uci = uci();
+        uci.run(Cursor::new("position startpos\ngo depth 3\n"));
+        let said = said(&uci);
+        let lines: Vec<&str> = said.lines().collect();
+        assert_eq!(lines.len(), 4, "a depth three search speaks four lines");
+        for line in &lines[..3] {
+            assert!(
+                line.starts_with("info depth "),
+                "not an info line: {}",
+                line
+            );
+        }
+        assert!(lines[3].starts_with("bestmove "));
+    }
+
+    #[test]
+    fn a_position_with_no_legal_moves_reports_the_null_move() {
+        for fen in [
+            "7k/6Q1/6K1/8/8/8/8/8 b - - 0 1", // checkmate
+            "7k/5Q2/6K1/8/8/8/8/8 b - - 0 1", // stalemate
+        ] {
+            let mut uci = uci();
+            uci.run(Cursor::new(format!("position fen {}\ngo depth 1\n", fen)));
+            let said = said(&uci);
+            assert!(
+                said.contains("info string no legal moves identified"),
+                "{}",
+                fen
+            );
+            assert!(said.ends_with("bestmove 0000\n"), "{}: {}", fen, said);
+        }
+    }
+
+    #[test]
+    fn what_could_not_be_acted_on_is_reported_as_an_info_string() {
+        let mut uci = uci();
+        uci.run(Cursor::new("position wibble\nwobble\n"));
+        let said = said(&uci);
+        assert!(said.contains("info string unrecognised position: wibble"));
+        assert!(said.contains("info string unrecognised command: wobble"));
+    }
+
+    #[test]
+    fn a_perft_command_reports_its_count() {
+        let mut uci = uci();
+        uci.run(Cursor::new("position startpos\nperft 2\n"));
+        assert_eq!(said(&uci), "info string perft depth 2 nodes 400\n");
     }
 
     #[test]

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -5,7 +5,7 @@ use basic_engine::SearchOutcome;
 use basic_engine::SearchParameters;
 use basic_engine::{PvLine, SearchResult};
 use regex::Regex;
-use std::io::BufRead;
+use std::io::{BufRead, Stdout, Write};
 use std::sync::LazyLock;
 use std::time::Duration;
 
@@ -29,14 +29,6 @@ fn capture(re: &Regex, line: &str) -> Option<u64> {
     Some(digits.parse().unwrap_or(u64::MAX))
 }
 
-/// Tells the interface about anything we could not act on. A bad line is the
-/// interface's problem to fix, so say so and carry on reading.
-fn report(result: Result<(), String>) {
-    if let Err(error) = result {
-        println!("info string {}", error);
-    }
-}
-
 fn time_control_from(line: &str, color: Color) -> TimeControl {
     TimeControl {
         time: match color {
@@ -53,26 +45,49 @@ fn time_control_from(line: &str, color: Color) -> TimeControl {
     }
 }
 
-pub struct UCI<T: Engine> {
+pub struct UCI<T: Engine, W: Write> {
     author: String,
     name: String,
     version: String,
 
     engine: T,
+    out: W,
 }
 
-impl<T: Engine> UCI<T> {
+impl<T: Engine> UCI<T, Stdout> {
     pub fn new_with_engine(engine: T) -> Self {
+        Self::with_output(engine, std::io::stdout())
+    }
+}
+
+impl<T: Engine, W: Write> UCI<T, W> {
+    /// Separate from new_with_engine so that what is said can be captured.
+    fn with_output(engine: T, out: W) -> Self {
         Self {
             author: env!("CARGO_PKG_AUTHORS").to_string(),
             name: env!("CARGO_PKG_NAME").to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
             engine,
+            out,
         }
     }
 
     pub fn read_loop(&mut self) {
         self.run(std::io::stdin().lock());
+    }
+
+    /// Writes one line to the interface. A failed write means the interface
+    /// itself is gone, which leaves no one to tell, so the error is dropped.
+    fn say(&mut self, line: std::fmt::Arguments) {
+        let _ = writeln!(self.out, "{}", line);
+    }
+
+    /// Tells the interface about anything we could not act on. A bad line is
+    /// the interface's problem to fix, so say so and carry on reading.
+    fn report(&mut self, result: Result<(), String>) {
+        if let Err(error) = result {
+            self.say(format_args!("info string {}", error));
+        }
     }
 
     /// Handles input until it is exhausted or `quit` arrives. Separate from
@@ -88,7 +103,7 @@ impl<T: Engine> UCI<T> {
                 // there is nothing left to read and no one to tell, so stop
                 // rather than sitting in the loop asking again
                 Err(error) => {
-                    println!("info string could not read input: {}", error);
+                    self.say(format_args!("info string could not read input: {}", error));
                     return;
                 }
             }
@@ -101,18 +116,20 @@ impl<T: Engine> UCI<T> {
             return false;
         }
         if line.starts_with("isready") {
-            println!("readyok");
+            self.say(format_args!("readyok"));
         } else if line.starts_with("ucinewgame") {
             self.engine.new_game();
             let result = self.parse_position("position startpos");
-            report(result);
+            self.report(result);
         } else if line.starts_with("uci") {
-            println!("id name {} {}", self.name, self.version);
-            println!("id author {}", self.author);
-            println!("uciok");
+            // written to the field directly: say borrows all of self, and
+            // these lines also read from it
+            let _ = writeln!(self.out, "id name {} {}", self.name, self.version);
+            let _ = writeln!(self.out, "id author {}", self.author);
+            self.say(format_args!("uciok"));
         } else if line.starts_with("position") {
             let result = self.parse_position(line);
-            report(result);
+            self.report(result);
         } else if line.starts_with("display") {
             self.engine.display_board();
         } else if line.starts_with("go") {
@@ -120,9 +137,9 @@ impl<T: Engine> UCI<T> {
         } else if line.starts_with("perft") {
             let depth = perft_depth(line);
             let nodes = self.engine.perft(depth);
-            println!("info string perft depth {} nodes {}", depth, nodes);
+            self.say(format_args!("info string perft depth {} nodes {}", depth, nodes));
         } else {
-            println!("info string unrecognised command: {}", line);
+            self.say(format_args!("info string unrecognised command: {}", line));
         }
         true
     }
@@ -160,22 +177,25 @@ impl<T: Engine> UCI<T> {
         sp.depth = capture(&DEPTH_RE, line).map(|depth| depth.try_into().unwrap_or(u8::MAX));
 
         let start = sp.start_time;
+        // the closure writes while the engine is borrowed for the search, so
+        // it goes to the writer directly rather than through say
+        let out = &mut self.out;
         let outcome = self
             .engine
             .iterative_deepening_search(sp, |depth, result, pv| {
-                println!("{}", format_info(depth, result, &pv, start.elapsed()));
+                let _ = writeln!(out, "{}", format_info(depth, result, &pv, start.elapsed()));
             });
         match outcome {
             SearchOutcome::Complete(result) | SearchOutcome::Aborted(Some(result)) => {
-                println!("bestmove {}", result.best_move);
+                self.say(format_args!("bestmove {}", result.best_move));
             }
             SearchOutcome::GameOver => {
-                println!("info string no legal moves identified");
+                self.say(format_args!("info string no legal moves identified"));
                 // 0000 is the null move, used to report that there is no move
                 // to make
-                println!("bestmove 0000");
+                self.say(format_args!("bestmove 0000"));
             }
-            SearchOutcome::Aborted(None) => println!("bestmove 0000"),
+            SearchOutcome::Aborted(None) => self.say(format_args!("bestmove 0000")),
         }
     }
 }
@@ -214,9 +234,18 @@ mod tests {
     use basic_engine::{AlphaBeta, Board};
     use std::io::Cursor;
 
-    /// A table small enough that a test can afford one per case.
-    fn uci() -> UCI<AlphaBeta> {
-        UCI::new_with_engine(AlphaBeta::with_table_bytes(Board::new(), 8 * 1024))
+    /// A table small enough that a test can afford one per case, speaking
+    /// into a buffer so that what the interface would see can be asserted.
+    fn uci() -> UCI<AlphaBeta, Vec<u8>> {
+        UCI::with_output(
+            AlphaBeta::with_table_bytes(Board::new(), 8 * 1024),
+            Vec::new(),
+        )
+    }
+
+    /// Everything said so far, as one string.
+    fn said(uci: &UCI<AlphaBeta, Vec<u8>>) -> String {
+        String::from_utf8(uci.out.clone()).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
Items 2 and 6 from the test audit, in three commits — no engine code changed.

## `fix(board)`: Tighten the bitboard index asserts to reject 64

`set_bit` and `clear_bit` guarded with `debug_assert!(index <= 64)`, which admits 64 — one past the last square, where the shift itself is already overflow. The bound is now strict, and `is_bit_set` carries the same assert instead of being the one accessor with no guard. Zero release cost: `debug_assert!` compiles out.

## `refactor(uci)`: Route output through a writer so the protocol is testable

The input side was already driveable without stdin (`run<R: BufRead>`), but every reply went through bare `println!` — a test could script a whole session and assert nothing about what the interface saw. Those lines were exactly the uncovered region in coverage.

- The writer is now a type parameter alongside the reader: `UCI<T: Engine, W: Write>`. `new_with_engine` keeps its signature and binds stdout, so `main.rs` is untouched; tests build with a `Vec<u8>` buffer.
- All output goes through one `say` helper that owns the failed-write decision: a failed write means the interface itself is gone, which leaves no one to tell, so the error is dropped.
- The search's info callback writes through a pre-borrowed `&mut self.out` since the engine is mutably borrowed for the duration; the `id` lines write to the field directly because they also read from `self`.

## `test(uci)`: Assert the replies the interface actually sees

Six transcript tests pin the previously untested face of the protocol:

- the `uci` handshake is exactly `id name` / `id author` / `uciok`
- `isready` answers `readyok` and nothing else
- `go depth 3` speaks exactly four lines — one info line per completed depth, then `bestmove`
- checkmate and stalemate both report `info string no legal moves identified` and `bestmove 0000` (the `GameOver` branch was dead in tests)
- a bad position and an unrecognised command each surface as an `info string` rather than silence
- `perft 2` from the start position reports exactly `info string perft depth 2 nodes 400`

## Verification

- `cargo test --workspace` green in both profiles — 37 uci-crate tests (up from 31) and the 89-test engine suite untouched.
- The debug-profile run is the one where the tightened `debug_assert!`s fire, so no caller relied on the loose bound.
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` clean.
- No engine code changed, so `node_counts_have_not_moved` guarantees search behavior is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhiJhdHPF8YDStbv8Wbsm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhiJhdHPF8YDStbv8Wbsm9)_