### PR TITLE
refactor: Correct three names that say the wrong thing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,4 +50,4 @@ repos:
           - --verbose
           - --force-scope
           - --scopes
-          - bench,board,book,ci,deps,deps-dev,docker,docs,eval,lint,magic,release,search,uci,zorbrist
+          - bench,board,book,ci,deps,deps-dev,docker,docs,eval,lint,magic,release,search,uci,zobrist

--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -184,7 +184,7 @@ struct AttackMasks {
 
 impl AttackMasks {
     fn new() -> Self {
-        let mut am = AttackMasks {
+        let mut attack_masks = AttackMasks {
             black_pawns: [0; 64],
             white_pawns: [0; 64],
             knights: [0; 64],
@@ -224,16 +224,16 @@ impl AttackMasks {
 
             for j in &kings {
                 let index = i + j;
-                am.kings[i as usize].set_bit(index as u8);
+                attack_masks.kings[i as usize].set_bit(index as u8);
             }
 
             for j in &white_pawns {
                 let index = i + j;
-                am.white_pawns[i as usize].set_bit(index as u8);
+                attack_masks.white_pawns[i as usize].set_bit(index as u8);
             }
             for j in &black_pawns {
                 let index = i + j;
-                am.black_pawns[i as usize].set_bit(index as u8);
+                attack_masks.black_pawns[i as usize].set_bit(index as u8);
             }
 
             for j in &knights {
@@ -244,7 +244,7 @@ impl AttackMasks {
                     let file_diff = file as isize - new_file as isize;
 
                     if (rank_diff).abs() <= 2 && (file_diff).abs() <= 2 {
-                        am.knights[i as usize].set_bit(index as u8);
+                        attack_masks.knights[i as usize].set_bit(index as u8);
                     };
                 }
             }
@@ -252,8 +252,8 @@ impl AttackMasks {
             for j in 0..8 {
                 let horizontal_index = (i / 8 * 8) + j;
                 let vertical_index = (i % 8) + (j * 8);
-                am.straight[i as usize].set_bit(horizontal_index as u8);
-                am.straight[i as usize].set_bit(vertical_index as u8);
+                attack_masks.straight[i as usize].set_bit(horizontal_index as u8);
+                attack_masks.straight[i as usize].set_bit(vertical_index as u8);
             }
 
             let directions = [9isize, -9, 11, -11];
@@ -267,11 +267,11 @@ impl AttackMasks {
                     };
                     let check_index = BASE_CONVERSIONS.base_100_to_64[check_100_index as usize];
                     j += 1;
-                    am.diagonal[i as usize].set_bit(check_index);
+                    attack_masks.diagonal[i as usize].set_bit(check_index);
                 }
             }
         }
-        am
+        attack_masks
     }
 }
 

--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -6,7 +6,7 @@ use super::misc::{
 use super::play::Play;
 use crate::Game;
 use crate::magic::Magic;
-use crate::pvt::PieceValueTables;
+use crate::psqt::PieceSquareTables;
 use crate::zobrist::Zobrist;
 use smallvec::SmallVec;
 use std::fmt;
@@ -71,7 +71,7 @@ const F8: u8 = 61;
 const G8: u8 = 62;
 const H8: u8 = 63;
 
-static PVT: PieceValueTables = PieceValueTables::TABLES;
+static PIECE_SQUARE_TABLES: PieceSquareTables = PieceSquareTables::TABLES;
 static ZOBRIST: Zobrist = Zobrist::TABLE;
 
 static ATTACK_MASKS: LazyLock<AttackMasks> = LazyLock::new(AttackMasks::new);
@@ -704,8 +704,12 @@ impl Board {
             let index = pop_lsb(&mut occupied);
             if let Some((piece, color)) = self.get_piece_and_color_index(index) {
                 total += i32::from(match color {
-                    Color::White => PVT.get_value(index as usize, piece, Color::White),
-                    Color::Black => -PVT.get_value(index as usize, piece, Color::Black),
+                    Color::White => {
+                        PIECE_SQUARE_TABLES.get_value(index as usize, piece, Color::White)
+                    }
+                    Color::Black => {
+                        -PIECE_SQUARE_TABLES.get_value(index as usize, piece, Color::Black)
+                    }
                 });
             }
         }
@@ -1248,8 +1252,8 @@ impl Board {
         let zobrist: &Zobrist = &ZOBRIST;
         self.key ^= zobrist.get_piece_key(index, piece, color);
         self.psqt += i32::from(match color {
-            Color::White => PVT.get_value(index as usize, piece, Color::White),
-            Color::Black => -PVT.get_value(index as usize, piece, Color::Black),
+            Color::White => PIECE_SQUARE_TABLES.get_value(index as usize, piece, Color::White),
+            Color::Black => -PIECE_SQUARE_TABLES.get_value(index as usize, piece, Color::Black),
         });
         match piece {
             Piece::Pawn => self.pawns.set_bit(index),
@@ -1282,8 +1286,8 @@ impl Board {
         let zobrist: &Zobrist = &ZOBRIST;
         self.key ^= zobrist.get_piece_key(index, piece, color);
         self.psqt -= i32::from(match color {
-            Color::White => PVT.get_value(index as usize, piece, Color::White),
-            Color::Black => -PVT.get_value(index as usize, piece, Color::Black),
+            Color::White => PIECE_SQUARE_TABLES.get_value(index as usize, piece, Color::White),
+            Color::Black => -PIECE_SQUARE_TABLES.get_value(index as usize, piece, Color::Black),
         });
         match piece {
             Piece::Pawn => self.pawns.clear_bit(index),

--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -7,7 +7,7 @@ use super::play::Play;
 use crate::Game;
 use crate::magic::Magic;
 use crate::pvt::PieceValueTables;
-use crate::zorbrist::Zorbrist;
+use crate::zobrist::Zobrist;
 use smallvec::SmallVec;
 use std::fmt;
 use std::sync::LazyLock;
@@ -72,7 +72,7 @@ const G8: u8 = 62;
 const H8: u8 = 63;
 
 static PVT: PieceValueTables = PieceValueTables::TABLES;
-static ZORB: Zorbrist = Zorbrist::TABLE;
+static ZOBRIST: Zobrist = Zobrist::TABLE;
 
 static ATTACK_MASKS: LazyLock<AttackMasks> = LazyLock::new(AttackMasks::new);
 pub static BASE_CONVERSIONS: LazyLock<BaseConversions> = LazyLock::new(BaseConversions::new);
@@ -678,15 +678,15 @@ impl Board {
         while occupied != 0 {
             let index = pop_lsb(&mut occupied);
             if let Some((piece, color)) = self.get_piece_and_color_index(index) {
-                key ^= ZORB.get_piece_key(index, piece, color);
+                key ^= ZOBRIST.get_piece_key(index, piece, color);
             }
         }
         if matches!(self.active_color, Color::Black) {
-            key ^= ZORB.side;
+            key ^= ZOBRIST.side;
         }
-        key ^= ZORB.castle_key(self.castle);
+        key ^= ZOBRIST.castle_key(self.castle);
         if let Some(en_passant) = self.en_passant {
-            key ^= ZORB.en_passant_key(en_passant.as_index());
+            key ^= ZOBRIST.en_passant_key(en_passant.as_index());
         }
         key
     }
@@ -837,7 +837,7 @@ impl Board {
         });
 
         let opposing_color = !self.active_color;
-        let zorb: &Zorbrist = &ZORB;
+        let zobrist: &Zobrist = &ZOBRIST;
         // update castling permissions
         let old_castle = self.castle;
         match play.from {
@@ -866,10 +866,10 @@ impl Board {
         }
         // XORing both the old and new castle keys removes the old permissions
         // from the position key and adds the new ones (a no-op when unchanged)
-        self.key ^= zorb.castle_key(old_castle) ^ zorb.castle_key(self.castle);
+        self.key ^= zobrist.castle_key(old_castle) ^ zobrist.castle_key(self.castle);
         if let Some(en_passant) = self.en_passant {
             // the en passant rights of the previous position have expired
-            self.key ^= zorb.en_passant_key(en_passant.as_index());
+            self.key ^= zobrist.en_passant_key(en_passant.as_index());
         }
         self.en_passant = None;
         self.fifty_move_rule += 1;
@@ -888,7 +888,7 @@ impl Board {
                 };
                 if self.pawn_can_capture_on(passed, opposing_color) {
                     self.en_passant = Some(Coordinate::from_index(passed));
-                    self.key ^= zorb.en_passant_key(passed);
+                    self.key ^= zobrist.en_passant_key(passed);
                 }
             }
             if play.en_passant {
@@ -954,7 +954,7 @@ impl Board {
             || attack_masks.straight[king_index as usize].is_bit_set(play.from)
             || attack_masks.diagonal[king_index as usize].is_bit_set(play.from);
         self.active_color = opposing_color;
-        self.key ^= zorb.side;
+        self.key ^= zobrist.side;
         self.debug_assert_state_in_step();
         debug_assert!(
             could_expose_king || !self.square_attacked(king_index, opposing_color),
@@ -1245,8 +1245,8 @@ impl Board {
     fn set_piece_index(&mut self, index: u8, piece: Piece, color: Color) {
         debug_assert!(!self.black.is_bit_set(index));
         debug_assert!(!self.white.is_bit_set(index));
-        let zorb: &Zorbrist = &ZORB;
-        self.key ^= zorb.get_piece_key(index, piece, color);
+        let zobrist: &Zobrist = &ZOBRIST;
+        self.key ^= zobrist.get_piece_key(index, piece, color);
         self.psqt += i32::from(match color {
             Color::White => PVT.get_value(index as usize, piece, Color::White),
             Color::Black => -PVT.get_value(index as usize, piece, Color::Black),
@@ -1279,8 +1279,8 @@ impl Board {
     #[inline]
     fn clear_piece_index(&mut self, index: u8, piece: Piece, color: Color) {
         debug_assert!((self.black | self.white).is_bit_set(index));
-        let zorb: &Zorbrist = &ZORB;
-        self.key ^= zorb.get_piece_key(index, piece, color);
+        let zobrist: &Zobrist = &ZOBRIST;
+        self.key ^= zobrist.get_piece_key(index, piece, color);
         self.psqt -= i32::from(match color {
             Color::White => PVT.get_value(index as usize, piece, Color::White),
             Color::Black => -PVT.get_value(index as usize, piece, Color::Black),
@@ -1540,14 +1540,14 @@ impl Game for Board {
         // comparable between boards parsed from FEN and boards reached by
         // playing moves
         if matches!(board.active_color, Color::Black) {
-            board.key ^= ZORB.side;
+            board.key ^= ZOBRIST.side;
         }
-        board.key ^= ZORB.castle_key(board.castle);
+        board.key ^= ZOBRIST.castle_key(board.castle);
         // the same rule as make_move, or a position parsed and the same one
         // played would not hash alike, which is worse than what is being fixed
         if let Some(en_passant) = board.en_passant {
             if board.pawn_can_capture_on(en_passant.as_index(), board.active_color) {
-                board.key ^= ZORB.en_passant_key(en_passant.as_index());
+                board.key ^= ZOBRIST.en_passant_key(en_passant.as_index());
             } else {
                 board.en_passant = None;
             }
@@ -1883,14 +1883,14 @@ mod position_key {
     #[cfg(debug_assertions)]
     #[should_panic(expected = "en passant square no pawn can take")]
     fn an_en_passant_square_no_pawn_can_take_fails_the_state_check() {
-        use super::{Coordinate, ZORB};
+        use super::{Coordinate, ZOBRIST};
         let mut board = Board::new();
         // e6 is out of reach of every white pawn at the start. Hash the bogus
         // square into the key as well as the field, so the key still matches
         // its recompute and only the rule itself can object: this is exactly
         // the corruption the recompute comparison is blind to.
         board.en_passant = Coordinate::from_string("e6").unwrap();
-        board.key ^= ZORB.en_passant_key(board.en_passant.unwrap().as_index());
+        board.key ^= ZOBRIST.en_passant_key(board.en_passant.unwrap().as_index());
         board.debug_assert_state_in_step();
     }
 

--- a/basic_engine/src/lib.rs
+++ b/basic_engine/src/lib.rs
@@ -4,7 +4,7 @@ mod engine;
 mod magic;
 mod misc;
 mod play;
-mod pvt;
+mod psqt;
 mod zobrist;
 
 pub use board::Board;

--- a/basic_engine/src/lib.rs
+++ b/basic_engine/src/lib.rs
@@ -5,7 +5,7 @@ mod magic;
 mod misc;
 mod play;
 mod pvt;
-mod zorbrist;
+mod zobrist;
 
 pub use board::Board;
 pub use engine::{AlphaBeta, Engine, PvLine, SearchOutcome, SearchParameters, SearchResult};

--- a/basic_engine/src/magic.rs
+++ b/basic_engine/src/magic.rs
@@ -234,7 +234,7 @@ impl BlockerBoards {
 
 impl BlockerMasks {
     fn new() -> Self {
-        let mut am = BlockerMasks {
+        let mut blocker_masks = BlockerMasks {
             straight: [0; 64], // rooks and queens
             diagonal: [0; 64], // bishops and queens
         };
@@ -242,8 +242,8 @@ impl BlockerMasks {
             for j in 1..7 {
                 let horizontal_index = (i / 8 * 8) + j;
                 let vertical_index = (i % 8) + (j * 8);
-                am.straight[i].set_bit(horizontal_index as u8);
-                am.straight[i].set_bit(vertical_index as u8);
+                blocker_masks.straight[i].set_bit(horizontal_index as u8);
+                blocker_masks.straight[i].set_bit(vertical_index as u8);
             }
 
             let directions = [9isize, -9, 11, -11];
@@ -258,13 +258,13 @@ impl BlockerMasks {
                         break; // if the next one is offboard then break now before setting the bit
                         // since a piece on the edge in direction of movement can't block
                     };
-                    am.diagonal[i].set_bit(check_index);
+                    blocker_masks.diagonal[i].set_bit(check_index);
                 }
             }
-            am.diagonal[i].clear_bit(i as u8); // can't be blocked by self
-            am.straight[i].clear_bit(i as u8); // can't be blocked by self
+            blocker_masks.diagonal[i].clear_bit(i as u8); // can't be blocked by self
+            blocker_masks.straight[i].clear_bit(i as u8); // can't be blocked by self
         }
-        am
+        blocker_masks
     }
 }
 

--- a/basic_engine/src/misc.rs
+++ b/basic_engine/src/misc.rs
@@ -13,7 +13,7 @@ use std::ops::Not;
 pub type Score = i16;
 
 /// One step of splitmix64, which turns a seed into a stream of well spread
-/// numbers. Small enough to run at compile time, which is what the zorbrist
+/// numbers. Small enough to run at compile time, which is what the zobrist
 /// keys need, and good enough for the magic search, which only wants candidates
 /// that are well spread rather than unpredictable.
 ///

--- a/basic_engine/src/psqt.rs
+++ b/basic_engine/src/psqt.rs
@@ -96,7 +96,7 @@ const QUEENS: [i16; 64] = [
 /// the ten tables are then 1280 bytes rather than 5120 and stay in L1 alongside
 /// everything else the search is touching. The values run from -50 to 50, so the
 /// narrower type costs nothing.
-pub struct PieceValueTables {
+pub struct PieceSquareTables {
     white_pawns: [i16; 64],
     black_pawns: [i16; 64],
 
@@ -113,7 +113,7 @@ pub struct PieceValueTables {
     black_queens: [i16; 64],
 }
 
-impl PieceValueTables {
+impl PieceSquareTables {
     #[inline]
     pub fn get_value(&self, index: usize, piece: Piece, color: Color) -> i16 {
         match (piece, color) {
@@ -133,7 +133,7 @@ impl PieceValueTables {
 
     /// Built at compile time, so there is nothing to construct on startup and
     /// nothing to synchronise on when reading it.
-    pub const TABLES: PieceValueTables = PieceValueTables {
+    pub const TABLES: PieceSquareTables = PieceSquareTables {
         white_pawns: mirror(&PAWNS),
         black_pawns: PAWNS,
         white_knights: mirror(&KNIGHTS),
@@ -155,7 +155,7 @@ mod tests {
 
     fn value(piece: Piece, color: Color, file: File, rank: u8) -> i16 {
         let index = coordinate_to_index(rank, file) as usize;
-        PieceValueTables::TABLES.get_value(index, piece, color)
+        PieceSquareTables::TABLES.get_value(index, piece, color)
     }
 
     /// The tables are written with the eighth rank first and the board indexes

--- a/basic_engine/src/zobrist.rs
+++ b/basic_engine/src/zobrist.rs
@@ -1,18 +1,18 @@
 use crate::Color;
 use crate::misc::{CastlePermissions, Piece, split_mix};
 
-pub struct Zorbrist {
+pub struct Zobrist {
     pieces: [[u64; 64]; 12],
     pub side: u64,
     castling: [u64; 4],
     en_passant: [u64; 8],
 }
 
-impl Zorbrist {
+impl Zobrist {
     /// The keys, built at compile time. They only have to be well spread and
     /// the same on both sides of a game, so there is nothing to be gained from
     /// drawing them at startup.
-    pub const TABLE: Zorbrist = Self::build(0x3865_5440_d1b6_3d78);
+    pub const TABLE: Zobrist = Self::build(0x3865_5440_d1b6_3d78);
 
     const fn build(seed: u64) -> Self {
         let mut state = seed;
@@ -96,7 +96,7 @@ impl Zorbrist {
 
 #[cfg(test)]
 mod keys {
-    use super::Zorbrist;
+    use super::Zobrist;
     use pretty_assertions::assert_eq;
 
     /// The keys are constants rather than draws now, so this guards the seed and
@@ -104,7 +104,7 @@ mod keys {
     /// different positions share a hash.
     #[test]
     fn every_key_is_distinct() {
-        let z = Zorbrist::TABLE;
+        let z = Zobrist::TABLE;
         let mut all = z.pieces.iter().flatten().copied().collect::<Vec<u64>>();
         all.push(z.side);
         all.extend(z.castling);

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -94,7 +94,7 @@ The engine ones are grouped by type instead:
 | `magic` | move generation, the magic bitboards and their tables |
 | `search` | alpha beta, quiescence and the transposition table |
 | `uci` | the protocol and time management |
-| `zorbrist` | the hash keys, spelled as the module is |
+| `zobrist` | the hash keys |
 
 `feat`, `fix`, `perf`, `refactor` and `docs` get a section each, and `build`,
 `chore`, `ci`, `style` and `test` all go to **Development**.


### PR DESCRIPTION
Four renames, one commit each. No behaviour change: replaying the same
identifier substitutions over master's copies of the six touched files, then
running rustfmt, reproduces every committed file byte for byte.

**`refactor(zobrist)`** — the keys are named after Albert Zobrist, and the
module, the struct, the static and the locals all had the r and the b the wrong
way round. The development guide had gone as far as documenting the
misspelling, listing the scope as "the hash keys, spelled as the module is".
The scope the commit-msg hook accepts changes in the same commit, because
pre-commit reads `.pre-commit-config.yaml` from the working tree — split apart,
the hook would reject `refactor(zobrist)`. `CHANGELOG.md` keeps its three
`*(zorbrist)*` entries, which record what those commits said at the time.

**`refactor(eval)`** — "piece value" already means something else here:
`Piece::material_value` is what a piece is worth. These tables hold the worth of
a piece *on a square*, which the rest of the code already calls psqt — both the
accumulator they feed and the function that recomputes it. So `pvt` → `psqt`,
`PieceValueTables` → `PieceSquareTables`, `PVT` → `PIECE_SQUARE_TABLES`.

The static is named after its type, which is what `ATTACK_MASKS`,
`BASE_CONVERSIONS`, `MAGIC` and `ZOBRIST` all do. That costs two lines of
`recompute_psqt` their place under the width, so rustfmt braces those two match
arms — the extra lines in the diffstat. The other four call sites are
unaffected.

**`refactor(board)`** — `AttackMasks::new` built its tables in a local called
`am`, in a function long enough that the type declaration is off screen for
most of it. It is `attack_masks` rather than plain `masks` because that is what
all eight other bindings of this type in the file are called, and because a
bare "mask" here means a `u64` of squares (`mask`, `color_mask`,
`capture_mask`, `attacker_mask`, `move_mask`) which this is not.

**`refactor(magic)`** — `BlockerMasks::new` had the same `am`, copied across
from the function above and still standing for attack masks while holding
blocker masks. The two differ by exactly the thing the type exists for: a
blocker mask is an attack mask with the last square of each ray trimmed off,
because a piece there blocks nothing behind it.

### Checks

- `fmt` and `clippy -D warnings` clean
- `cargo test --workspace --release`: 92 passed; debug profile: 93 passed
- Reviewed over the full diff: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
