### PR TITLE
build: Make the script tests work from a windows clone

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Normalise text to unix line endings in the repository whatever the clone's
+# core.autocrlf says. A windows checkout may still convert most files on the
+# way out, which the compilers and the python interpreter do not mind.
+* text=auto
+
+# The shell scripts are run through their shebang, which a carriage return
+# turns into a program called "bash\r" that does not exist. They are checked
+# out with unix line endings everywhere, so the script tests and the docker
+# smoke test work from a windows clone too.
+*.sh text eol=lf

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -40,6 +40,11 @@ shape fails a test instead of quietly publishing the wrong number:
 python3 -m pytest scripts/tests
 ```
 
+The tests that run a shell script are skipped on windows, which cannot run
+one through its shebang; from a windows clone run them under wsl. The scripts
+are checked out with unix line endings whatever `core.autocrlf` says, so that
+works on the same checkout.
+
 ## Lints
 
 Both of these are gated in ci:

--- a/scripts/benchmark_summary.py
+++ b/scripts/benchmark_summary.py
@@ -68,6 +68,11 @@ def percent(change):
 
 
 def main():
+    # criterion writes utf-8, a minus sign and a micro sign among it, whatever
+    # the console's own encoding is. Read and write the same way, so a windows
+    # clone parses the sign rather than a mangled one and prints the table
+    sys.stdin.reconfigure(encoding="utf-8")
+    sys.stdout.reconfigure(encoding="utf-8")
     results = list(parse(sys.stdin))
     if not results:
         print("No benchmark comparison was produced.")

--- a/scripts/tests/test_benchmark_summary.py
+++ b/scripts/tests/test_benchmark_summary.py
@@ -57,7 +57,9 @@ def run(text):
         input=text,
         check=False,
         capture_output=True,
-        text=True,
+        # the fixture carries criterion's minus sign, which the console
+        # encoding of a windows clone cannot hold
+        encoding="utf-8",
     )
 
 

--- a/scripts/tests/test_changelog.py
+++ b/scripts/tests/test_changelog.py
@@ -9,12 +9,19 @@ running the hook twice leaves the same bytes as running it once.
 import os
 import stat
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
 import pytest
 
 SCRIPT = Path(__file__).resolve().parent.parent / "changelog.sh"
+
+# the script is run through its shebang, which only a posix shell can do:
+# from a windows clone run these under wsl
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="runs a shell script, which windows cannot"
+)
 
 CHANGELOG = textwrap.dedent(
     """\

--- a/scripts/tests/test_resolve_ref.py
+++ b/scripts/tests/test_resolve_ref.py
@@ -7,11 +7,18 @@ request's head.
 """
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 SCRIPT = Path(__file__).resolve().parent.parent / "resolve_ref.sh"
+
+# the script is run through its shebang, which only a posix shell can do:
+# from a windows clone run these under wsl
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="runs a shell script, which windows cannot"
+)
 
 
 def git(cwd, *args):


### PR DESCRIPTION
Audit item R2, tier 0.4: a Windows clone could not run the script tests or the docker smoke test.

**What was wrong, measured on this machine (`core.autocrlf=true`, git for windows' default):**

- `git ls-files --eol scripts/*.sh docker/*.sh` showed `i/lf w/crlf` — stored LF, checked out CRLF — so the shebang became `bash\r`. Under WSL on that checkout `python3 -m pytest scripts/tests` failed 9 of 51.
- Native Windows python failed 13 of 51, for two further reasons: Windows cannot run a `.sh` through its shebang at all (`WinError 193`), and the benchmark summariser's harness could not pipe criterion's `−` (U+2212) through a cp1252 console.

**Three commits:**

1. `build(ci)` — `.gitattributes` with `* text=auto` and `*.sh text eol=lf`. Changes nothing stored (`git add --renormalize .` is a no-op); pins the scripts to LF on checkout. Existing clones keep their endings until the files are checked out afresh (delete and `git checkout --`, or `git rm --cached -r . && git reset --hard`).
2. `test(ci)` — the two modules that execute shell scripts skip on `win32` with the reason, and `DEVELOPMENT.md` sends a Windows clone to WSL for them.
3. `fix(bench)` — `benchmark_summary.py` reconfigures stdin/stdout to UTF-8 (the only encoding criterion ever writes), and its test harness feeds the fixture as UTF-8. Without the script half, UTF-8 bytes decoded as cp1252 turn `−2.0000%` into three characters that match no change.

**After:** WSL on the same checkout 51 passed; native Windows 40 passed, 11 skipped; ruff check and format clean; CI on Linux is unaffected (it never had CRLF and is already UTF-8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
