### PR TITLE
fix(search): Store the root entry past the depth contest

### DIFF
--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -541,7 +541,9 @@ impl AlphaBeta {
         }
 
         let play = best.expect("any legal move's score beats the opening alpha of Score::MIN + 1");
-        self.moves.set(
+        // stored past the depth contest: this is the move about to be
+        // answered, and the line reported for it is read back from this slot
+        self.moves.set_always(
             self.board.key,
             Pv {
                 play,
@@ -645,7 +647,15 @@ impl Engine for AlphaBeta {
                     return SearchOutcome::GameOver;
                 }
                 SearchOutcome::Complete(result) => {
-                    on_depth(depth, &result, self.pv_line());
+                    let pv = self.pv_line();
+                    // the root's entry was just stored past any leftover, so
+                    // the line the table tells opens with the move answered
+                    debug_assert_eq!(
+                        pv.line.first(),
+                        Some(&result.best_move),
+                        "the reported line disagrees with the best move"
+                    );
+                    on_depth(depth, &result, pv);
                     best = Some(result);
                 }
             }
@@ -794,6 +804,19 @@ impl HashTable {
         }
         self.table[index] = Some((pv, key));
     }
+
+    /// Store without the depth contest above. The root's end-of-iteration
+    /// entry is for this: it names the move the search is about to answer
+    /// with, and the reported line is read back from its slot, so an entry a
+    /// deeper search left there earlier in the game must not outrank it.
+    /// When one did, the engine answered one move while its line opened with
+    /// another, which is a lie the match tools flag. The leftover's extra
+    /// depth is no loss: its score describes repetition and fifty move
+    /// context the game has since moved past.
+    fn set_always(&mut self, key: u64, pv: Pv) {
+        let index = self.index_for(key);
+        self.table[index] = Some((pv, key));
+    }
 }
 
 pub struct PvLine {
@@ -923,6 +946,31 @@ mod search {
         let _ = e.parse_fen("r4rk1/pppb1ppp/4pn2/6N1/3P4/2qBP3/P4PPP/3R1R1K w - - 2 16");
         let result = completed(e.search(7));
         assert!(result.score < -800, "expect bad score got {}", result.score);
+    }
+
+    #[test]
+    fn the_reported_line_opens_with_the_move_actually_answered() {
+        // A deeper entry for the root position, left by an earlier search of
+        // it, used to win the depth contest against the root's own store:
+        // the table then told a line opening with the leftover's move while
+        // bestmove answered the fresh one, and the two disagreed in front of
+        // whatever was relaying the search. Here the queen hangs, so a fresh
+        // search must answer with the capture, while the planted leftover
+        // claims a quiet king move from a depth no shallow search can beat.
+        let game = Board::from_fen("k7/8/8/3q4/8/8/3R4/K7 w - - 0 1").unwrap();
+        let mut e = engine(game);
+        let quiet = play_named(&e.board, "a1b1");
+        e.moves.set(
+            e.board.key,
+            Pv {
+                depth: 14,
+                ..searched(quiet, e.board.ply)
+            },
+        );
+        let result = completed(e.search(2));
+        let takes = play_named(&e.board, "d2d5");
+        assert_eq!(result.best_move, takes);
+        assert_eq!(e.pv_line().line.first(), Some(&takes));
     }
 
     #[test]


### PR DESCRIPTION
## What

The transposition table's replacement policy prefers depth, and the table outlives the move. In an endgame that shuffles, the root position's slot often still holds an entry a deeper search wrote earlier in the game — sometimes carrying a different move. The root's own end-of-iteration store then lost the depth contest **silently**, and `pv_line`, which walks the table, opened the reported line with the leftover's move while `bestmove` answered with the fresh one. fastchess flags exactly that disagreement, which is how this surfaced ([SPRT run log](https://github.com/aywrite/arche/actions/runs/31153968589), two warnings in one endgame game).

The root's entry now goes in through a new `set_always`, past the contest: it names the move about to be answered, and the line reported for it is read back from its slot, so nothing may outrank it. The leftover's extra depth is no loss — its score describes repetition and fifty-move context the game has since moved past. Interior nodes keep the existing depth-preferred policy untouched.

## How it was pinned down

Replaying the flagged game against a draining 20+0.1 clock reproduced both warnings verbatim (`chose g2f2, table keeps g2h2 at depth 11`; `chose e4f3, table keeps e4e3 at depth 14`) — and showed roughly a third of the root stores across that game being refused. The visible warnings are only the ones where the final printed line happened to be a lying one. The behavior predates #66: the same instrumentation on the pre-#66 base shows the same refusals at the same plies.

Severity was cosmetic-plus: `bestmove` always came from the completed iteration itself, never the table, so no wrong move was ever played. What was wrong was the story — info lines advertising a line the engine was not following, and the next search's root ordered by a stale move.

## Enforcement

- The deepening loop now `debug_assert`s the repaired invariant on every completed iteration: the reported line opens with the move answered. The entire debug suite runs every search test through it.
- A regression test plants a depth-14 leftover naming a quiet king move over a position where the search must take a hanging queen, and asserts both `best_move` and the PV head are the capture. Verified to have teeth by mutation: restoring the plain store fails it.

Full suite green in release and debug profiles, clippy and fmt clean. No SPRT planned: the only behavioral change beyond reporting is that the next search's root ordering uses the fresh move instead of a stale one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYHZrAnmNtuKTFEw171ty6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYHZrAnmNtuKTFEw171ty6)_