### PR TITLE
fix: Score a mate on the hundredth half move, and read a negative clock

### DIFF
--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -800,6 +800,23 @@ impl Board {
         self.repetition_count() >= 1
     }
 
+    /// Whether the side to move has a legal move at all. Asked only where a
+    /// draw rule and a mate could coincide, which is rare, so it plays the
+    /// moves rather than keeping anything incremental.
+    pub fn has_legal_move(&mut self) -> bool {
+        let mut moves = self.generate_moves();
+        if self.in_check() {
+            self.retain_evasions(&mut moves);
+        }
+        for m in &moves {
+            if self.make_move(m) {
+                self.undo_move();
+                return true;
+            }
+        }
+        false
+    }
+
     pub fn make_move(&mut self, play: &Play) -> bool {
         self.make_move_impl::<true>(play)
     }

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -322,14 +322,28 @@ impl AlphaBeta {
         // every node here sits below the root, which search() owns: a
         // repetition there is not a finished game because the engine still has
         // to move, but from here on it is a draw either side can take
-        if self.board.fifty_move_rule >= 100 || self.board.has_repeated() {
+        let in_check = self.board.in_check();
+        if self.board.fifty_move_rule >= 100 {
+            // a mate delivered by the hundredth half move is a mate: the game
+            // ends on it, before the side mated has a move on which to claim
+            // the draw. Only asked here and not of a repetition, which cannot
+            // be a mate since the position would have ended the game the
+            // first time it came up, so the cost stays off the lines that
+            // repeat
+            if in_check && !self.board.has_legal_move() {
+                self.tainted = false;
+                return Ok(-CHECKMATE_SCORE + (self.board.line_ply as Score));
+            }
             // where the taint starts: the draw is true of the path that
             // reached this position, not of the position itself
             self.tainted = true;
             return Ok(0);
         }
+        if self.board.has_repeated() {
+            self.tainted = true;
+            return Ok(0);
+        }
         let mut node_tainted = false;
-        let in_check = self.board.in_check();
         if in_check {
             depth += 1;
         }
@@ -1107,6 +1121,29 @@ mod search {
         let game = Board::from_fen("5k2/1p3p1p/p3pK1P/P1P1P3/4bP2/2B5/8/8 w - - 100 112").unwrap();
         let mut e = engine(game);
         assert!(matches!(e.search(3), SearchOutcome::GameOver));
+    }
+
+    #[test]
+    fn a_mate_on_the_hundredth_half_move_is_a_mate_not_a_draw() {
+        // Rh8 mates, and it is the hundredth half move since anything
+        // irreversible. Checkmate ends the game on the spot, before the mated
+        // side has a move on which to claim the draw, so the mate outranks
+        // the fifty move rule rather than the other way round
+        let game = Board::from_fen("k7/8/1K6/8/8/8/8/7R w - - 99 100").unwrap();
+        let mut e = engine(game);
+        let result = completed(e.search(2));
+        assert_eq!(result.checkmate_in(), Some(1));
+        assert_eq!(format!("{}", result.best_move), "h1h8");
+    }
+
+    #[test]
+    fn a_check_that_does_not_mate_on_the_hundredth_half_move_is_still_a_draw() {
+        // the same rook gives check on h8 but the king slips out to a7, so
+        // the hundredth half move ends the game as a draw after all
+        let game = Board::from_fen("k7/8/2K5/8/8/8/8/7R w - - 99 100").unwrap();
+        let mut e = engine(game);
+        let result = completed(e.search(3));
+        assert_eq!(result.score, 0);
     }
 
     #[test]

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -11,21 +11,26 @@ use std::time::Duration;
 
 const START_FEN: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
-static WTIME_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"wtime (\d+)").unwrap());
-static BTIME_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"btime (\d+)").unwrap());
-static WINC_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"winc (\d+)").unwrap());
-static BINC_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"binc (\d+)").unwrap());
+static WTIME_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"wtime (-?\d+)").unwrap());
+static BTIME_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"btime (-?\d+)").unwrap());
+static WINC_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"winc (-?\d+)").unwrap());
+static BINC_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"binc (-?\d+)").unwrap());
 static MOVES_TO_GO_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"movestogo (\d+)").unwrap());
 static MOVE_TIME: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"movetime (\d+)").unwrap());
 static DEPTH_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"depth (\d+)").unwrap());
 static PERFT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"perft (\d+)").unwrap());
 
-/// Reads the value that follows a keyword. The value is matched as digits, so
-/// the only way it can fail to parse is by being too large to hold, in which
-/// case use the largest value we can. Discarding it would read as the keyword
-/// having been absent, which for a clock means searching without a limit.
+/// Reads the value that follows a keyword. A clock below zero, which the match
+/// tools send once their time margin has been eaten into, reads as an empty
+/// one. Otherwise the value is digits, so the only way it can fail to parse is
+/// by being too large to hold, in which case use the largest value we can.
+/// Discarding either would read as the keyword having been absent, which for
+/// a clock means searching without a limit.
 fn capture(re: &Regex, line: &str) -> Option<u64> {
     let digits = re.captures(line)?.get(1)?.as_str();
+    if digits.starts_with('-') {
+        return Some(0);
+    }
     Some(digits.parse().unwrap_or(u64::MAX))
 }
 
@@ -359,6 +364,16 @@ mod tests {
     }
 
     #[test]
+    fn a_search_on_a_negative_clock_still_answers_with_a_move() {
+        let mut uci = uci();
+        uci.run(Cursor::new("position startpos\ngo wtime -5 btime -5\n"));
+        let said = said(&uci);
+        let last = said.lines().last().unwrap_or("");
+        assert!(last.starts_with("bestmove "), "{}", said);
+        assert_ne!(last, "bestmove 0000", "{}", said);
+    }
+
+    #[test]
     fn a_position_with_no_legal_moves_reports_the_null_move() {
         for fen in [
             "7k/6Q1/6K1/8/8/8/8/8 b - - 0 1", // checkmate
@@ -451,6 +466,19 @@ mod tests {
             Some(u64::MAX),
             "an unreadable clock must not turn into an unlimited search"
         );
+    }
+
+    #[test]
+    fn a_negative_clock_is_read_as_empty() {
+        // cutechess and fastchess send a clock below zero once their time
+        // margin has been eaten into. Not reading it would leave the budget
+        // unset and search without a limit, at the moment there is the least
+        // time to spare
+        let control = time_control_from("go wtime -5 btime -5", Color::White);
+        assert_eq!(control.time, Some(0));
+        let control = time_control_from("go wtime -5 btime -5 winc -1 binc -1", Color::Black);
+        assert_eq!(control.time, Some(0));
+        assert_eq!(control.increment, Some(0));
     }
 
     #[test]


### PR DESCRIPTION
Two bugs found by the repository audit, each fixed test-first with a reproduction.

## `fix(search)`: a mate on the hundredth half move was scored as a draw

The interior draw check (`engine.rs:323`) returned 0 for `fifty_move_rule >= 100` before asking whether the side to move had a move at all. Checkmate ends the game before any claim can be made, so the mate has to outrank the rule.

```
position fen k7/8/1K6/8/8/8/8/7R w - - 99 100
before:  info depth 4 ... score cp 0    pv h1a1    bestmove h1a1
after:   info depth 4 ... score mate 1  pv h1h8    bestmove h1h8
```

The draw return now asks first whether the side to move is in check with no legal reply (`Board::has_legal_move`, only ever called in that rare case). A repetition cannot coincide with a mate, so it needs no such check. Root and PV replay are unchanged. Two tests: the mate is found and reported as mate in one; a check the king can step out of on the same half move still reads as a draw.

## `fix(uci)`: a negative clock became an unlimited search

`wtime (\d+)` and friends matched nothing on `go wtime -5 btime -5`, which cutechess and fastchess send once their time margin is eaten into. With no increment to fall back on, the budget was unset and the search ran to `MAX_DEPTH`:

```
before:  go wtime -5 btime -5  →  still deepening past depth 9 when killed at 3 s, no bestmove
after:   go wtime -5 btime -5  →  bestmove b1c3 in 0.10 s
```

The patterns accept a sign and a signed value reads as zero, which the existing floor turns into the 1 ms minimum budget. Two tests: the parse for clock and increment, and a search driven through the interface on a negative clock that must answer with a move.

## Verification

- `cargo test --workspace --release`: 39 + 92 pass; `cargo test --workspace` (debug, with the state-in-step asserts): 39 + 93 pass
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean
- `node_counts_have_not_moved` is unchanged: neither pinned position is near the fifty-move rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)
