### PR TITLE
docs: Say what the board relies on and correct what drifted

### DIFF
--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -22,10 +22,9 @@ fn pop_lsb(bb: &mut u64) -> u8 {
     i
 }
 
-/// Play State is used to store the history of moves (plays)
-///
-/// Although the move/play object already contains most of the information we need, in order to
-/// undo a move we need some additional state.
+/// One ply of history: everything `undo_move` needs that the move itself does
+/// not carry, being the rights and counters the move cleared and the key and
+/// checkers it replaced.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 struct PlayState {
     play: Play,
@@ -115,6 +114,13 @@ const F1_G1: u64 = 1 << F1 | 1 << G1;
 const B8_C8_D8: u64 = 1 << B8 | 1 << C8 | 1 << D8;
 const F8_G8: u64 = 1 << F8 | 1 << G8;
 
+/// The sixty four squares laid out inside a ten by ten grid whose border rows
+/// and columns are sentinels, so that a step off the side of the board lands on
+/// one instead of wrapping onto the far file.
+///
+/// One row of border is enough because every walk tests a square before
+/// stepping again, so an index can never be more than one step out and always
+/// stays inside the array.
 pub struct BaseConversions {
     pub base_64_to_100: [u8; 64],
     pub base_100_to_64: [u8; 100],
@@ -144,6 +150,9 @@ impl BaseConversions {
     }
 }
 
+/// Print the mailbox as a grid, the sentinels included. Nothing calls it: it
+/// is a debugging aid kept for when a walk comes out wrong, the same standing
+/// `debug_print` has for bitboards.
 impl fmt::Display for BaseConversions {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for rank in 0..10 {
@@ -157,6 +166,13 @@ impl fmt::Display for BaseConversions {
     }
 }
 
+/// What a piece on each square attacks with nothing in the way.
+///
+/// The two slider entries are not that. They are the whole rank and file, and
+/// the whole diagonals, edges and the square itself included, because what the
+/// search asks of them is only whether two squares share a line: that rules a
+/// slider out before the blocker-aware probe in `magic` is worth running.
+/// Nothing asks whether a square shares a line with itself.
 struct AttackMasks {
     black_pawns: [u64; 64],
     white_pawns: [u64; 64],
@@ -259,6 +275,10 @@ impl AttackMasks {
     }
 }
 
+/// The whole position with its history, which makes a board a little over
+/// forty kilobytes and `Copy`. Copying one is nothing next to a search and a
+/// great deal next to a node, so the search makes and unmakes moves on the one
+/// board; only `pv_line` and the tests take copies.
 #[derive(Debug, PartialEq, Copy, Clone, Eq, Hash)]
 pub struct Board {
     pawns: u64,
@@ -419,9 +439,9 @@ impl Board {
 
     /// The one generator behind generate_moves and generate_captures. The
     /// const parameter is settled at compile time, so each wrapper
-    /// monomorphises into what used to be its own hand-written copy: the
-    /// captures one masks every piece's targets with the opponent's pieces
-    /// and drops the quiet-only sections, with nothing tested per move.
+    /// monomorphises into the equivalent of a hand-written copy: the captures
+    /// one masks every piece's targets with the opponent's pieces and drops
+    /// the quiet-only sections, with nothing tested per move.
     fn generate<const CAPTURES_ONLY: bool>(&self) -> MoveList {
         let mut moves = MoveList::new();
         let (color_mask, capture_mask) = match self.active_color {
@@ -650,8 +670,8 @@ impl Board {
 
     /// The position key computed from the board rather than maintained as moves
     /// are made, built the way `from_fen` builds it. `key` is meant to equal
-    /// this at all times, and until now nothing compared the two except a
-    /// handful of tests naming specific positions.
+    /// this at all times, which `debug_assert_state_in_step` checks on every
+    /// move made.
     pub fn recompute_key(&self) -> u64 {
         let mut key = INITIAL_KEY;
         let mut occupied = self.white | self.black;
@@ -673,7 +693,8 @@ impl Board {
 
     /// The piece square score of the position as it stands, computed from the
     /// board rather than accumulated as pieces move. `psqt` is meant to equal
-    /// this at all times, and nothing checked that until now.
+    /// this at all times, which `debug_assert_state_in_step` checks on every
+    /// move made.
     pub fn recompute_psqt(&self) -> i32 {
         let mut total: i32 = 0;
         // walking the occupied squares rather than all sixty four, an empty

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -250,12 +250,14 @@ impl AlphaBeta {
         }
 
         if alpha != old_alpha {
+            // depth zero and an Ordering bound: never read back in place of
+            // evaluating a position, only to sort its moves
             self.moves.set(
                 self.board.key,
                 Pv {
                     play: best_move.unwrap(),
                     score: score_to_tt(alpha, self.board.line_ply),
-                    depth: 0, // Never use a quiescence move instead of evaluating, only for move ordering
+                    depth: 0,
                     bound: Bound::Ordering,
                     tainted: false,
                     ply: self.board.ply as u16,
@@ -321,8 +323,8 @@ impl AlphaBeta {
         // repetition there is not a finished game because the engine still has
         // to move, but from here on it is a draw either side can take
         if self.board.fifty_move_rule >= 100 || self.board.has_repeated() {
-            // the source. This score is true of the path that reached this
-            // position, not of the position
+            // where the taint starts: the draw is true of the path that
+            // reached this position, not of the position itself
             self.tainted = true;
             return Ok(0);
         }
@@ -576,9 +578,9 @@ impl AlphaBeta {
             };
             if matches!(pv.bound, Bound::Ordering) {
                 // written by quiescence, which looks at captures and
-                // promotions alone, so the
-                // move is fit for ordering the next search and not for telling
-                // anyone what the engine intends to play
+                // promotions alone, so the move is fit for ordering the next
+                // search and not for telling anyone what the engine intends
+                // to play
                 break;
             }
             let play = pv.play;
@@ -902,10 +904,10 @@ mod search {
     use pretty_assertions::assert_eq;
     use std::time;
 
-    /// The default table is half a gigabyte, which is the right size to play
-    /// with and the wrong size to test with: one per test dominated both the
-    /// memory and the run time of the suite. This is still far larger than
-    /// anything here searches deeply enough to fill.
+    /// The default table is 256MB, which is the right size to play with and
+    /// the wrong size to test with: one per test dominated both the memory and
+    /// the run time of the suite. This is still far larger than anything here
+    /// searches deeply enough to fill.
     const TABLE_BYTES: usize = 16 * 1024 * 1024;
 
     fn engine(board: Board) -> AlphaBeta {
@@ -1064,7 +1066,7 @@ mod search {
         // warm than cold. On the promotions position the difference was
         // visible at the root, deepening promoted to a queen where a cold
         // search of the same depth chose the rook.
-        // test_warm_cache_matches_cold_search cannot see any of this because
+        // a_warm_cache_matches_a_cold_search cannot see any of this because
         // it searches each depth directly rather than deepening to it.
         let fens = [
             "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
@@ -1377,8 +1379,8 @@ mod search {
     #[test]
     fn the_pv_line_does_not_follow_a_quiescence_entry() {
         // quiescence looks at captures and promotions alone, so its move is
-        // fit for ordering
-        // the next search and not for saying what the engine means to play
+        // fit for ordering the next search and not for saying what the engine
+        // means to play
         let mut e = engine(Board::new());
         let play = play_named(&e.board, "e2e4");
         e.moves.set(

--- a/basic_engine/src/misc.rs
+++ b/basic_engine/src/misc.rs
@@ -185,10 +185,14 @@ mod castle_permissions {
     }
 }
 
+/// The index of a square, counting a1 as zero. Ranks are one based, the way
+/// a fen and the board display write them.
 pub fn coordinate_to_index(rank: u8, file: File) -> u8 {
     ((rank - 1) * 8) + (file) as u8
 }
 
+/// The same square in the mailbox indexing, which offsets by a row and a column
+/// of sentinels. See `BaseConversions`.
 pub fn coordinate_to_large_index(rank: u8, file: File) -> u8 {
     ((rank - 1) * 10) + (file) as u8 + 11
 }

--- a/basic_engine/src/play.rs
+++ b/basic_engine/src/play.rs
@@ -3,6 +3,10 @@ use crate::misc::index_to_coordinate;
 use crate::misc::{Piece, PromotePiece};
 use std::fmt;
 
+/// A move. Six bytes, which is what the fields happen to come to and what the
+/// search is tuned around: a move is copied into a move list, out of it, into
+/// the history and into the transposition table, several times per node.
+/// Widening it has been measured twice and was slower both times.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Play {
     pub from: u8,

--- a/basic_engine/src/pvt.rs
+++ b/basic_engine/src/pvt.rs
@@ -27,6 +27,9 @@ const fn mirror(array: &[i16; 64]) -> [i16; 64] {
 // top row, so the first entry is a8 and the last is h1. The board counts the
 // other way, a1 being index zero, which is why black takes the tables as
 // written and white takes them mirrored.
+//
+// The one change from the page is the fourth rank of the pawn table, where the
+// squares outside the two centre files score 1 rather than 0.
 
 #[rustfmt::skip]
 const PAWNS: [i16; 64] = [


### PR DESCRIPTION
Comment-only. The one non-comment line the diff touches is `depth: 0,` in
`quiescence`, and only because a trailing comment was lifted off it.

**Written down for the first time:** the mailbox's sentinel border and why one
row of it is enough; that `AttackMasks`' two slider entries are alignment
masks, not attack sets; that `Board` is `Copy` at a little over 40KB; that
`Play` is six bytes and has measured slower both times it was widened.

**Corrected:** a half-deleted comment in `alpha_beta` beginning mid-sentence at
`// the source.`; "half a gigabyte" for a table that has been 256MB since it
was halved; a reference to `test_warm_cache_matches_cold_search`, since
renamed; three docs that narrated their own commit rather than the code; the
piece square tables' credit, which the pawn table's fourth rank departs from;
and three hand-wrapped comments.

First slice of a wider audit — the code changes follow separately.

`fmt` and `clippy -D warnings` clean. `cargo test --workspace --release`: 90
passed, the same suite as master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
