### PR TITLE
feat: Honour go nodes, and always finish depth one

### DIFF
--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -167,6 +167,15 @@ impl AlphaBeta {
         if self.nodes < self.next_check {
             return Ok(());
         }
+        self.check_limits()
+    }
+
+    /// The slow half of poll_deadline, kept out of the search's own code:
+    /// reading the clock and arming the next check happen once in thousands
+    /// of nodes, and inlined at every poll they only made the hot loop larger.
+    #[cold]
+    #[inline(never)]
+    fn check_limits(&mut self) -> Result<(), Aborted> {
         if self.nodes >= self.node_budget {
             return Err(Aborted);
         }
@@ -175,7 +184,10 @@ impl AlphaBeta {
                 return Err(Aborted);
             }
         }
-        self.next_check = (self.nodes + POLL_INTERVAL).min(self.node_budget);
+        self.next_check = self
+            .nodes
+            .saturating_add(POLL_INTERVAL)
+            .min(self.node_budget);
         Ok(())
     }
 
@@ -1258,17 +1270,53 @@ mod search {
 
     #[test]
     fn a_node_budget_stops_the_search_on_exactly_that_node() {
+        // a spread of budgets, so the last node falls in the full search and
+        // in quiescence by turns, and now and then exactly on the end of an
+        // iteration, which leaves the next one nothing and aborts it at once
+        for limit in (50..6_000).step_by(97) {
+            let mut e = engine(Board::new());
+            let mut options = SearchParameters::new();
+            options.nodes = Some(limit);
+            let mut completed: u64 = 0;
+            let outcome =
+                e.iterative_deepening_search(options, |_, result, _| completed = result.nodes);
+            assert!(
+                matches!(outcome, SearchOutcome::Aborted(Some(_))),
+                "{}",
+                limit
+            );
+            // the reported total is the last completed depth's, and the
+            // aborted iteration's own count is still on the engine: together
+            // they are every node visited, and that has to be the budget to
+            // the node
+            assert_eq!(completed + e.nodes, limit, "budget {}", limit);
+        }
+    }
+
+    #[test]
+    fn a_node_budget_and_a_clock_stop_at_whichever_comes_first() {
+        // the clock wins: a spent clock and a generous budget end after
+        // depth one, which runs whatever either says
         let mut e = engine(Board::new());
-        let limit = 5_000;
+        let mut options = SearchParameters::new();
+        options.nodes = Some(1_000_000);
+        options.search_duration = Some(time::Duration::ZERO);
+        let mut depths = Vec::new();
+        let outcome = e.iterative_deepening_search(options, |depth, _, _| depths.push(depth));
+        assert!(matches!(outcome, SearchOutcome::Aborted(Some(_))));
+        assert_eq!(depths, vec![1]);
+
+        // the budget wins: a clock with time to spare and a small budget stop
+        // on the budget's node
+        let mut e = engine(Board::new());
+        let limit = 1_000;
         let mut options = SearchParameters::new();
         options.nodes = Some(limit);
+        options.search_duration = Some(time::Duration::from_secs(10));
         let mut completed: u64 = 0;
         let outcome =
             e.iterative_deepening_search(options, |_, result, _| completed = result.nodes);
         assert!(matches!(outcome, SearchOutcome::Aborted(Some(_))));
-        // the reported total is the last completed depth's, and the aborted
-        // iteration's own count is still on the engine: together they are
-        // every node visited, and that has to be the budget to the node
         assert_eq!(completed + e.nodes, limit);
     }
 

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -8,6 +8,8 @@ use std::time;
 
 const CHECKMATE_SCORE: Score = 30_000;
 const MAX_DEPTH: u8 = 20;
+/// How many nodes pass between reads of the clock.
+const POLL_INTERVAL: u64 = 3000;
 const DEFAULT_TABLE_BYTES: usize = 256 * 1024 * 1024;
 // Any score this close to CHECKMATE_SCORE is a forced mate. Regular evals are
 // bounded by the material on the board, which cannot come near it.
@@ -75,6 +77,9 @@ pub trait Engine {
 pub struct SearchParameters {
     pub depth: Option<u8>,
     pub search_duration: Option<time::Duration>,
+    /// The most nodes the whole search may visit, or none. Depth one runs
+    /// regardless, so an answer always exists.
+    pub nodes: Option<u64>,
     pub start_time: time::Instant,
 }
 
@@ -89,6 +94,7 @@ impl SearchParameters {
         Self {
             depth: None,
             search_duration: None,
+            nodes: None,
             start_time: time::Instant::now(),
         }
     }
@@ -97,6 +103,7 @@ impl SearchParameters {
         Self {
             depth: Some(depth),
             search_duration: None,
+            nodes: None,
             start_time: time::Instant::now(),
         }
     }
@@ -115,6 +122,11 @@ pub struct AlphaBeta {
     pub ghi: GhiCounters,
     start_time: time::Instant,
     search_duration: Option<time::Duration>,
+    /// The nodes this search call may visit, u64::MAX for no limit.
+    node_budget: u64,
+    /// The node count at which the limits are looked at next: every
+    /// POLL_INTERVAL nodes for the clock, and the budget itself, exactly.
+    next_check: u64,
 }
 
 impl AlphaBeta {
@@ -128,6 +140,8 @@ impl AlphaBeta {
             ghi: GhiCounters::default(),
             start_time: time::Instant::now(),
             search_duration: None,
+            node_budget: u64::MAX,
+            next_check: 0,
         }
     }
 
@@ -139,16 +153,24 @@ impl AlphaBeta {
         self.moves.clear();
     }
 
-    /// Cooperative deadline check, polled every few thousand nodes so the
-    /// clock is not read on every one of them.
-    fn poll_deadline(&self) -> Result<(), Aborted> {
-        if self.nodes % 3000 == 0 {
-            if let Some(search_time) = self.search_duration {
-                if self.start_time.elapsed() >= search_time {
-                    return Err(Aborted);
-                }
+    /// Cooperative limit check. The clock is read every POLL_INTERVAL nodes
+    /// rather than on every one, and the node budget is checked on the node
+    /// it names, which is what lets a fixed node search stop on that node.
+    /// The count is incremented after this is asked, so a budget of n is n
+    /// nodes visited.
+    fn poll_deadline(&mut self) -> Result<(), Aborted> {
+        if self.nodes < self.next_check {
+            return Ok(());
+        }
+        if self.nodes >= self.node_budget {
+            return Err(Aborted);
+        }
+        if let Some(search_time) = self.search_duration {
+            if self.start_time.elapsed() >= search_time {
+                return Err(Aborted);
             }
         }
+        self.next_check = (self.nodes + POLL_INTERVAL).min(self.node_budget);
         Ok(())
     }
 
@@ -499,14 +521,22 @@ impl AlphaBeta {
     /// come from a line whose repetition and fifty move context differ from
     /// the game being played, and the answer must not depend on one.
     pub fn search(&mut self, depth: u8) -> SearchOutcome {
-        self.search_within(depth, self.search_duration)
+        self.search_within(depth, u64::MAX, self.search_duration)
     }
 
     /// One fixed depth search under the limits given for it. `search` passes
-    /// the configured deadline through; the deepening loop decides per
-    /// iteration, which is how depth one runs with none.
-    fn search_within(&mut self, depth: u8, deadline: Option<time::Duration>) -> SearchOutcome {
+    /// the configured deadline through with no node budget; the deepening
+    /// loop decides both per iteration, which is how depth one runs with
+    /// neither.
+    fn search_within(
+        &mut self,
+        depth: u8,
+        node_budget: u64,
+        deadline: Option<time::Duration>,
+    ) -> SearchOutcome {
         self.search_duration = deadline;
+        self.node_budget = node_budget;
+        self.next_check = 0;
         self.nodes = 0;
         self.selective_depth = depth;
         self.board.line_ply = 0;
@@ -666,12 +696,18 @@ impl Engine for AlphaBeta {
             // a limit is only armed once a completed iteration is in hand:
             // whatever the clock says the answer has to be a legal move, and
             // depth one is the few dozen nodes that make sure there is one
-            let deadline = if best.is_some() {
-                search_options.search_duration
+            let (node_budget, deadline) = if best.is_some() {
+                (
+                    search_options
+                        .nodes
+                        .map(|limit| limit.saturating_sub(total_nodes))
+                        .unwrap_or(u64::MAX),
+                    search_options.search_duration,
+                )
             } else {
-                None
+                (u64::MAX, None)
             };
-            match self.search_within(depth, deadline) {
+            match self.search_within(depth, node_budget, deadline) {
                 SearchOutcome::Aborted(partial) => {
                     // A completed shallower iteration outranks the interrupted
                     // one's best-so-far, which may be a fail high that never
@@ -1204,6 +1240,52 @@ mod search {
     }
 
     #[test]
+    fn a_node_budget_stops_the_search_on_exactly_that_node() {
+        let mut e = engine(Board::new());
+        let limit = 5_000;
+        let mut options = SearchParameters::new();
+        options.nodes = Some(limit);
+        let mut completed: u64 = 0;
+        let outcome =
+            e.iterative_deepening_search(options, |_, result, _| completed = result.nodes);
+        assert!(matches!(outcome, SearchOutcome::Aborted(Some(_))));
+        // the reported total is the last completed depth's, and the aborted
+        // iteration's own count is still on the engine: together they are
+        // every node visited, and that has to be the budget to the node
+        assert_eq!(completed + e.nodes, limit);
+    }
+
+    #[test]
+    fn a_node_budget_too_small_for_depth_one_still_answers_a_move() {
+        let mut e = engine(Board::new());
+        let mut options = SearchParameters::new();
+        options.nodes = Some(0);
+        let mut depths = Vec::new();
+        let outcome = e.iterative_deepening_search(options, |depth, _, _| depths.push(depth));
+        assert!(matches!(outcome, SearchOutcome::Aborted(Some(_))));
+        assert_eq!(depths, vec![1]);
+    }
+
+    #[test]
+    fn a_node_budget_and_a_depth_stop_at_whichever_comes_first() {
+        let mut e = engine(Board::new());
+        let mut options = SearchParameters::new_with_depth(2);
+        options.nodes = Some(1_000_000);
+        assert!(matches!(
+            e.iterative_deepening_search(options, |_, _, _| {}),
+            SearchOutcome::Complete(_)
+        ));
+
+        let mut e = engine(Board::new());
+        let mut options = SearchParameters::new_with_depth(super::MAX_DEPTH);
+        options.nodes = Some(1_000);
+        let mut last_depth = 0;
+        let outcome = e.iterative_deepening_search(options, |depth, _, _| last_depth = depth);
+        assert!(matches!(outcome, SearchOutcome::Aborted(Some(_))));
+        assert!(last_depth < super::MAX_DEPTH);
+    }
+
+    #[test]
     fn timed_out_deepening_still_returns_a_move() {
         // The budget runs out long before MAX_DEPTH can complete, so the
         // deepening loop ends on an Aborted outcome and must fall back to a
@@ -1213,6 +1295,7 @@ mod search {
         let params = SearchParameters {
             depth: None,
             search_duration: Some(time::Duration::from_millis(50)),
+            nodes: None,
             start_time: time::Instant::now(),
         };
         let outcome = e.iterative_deepening_search(params, |_, _, _| {});

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -499,6 +499,14 @@ impl AlphaBeta {
     /// come from a line whose repetition and fifty move context differ from
     /// the game being played, and the answer must not depend on one.
     pub fn search(&mut self, depth: u8) -> SearchOutcome {
+        self.search_within(depth, self.search_duration)
+    }
+
+    /// One fixed depth search under the limits given for it. `search` passes
+    /// the configured deadline through; the deepening loop decides per
+    /// iteration, which is how depth one runs with none.
+    fn search_within(&mut self, depth: u8, deadline: Option<time::Duration>) -> SearchOutcome {
+        self.search_duration = deadline;
         self.nodes = 0;
         self.selective_depth = depth;
         self.board.line_ply = 0;
@@ -655,7 +663,15 @@ impl Engine for AlphaBeta {
         self.configure(search_options.start_time, search_options.search_duration);
 
         for depth in 1..=max_depth {
-            match self.search(depth) {
+            // a limit is only armed once a completed iteration is in hand:
+            // whatever the clock says the answer has to be a legal move, and
+            // depth one is the few dozen nodes that make sure there is one
+            let deadline = if best.is_some() {
+                search_options.search_duration
+            } else {
+                None
+            };
+            match self.search_within(depth, deadline) {
                 SearchOutcome::Aborted(partial) => {
                     // A completed shallower iteration outranks the interrupted
                     // one's best-so-far, which may be a fail high that never
@@ -913,7 +929,7 @@ mod search {
     use super::Board;
     use super::Engine;
     use super::Game;
-    use super::{Bound, Play, Pv, SearchOutcome, SearchResult};
+    use super::{Bound, Play, Pv, SearchOutcome, SearchParameters, SearchResult};
     use crate::board::{fens, play_named};
     use pretty_assertions::assert_eq;
     use std::time;
@@ -1167,6 +1183,24 @@ mod search {
         let mut e = engine(Board::new());
         e.configure(time::Instant::now(), Some(time::Duration::ZERO));
         assert!(matches!(e.search(5), SearchOutcome::Aborted(None)));
+    }
+
+    #[test]
+    fn deepening_with_no_time_budget_still_answers_depth_one() {
+        // a clock that has already run out must still get a legal move back:
+        // depth one is a few dozen nodes, so it runs whatever the clock says,
+        // and only then is the budget allowed to stop anything
+        let mut e = engine(Board::new());
+        let mut options = SearchParameters::new();
+        options.search_duration = Some(time::Duration::ZERO);
+        let mut depths = Vec::new();
+        let outcome = e.iterative_deepening_search(options, |depth, _, _| depths.push(depth));
+        assert!(
+            matches!(outcome, SearchOutcome::Aborted(Some(_))),
+            "expected a move from depth one, got {:?}",
+            outcome
+        );
+        assert_eq!(depths, vec![1]);
     }
 
     #[test]

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -122,6 +122,10 @@ pub struct AlphaBeta {
     pub ghi: GhiCounters,
     start_time: time::Instant,
     search_duration: Option<time::Duration>,
+    /// The clock limit of the search call under way. search() takes it
+    /// from search_duration, which configure() set; the deepening loop
+    /// chooses it per iteration, and neither disturbs the other
+    deadline: Option<time::Duration>,
     /// The nodes this search call may visit, u64::MAX for no limit.
     node_budget: u64,
     /// The node count at which the limits are looked at next: every
@@ -140,6 +144,7 @@ impl AlphaBeta {
             ghi: GhiCounters::default(),
             start_time: time::Instant::now(),
             search_duration: None,
+            deadline: None,
             node_budget: u64::MAX,
             next_check: 0,
         }
@@ -165,7 +170,7 @@ impl AlphaBeta {
         if self.nodes >= self.node_budget {
             return Err(Aborted);
         }
-        if let Some(search_time) = self.search_duration {
+        if let Some(search_time) = self.deadline {
             if self.start_time.elapsed() >= search_time {
                 return Err(Aborted);
             }
@@ -534,7 +539,7 @@ impl AlphaBeta {
         node_budget: u64,
         deadline: Option<time::Duration>,
     ) -> SearchOutcome {
-        self.search_duration = deadline;
+        self.deadline = deadline;
         self.node_budget = node_budget;
         self.next_check = 0;
         self.nodes = 0;
@@ -708,15 +713,11 @@ impl Engine for AlphaBeta {
                 (u64::MAX, None)
             };
             match self.search_within(depth, node_budget, deadline) {
-                SearchOutcome::Aborted(partial) => {
-                    // A completed shallower iteration outranks the interrupted
-                    // one's best-so-far, which may be a fail high that never
-                    // got re-searched. The partial only fills in when depth 1
-                    // itself ran out of time.
-                    return SearchOutcome::Aborted(best.or(partial.map(|mut result| {
-                        result.nodes += total_nodes;
-                        result
-                    })));
+                SearchOutcome::Aborted(_) => {
+                    // the interrupted iteration's best-so-far is discarded: a
+                    // completed shallower iteration outranks it, and depth one
+                    // runs without limits so there always is one
+                    return SearchOutcome::Aborted(best);
                 }
                 SearchOutcome::GameOver => {
                     // checkmate, stalemate or a rule draw: deeper searches
@@ -926,13 +927,13 @@ pub enum SearchOutcome {
     /// The root has no play to make: checkmate, stalemate, or a rule draw.
     /// Searching deeper cannot change it.
     GameOver,
-    /// The deadline arrived partway through, carrying a best-so-far when the
+    /// A limit ran out partway through, carrying a best-so-far when the
     /// root got far enough to have one. Weaker than any Complete result: the
     /// play may be a fail high that never got re-searched.
     Aborted(Option<SearchResult>),
 }
 
-/// The search hit its deadline and unwound without finishing. The score of an
+/// The search hit a limit and unwound without finishing. The score of an
 /// aborted frame is meaningless, and returning this instead of a score is what
 /// keeps it out of the transposition table: propagation with `?` never reaches
 /// the stores.
@@ -1237,6 +1238,22 @@ mod search {
             outcome
         );
         assert_eq!(depths, vec![1]);
+    }
+
+    #[test]
+    fn deepening_leaves_the_configured_deadline_alone() {
+        // the deadline a deepening was given stays configured for a direct
+        // search() afterwards: the iterations choose their own limits, and
+        // the last one's exemption must not be what is left behind
+        let mut e = engine(Board::new());
+        let mut options = SearchParameters::new_with_depth(1);
+        options.search_duration = Some(time::Duration::ZERO);
+        let outcome = e.iterative_deepening_search(options, |_, _, _| {});
+        assert!(matches!(outcome, SearchOutcome::Complete(_)));
+        assert!(
+            matches!(e.search(5), SearchOutcome::Aborted(None)),
+            "the configured deadline no longer applies"
+        );
     }
 
     #[test]

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -166,6 +166,17 @@ Notes on the flags:
   Watch for `disconnect` in the output, a crashing engine scores zero for that
   game and the result is no longer a fair estimate of strength.
 
+A match can be played by node count instead of by the clock, with `nodes=N`
+in place of `tc=` in the `-each` arguments, which fastchess passes on as
+`go nodes N`. The search is deterministic, so a game played that way is
+reproducible move for move on any machine, which a clock on a shared runner
+cannot offer. The count does not see how long a node takes, though: a change
+that makes nodes faster or slower is invisible to it. Use nodes to compare
+what a search does and the clock to compare what it costs. The tree also
+moves with the size of the transposition table, so a replay needs the same
+table on both sides; the default is the same for every build, so the command
+as written is reproducible.
+
 The error bar shrinks with the square root of the number of games, so roughly
 `800 / sqrt(games)` elo is the smallest difference a match can tell from none.
 Fifty games settles nothing below about a hundred elo. A change worth ten needs

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -18,6 +18,7 @@ static BINC_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"binc (-?\d+)").u
 static MOVES_TO_GO_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"movestogo (\d+)").unwrap());
 static MOVE_TIME: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"movetime (\d+)").unwrap());
 static DEPTH_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"depth (\d+)").unwrap());
+static NODES_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"nodes (\d+)").unwrap());
 static PERFT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"perft (\d+)").unwrap());
 
 /// Reads the value that follows a keyword. A clock below zero, which the match
@@ -183,6 +184,7 @@ impl<T: Engine, W: Write> UCI<T, W> {
         let mut sp = SearchParameters::new();
         sp.search_duration = time_control_from(line, self.engine.active_color()).budget();
         sp.depth = capture(&DEPTH_RE, line).map(|depth| depth.try_into().unwrap_or(u8::MAX));
+        sp.nodes = capture(&NODES_RE, line);
 
         let start = sp.start_time;
         // the closure writes while the engine is borrowed for the search, so
@@ -479,6 +481,29 @@ mod tests {
         let control = time_control_from("go wtime -5 btime -5 winc -1 binc -1", Color::Black);
         assert_eq!(control.time, Some(0));
         assert_eq!(control.increment, Some(0));
+    }
+
+    #[test]
+    fn a_node_limit_is_read() {
+        assert_eq!(capture(&NODES_RE, "go nodes 1234"), Some(1234));
+        assert_eq!(capture(&NODES_RE, "go depth 3"), None);
+    }
+
+    #[test]
+    fn a_node_limit_is_honoured_end_to_end() {
+        let mut uci = uci();
+        uci.run(Cursor::new("position startpos\ngo nodes 5000\n"));
+        let said = said(&uci);
+        let lines: Vec<&str> = said.lines().collect();
+        assert!(lines.last().unwrap().starts_with("bestmove "), "{}", said);
+        let info = lines[lines.len() - 2];
+        let nodes: u64 = info
+            .split_whitespace()
+            .skip_while(|word| *word != "nodes")
+            .nth(1)
+            .and_then(|n| n.parse().ok())
+            .unwrap_or_else(|| panic!("no node count in {}", info));
+        assert!(nodes <= 5000, "{}", said);
     }
 
     #[test]


### PR DESCRIPTION
`go nodes N` was parsed by nothing, so a match tool asking for a fixed number of nodes got an unlimited search. This makes the node limit exact, and on the way guarantees that depth one always completes so a limit that is too small can never produce `bestmove 0000`.

The decisions, in brief:

- **Exact cap.** The clock poll's `% 3000` modulo becomes a `next_check` counter: one compare per node, the same 3000-node cadence for the clock, and the budget itself as the last check point, so the search stops on the node asked for. Stockfish polls its node limit; this is stricter at no cost.
- **Depth one always completes**, for the node budget and the time budget alike. Limits are armed only once a completed iteration is in hand (audit item C9: a 1 ms budget could abort at the root and answer the null move).
- **Limits are independent; earliest wins.** The UCI text says `nodes x` is "search x nodes only" and an absent command "should be interpreted as it would not influence the search"; Stockfish's `check_time()` treats time, movetime and nodes as three independent stop conditions. Same here.
- `search()` keeps counting its own nodes; the deepening loop hands each iteration what remains through a private `search_within`, so `node_counts_have_not_moved` is unchanged.

## Commits

1. `fix(search)`: finish depth one before the clock can stop the search
2. `feat(search)`: take a node budget and stop on the node it names
3. `feat(uci)`: read `go nodes`, and a paragraph in `DEVELOPMENT.md` on fixed-node matches (`nodes=N` in fastchess) and what they do not measure

## Probes (release binary, start position)

```
go nodes 5000          → info depth 4 ... nodes 4039 ...   bestmove b1c3
go nodes 0             → info depth 1 ... nodes 41 ...     bestmove b1c3
go wtime 1 btime 1     → info depth 4 ... nodes 4039 ...   bestmove b1c3   (was reachable as bestmove 0000)
go nodes 5000 depth 3  → info depth 3 ... nodes 1145 ...   bestmove b1c3
```

## Tests

- search: a node budget stops on exactly that node (completed total + aborted iteration's count == N); a budget of 0 still answers depth one; nodes and depth stop at whichever comes first; a zero time budget through the deepening loop answers depth one's move
- uci: `go nodes 1234` parses; `go nodes 5000` end to end answers a `bestmove` with the last info line reporting ≤ 5000 nodes
- `cargo test --workspace --release` 41 + 96, `cargo test --workspace` (debug) 41 + 97, fmt and clippy clean, pinned node counts unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
