### PR TITLE
feat: Add bench command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ MVV-LVA move ordering. Evaluation is material plus piece square tables.
 
 The engine does not ship with any GUI. It currently implements a subset of the UCI protocol, you can use it with an open source GUI such as [Arena](http://www.playwitharena.de/).
 
-The program does not accept posix style arguments it will immediately start in UCI mode.
+The program starts in UCI mode immediately. The one argument it takes is `bench`, which
+searches a fixed set of positions and prints what each search counted, for measuring a
+change to the search or the speed of a machine.
 
 Binaries for linux, macos and windows are attached to each
 [release](https://github.com/aywrite/arche/releases). To build from source:

--- a/basic_engine/bench.epd
+++ b/basic_engine/bench.epd
@@ -1,0 +1,27 @@
+# The bench suite. One position a line as a four field fen followed by an id
+# operation, which is the epd form. The clocks are not part of it: every
+# position is searched as if it had just arisen.
+#
+# Chosen once, for coverage rather than difficulty: the standard perft
+# positions the tests already lean on, two openings, a sharp and a quiet
+# middlegame, two tactical positions, and the endgames where a search with no
+# knowledge has the most to learn. Changing a line changes every number the
+# bench has ever printed, so add to the end rather than edit.
+rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - id "start";
+r1bqk2r/pppp1ppp/2n2n2/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - id "italian";
+r1bq1rk1/2p1bppp/p1np1n2/1p2p3/4P3/1B3N2/PPPP1PPP/RNBQR1K1 w - - id "ruy lopez";
+r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - id "kiwipete";
+r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - id "perft 4";
+rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - id "promotions";
+r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - id "middlegame";
+r1b2rk1/ppp1qppp/4pn2/6N1/Qn1P4/2NBP3/PP3PPP/R3K2R w KQ - id "sharp middlegame";
+1k1r4/pp1b1R2/3q2pp/4p3/2B5/4Q3/PPP2B2/2K5 b - - id "bratko kopec 1";
+r1bq2rk/pp3pbp/2p1p1pQ/7P/3P4/2PB1N2/PP3PPR/2KR4 w - - id "wac 4";
+8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - id "rook and pawns";
+r5k1/5ppp/P7/8/8/8/5PPP/3R1K2 w - - id "tarrasch";
+1K6/1P1k4/8/8/8/8/r7/2R5 w - - id "lucena";
+4k3/8/r7/8/4PK2/8/8/4R3 b - - id "philidor";
+6k1/5pp1/7p/3n4/8/3B3P/5PP1/6K1 w - - id "minor endgame";
+8/5k2/8/8/3Q4/8/6q1/2K5 w - - id "queen endgame";
+8/8/8/3k4/8/3K4/3P4/8 b - - id "king and pawn";
+8/8/8/4p3/4Pk2/3K4/8/8 w - - id "trebuchet";

--- a/basic_engine/src/bench.rs
+++ b/basic_engine/src/bench.rs
@@ -1,0 +1,373 @@
+//! The bench: a fixed suite of positions, each searched to a fixed depth with
+//! a fixed table, and what the searches counted.
+//!
+//! The search is deterministic, so the node count is exact and says the same
+//! thing on any machine: it moves if and only if the tree searched moves.
+//! That makes it the signature of a search change, which a commit that makes
+//! one states in its message. The speed is the other half, and it is what
+//! the match tools scale their time controls by, so the clock runs over the
+//! search alone and not over allocating the table.
+
+use crate::Game;
+use crate::board::Board;
+use crate::engine::{AlphaBeta, Engine, SearchOutcome, SearchParameters};
+use std::fmt;
+use std::time::{Duration, Instant};
+
+/// The depth every position is searched to.
+pub const DEPTH: u8 = 7;
+
+/// The table every position is searched with. The tree moves with the
+/// table, so this is part of what the numbers mean.
+pub const TABLE_BYTES: usize = 16 * 1024 * 1024;
+
+/// The suite, as epd: a four field fen and an id operation a line.
+const SUITE: &str = include_str!("../bench.epd");
+
+/// A position of the suite, as a full fen and the name the report gives it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Position {
+    pub id: String,
+    pub fen: String,
+}
+
+/// The suite's positions, in the order the file lists them.
+pub fn positions() -> Vec<Position> {
+    parse_epd(SUITE)
+}
+
+/// Reads epd: the first four fields are the fen, and an `id "..."` operation
+/// among those that follow names the position. The clocks an epd leaves out
+/// are filled in as zero and one, a position that has just arisen. A line
+/// with no id is named by its fen. Blank lines and lines opening with `#`
+/// are skipped.
+fn parse_epd(text: &str) -> Vec<Position> {
+    text.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| {
+            let mut words = line.split_whitespace();
+            let fen: Vec<&str> = words.by_ref().take(4).collect();
+            let fen = format!("{} 0 1", fen.join(" "));
+            // what is left is the operations, each ended by a semicolon
+            let operations = words.collect::<Vec<&str>>().join(" ");
+            let id = operations
+                .split(';')
+                .map(str::trim)
+                .find_map(|operation| operation.strip_prefix("id "))
+                .map(|name| name.trim().trim_matches('"').to_string())
+                .unwrap_or_else(|| fen.clone());
+            Position { id, fen }
+        })
+        .collect()
+}
+
+/// What one position's search counted.
+#[derive(Debug, Clone)]
+pub struct PositionReport {
+    pub id: String,
+    pub nodes: u64,
+    /// The nodes quiescence visited, a part of nodes.
+    pub quiescence_nodes: u64,
+    /// Probes that cut the search off with a stored score.
+    pub tt_cutoffs: u64,
+    /// Entries stored in total.
+    pub tt_stores: u64,
+    /// Entries stored with a draw tainted score, a part of the stores.
+    pub tainted_stores: u64,
+    /// Cutoffs taken from a draw tainted score, which the search refuses, so
+    /// this stays at zero while it does.
+    pub tainted_cutoffs: u64,
+    /// The search alone, not the table's allocation.
+    pub elapsed: Duration,
+}
+
+/// The whole bench: the settings it ran with and what each position counted.
+#[derive(Debug, Clone)]
+pub struct Report {
+    pub depth: u8,
+    pub table_bytes: usize,
+    pub positions: Vec<PositionReport>,
+}
+
+impl Report {
+    pub fn nodes(&self) -> u64 {
+        self.positions.iter().map(|p| p.nodes).sum()
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        self.positions.iter().map(|p| p.elapsed).sum()
+    }
+
+    /// Nodes a second over the whole bench.
+    pub fn nps(&self) -> u64 {
+        nps(self.nodes(), self.elapsed())
+    }
+}
+
+/// Counted in microseconds, so a position searched in well under a
+/// millisecond still gets a rate rather than its count times a thousand, and
+/// measured as at least one so the rate stays finite and the arithmetic whole.
+fn nps(nodes: u64, elapsed: Duration) -> u64 {
+    (nodes as u128 * 1_000_000 / elapsed.as_micros().max(1)) as u64
+}
+
+/// Runs a suite under the settings given. Each position gets a fresh engine
+/// and a fresh table, allocated before its clock starts, and is deepened to
+/// the depth the way a game would be, so the table is warm from each
+/// iteration to the next. A depth of zero runs no iteration and counts
+/// nothing, which is no bench at all, so it is searched as one.
+pub fn run_suite(positions: &[Position], depth: u8, table_bytes: usize) -> Report {
+    let depth = depth.max(1);
+    let positions = positions
+        .iter()
+        .map(|position| {
+            let board = Board::from_fen(&position.fen)
+                .unwrap_or_else(|e| panic!("bench position {} does not parse: {}", position.id, e));
+            let mut engine = AlphaBeta::with_table_bytes(board, table_bytes);
+            let start = Instant::now();
+            let outcome = engine
+                .iterative_deepening_search(SearchParameters::new_with_depth(depth), |_, _, _| {});
+            let elapsed = start.elapsed();
+            let nodes = match outcome {
+                SearchOutcome::Complete(result) => result.nodes,
+                other => panic!(
+                    "bench position {} did not complete: {:?}",
+                    position.id, other
+                ),
+            };
+            PositionReport {
+                id: position.id.clone(),
+                nodes,
+                quiescence_nodes: engine.quiescence_nodes(),
+                tt_cutoffs: engine.ghi.score_cutoffs,
+                tt_stores: engine.ghi.stores,
+                tainted_stores: engine.ghi.tainted_stores,
+                tainted_cutoffs: engine.ghi.tainted_score_cutoffs,
+                elapsed,
+            }
+        })
+        .collect();
+    Report {
+        depth,
+        table_bytes,
+        positions,
+    }
+}
+
+fn share(part: u64, whole: u64) -> f64 {
+    if whole == 0 {
+        0.0
+    } else {
+        100.0 * part as f64 / whole as f64
+    }
+}
+
+/// The report as the command prints it: a header naming the settings, a row
+/// a position, a total, and last the one line the match tools read, which is
+/// `<nodes> nodes <nps> nps` and nothing else.
+impl fmt::Display for Report {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "bench depth {} hash {}MB positions {}",
+            self.depth,
+            self.table_bytes / (1024 * 1024),
+            self.positions.len()
+        )?;
+        // the name column is as wide as the widest name, so a suite of
+        // fen-named positions still lines up
+        let width = self
+            .positions
+            .iter()
+            .map(|p| p.id.len())
+            .max()
+            .unwrap_or(0)
+            .max("position".len());
+        writeln!(
+            f,
+            "{:<width$} {:>10} {:>7} {:>9} {:>9} {:>8} {:>6} {:>6} {:>10}",
+            "position", "nodes", "qs%", "cutoffs", "stores", "tainted", "tcuts", "ms", "nps"
+        )?;
+        let row = |f: &mut fmt::Formatter<'_>,
+                   name: &str,
+                   nodes: u64,
+                   quiescence: u64,
+                   cutoffs: u64,
+                   stores: u64,
+                   tainted: u64,
+                   tainted_cutoffs: u64,
+                   elapsed: Duration| {
+            writeln!(
+                f,
+                "{:<width$} {:>10} {:>6.1}% {:>9} {:>9} {:>8} {:>6} {:>6} {:>10}",
+                name,
+                nodes,
+                share(quiescence, nodes),
+                cutoffs,
+                stores,
+                tainted,
+                tainted_cutoffs,
+                elapsed.as_millis(),
+                nps(nodes, elapsed)
+            )
+        };
+        for p in &self.positions {
+            row(
+                f,
+                &p.id,
+                p.nodes,
+                p.quiescence_nodes,
+                p.tt_cutoffs,
+                p.tt_stores,
+                p.tainted_stores,
+                p.tainted_cutoffs,
+                p.elapsed,
+            )?;
+        }
+        let sum = |field: fn(&PositionReport) -> u64| self.positions.iter().map(field).sum::<u64>();
+        row(
+            f,
+            "total",
+            self.nodes(),
+            sum(|p| p.quiescence_nodes),
+            sum(|p| p.tt_cutoffs),
+            sum(|p| p.tt_stores),
+            sum(|p| p.tainted_stores),
+            sum(|p| p.tainted_cutoffs),
+            self.elapsed(),
+        )?;
+        write!(f, "{} nodes {} nps", self.nodes(), self.nps())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn an_epd_line_yields_its_fen_and_id() {
+        let parsed = parse_epd("4k3/8/8/8/8/8/8/4K3 w - - id \"bare kings\";");
+        assert_eq!(
+            parsed,
+            vec![Position {
+                id: "bare kings".to_string(),
+                fen: "4k3/8/8/8/8/8/8/4K3 w - - 0 1".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn a_line_without_an_id_is_named_by_its_fen() {
+        let parsed = parse_epd("# a comment\n\n4k3/8/8/8/8/8/8/4K3 w - -\n");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].id, "4k3/8/8/8/8/8/8/4K3 w - - 0 1");
+    }
+
+    #[test]
+    fn the_suite_parses_into_distinct_legal_positions() {
+        let positions = positions();
+        assert!(positions.len() >= 16, "{} positions", positions.len());
+        let mut ids: Vec<&str> = positions.iter().map(|p| p.id.as_str()).collect();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), positions.len(), "an id repeats");
+        for position in &positions {
+            assert!(!position.id.is_empty());
+            Board::from_fen(&position.fen).unwrap_or_else(|e| panic!("{}: {}", position.id, e));
+        }
+    }
+
+    #[test]
+    fn the_report_ends_with_the_line_the_match_tools_read() {
+        let suite = parse_epd("4k3/8/8/8/8/8/8/4K3 w - - id \"bare kings\";");
+        let report = run_suite(&suite, 2, 1 << 20);
+        let text = report.to_string();
+        let last = text.lines().last().unwrap();
+        let words: Vec<&str> = last.split(' ').collect();
+        assert_eq!(words.len(), 4, "{}", last);
+        assert_eq!(words[1], "nodes");
+        assert_eq!(words[3], "nps");
+        assert_eq!(words[0].parse::<u64>().unwrap(), report.nodes());
+        assert_eq!(words[2].parse::<u64>().unwrap(), report.nps());
+        assert!(text.starts_with("bench depth 2 hash 1MB positions 1\n"));
+    }
+
+    #[test]
+    fn the_report_counts_every_position() {
+        let suite = parse_epd(
+            "4k3/8/8/8/8/8/8/4K3 w - - id \"bare kings\";\n\
+             rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - id \"start\";",
+        );
+        let report = run_suite(&suite, 3, 1 << 16);
+        assert_eq!(report.positions.len(), 2);
+        assert!(report.positions.iter().all(|p| p.nodes > 0));
+        assert!(report.positions[1].quiescence_nodes <= report.positions[1].nodes);
+        assert_eq!(
+            report.nodes(),
+            report.positions.iter().map(|p| p.nodes).sum::<u64>()
+        );
+    }
+
+    #[test]
+    fn fields_may_be_separated_by_any_whitespace_and_the_id_need_not_come_first() {
+        let parsed = parse_epd("4k3/8/8/8/8/8/8/4K3\tw  - -  c0 \"a note\"; id \"bare kings\";");
+        assert_eq!(parsed[0].id, "bare kings");
+        assert_eq!(parsed[0].fen, "4k3/8/8/8/8/8/8/4K3 w - - 0 1");
+    }
+
+    #[test]
+    fn a_depth_of_zero_is_searched_as_one() {
+        // a depth of zero runs no iteration and finds nothing, which is not
+        // a bench: there is nothing to count below one
+        let suite = parse_epd("4k3/8/8/8/8/8/8/4K3 w - - id \"bare kings\";");
+        let report = run_suite(&suite, 0, 1 << 20);
+        assert_eq!(report.depth, 1);
+        assert!(report.positions[0].nodes > 0);
+    }
+
+    /// The search is deterministic, so how many nodes the bench visits is an
+    /// exact figure rather than a timing, and it says the same thing on any
+    /// machine. It moves whenever move ordering, quiescence, the transposition
+    /// table or any pruning changes, including the many such changes that
+    /// leave the move finally played untouched, which is what makes it worth
+    /// pinning.
+    ///
+    /// A deliberate change to the search is expected to move these. Update
+    /// them in the same commit, from `arche bench`: the diff is then a
+    /// statement of how much less, or more, of the tree the engine now looks
+    /// at, position by position.
+    #[test]
+    fn node_counts_have_not_moved() {
+        let report = run_suite(&positions(), DEPTH, TABLE_BYTES);
+        let counted: Vec<(&str, u64)> = report
+            .positions
+            .iter()
+            .map(|p| (p.id.as_str(), p.nodes))
+            .collect();
+        assert_eq!(
+            counted,
+            vec![
+                ("start", 1_195_758),
+                ("italian", 4_426_337),
+                ("ruy lopez", 3_099_801),
+                ("kiwipete", 4_641_935),
+                ("perft 4", 4_069_374),
+                ("promotions", 2_617_360),
+                ("middlegame", 4_007_180),
+                ("sharp middlegame", 11_195_520),
+                ("bratko kopec 1", 718_574),
+                ("wac 4", 2_302_115),
+                ("rook and pawns", 173_755),
+                ("tarrasch", 434_137),
+                ("lucena", 523_941),
+                ("philidor", 913_576),
+                ("minor endgame", 142_796),
+                ("queen endgame", 2_373_132),
+                ("king and pawn", 9_196),
+                ("trebuchet", 3_264),
+            ]
+        );
+    }
+}

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -131,6 +131,11 @@ pub struct AlphaBeta {
     /// The node count at which the limits are looked at next: every
     /// POLL_INTERVAL nodes for the clock, and the budget itself, exactly.
     next_check: u64,
+    /// The nodes quiescence visited, a part of nodes. Counted for the bench,
+    /// which reports what share of the tree the captures are. Never reset,
+    /// like the ghi counters: it runs over the engine's whole life, and the
+    /// bench reads it from an engine made for the one search
+    quiescence_nodes: u64,
 }
 
 impl AlphaBeta {
@@ -147,6 +152,7 @@ impl AlphaBeta {
             deadline: None,
             node_budget: u64::MAX,
             next_check: 0,
+            quiescence_nodes: 0,
         }
     }
 
@@ -156,6 +162,12 @@ impl AlphaBeta {
 
     pub fn clear_cache(&mut self) {
         self.moves.clear();
+    }
+
+    /// How many of the nodes visited so far were quiescence's, over every
+    /// search this engine has run.
+    pub fn quiescence_nodes(&self) -> u64 {
+        self.quiescence_nodes
     }
 
     /// Cooperative limit check. The clock is read every POLL_INTERVAL nodes
@@ -231,6 +243,7 @@ impl AlphaBeta {
 
         self.poll_deadline()?;
         self.nodes += 1;
+        self.quiescence_nodes += 1;
 
         // Standing pat is declining to move, which only the side not in check
         // may do: the static eval is no floor for a side that has to get out
@@ -779,10 +792,10 @@ impl Engine for AlphaBeta {
 ///
 /// On. A tainted score describes the path that stored it rather than the
 /// position, so a search arriving another way can read a draw it cannot
-/// actually reach. Refusing costs, over the pinned positions at their pinned
-/// depths, nothing at all in kiwipete, promotions and the middlegame, which
-/// have no tainted cutoffs to refuse, +0.037% in the opening and +2.970% in the
-/// pawn endgame, for +0.617% overall.
+/// actually reach. Refusing costs, over the five positions the node counts
+/// pinned then at their depths, nothing at all in kiwipete, promotions and
+/// the middlegame, which have no tainted cutoffs to refuse, +0.037% in the
+/// opening and +2.970% in the pawn endgame, for +0.617% overall.
 const REFUSE_TAINTED_CUTOFFS: bool = true;
 
 /// How often the transposition table hands back a score that depended on the
@@ -834,6 +847,11 @@ enum Bound {
 /// A slot in the table. The key is kept alongside the entry so that a probe can
 /// tell a real hit from another position landing on the same index.
 type Entry = Option<(Pv, u64)>;
+
+// the bench's node counts depend on how many slots a table of a given size
+// holds, so a compiler that laid the entry out differently would move every
+// one of them: this says why, the moment it happens
+const _: () = assert!(mem::size_of::<Entry>() == 24);
 
 #[derive(Debug)]
 struct HashTable {
@@ -1425,7 +1443,7 @@ mod search {
 
     #[test]
     fn draw_taint_is_still_recorded_and_never_trusted() {
-        // The pawn endgame carries the most draw traffic of the pinned
+        // The pawn endgame carries the most draw traffic of the bench
         // positions, so it is the one that exercises both halves of the graph
         // history work. tainted_stores going to zero means taint propagation
         // broke, and then the refusal in get_transposition is refusing nothing
@@ -1753,133 +1771,5 @@ mod hash_table {
         table.set(1, new_pv(Bound::Exact, 8, 1));
         table.set(2, new_pv(Bound::Lower, 1, 100));
         assert!(table.get(2).is_some());
-    }
-}
-
-#[cfg(test)]
-mod node_counts {
-    use super::AlphaBeta;
-    use super::Board;
-    use super::Game;
-    use crate::board::fens;
-    use pretty_assertions::assert_eq;
-
-    /// Pinned, because how often the transposition table collides decides how
-    /// much of the tree is searched again.
-    const TABLE_BYTES: usize = 1 << 20;
-
-    /// Positions chosen to reach different parts of the search: a quiet
-    /// opening, a tactical middlegame, a pawn endgame, a position full of
-    /// captures, and one with castling and promotions available.
-    const POSITIONS: [(&str, &str, u8); 5] = [
-        ("opening", fens::START, 6),
-        ("kiwipete", fens::KIWIPETE, 5),
-        ("pawn endgame", fens::PAWN_ENDGAME, 7),
-        ("promotions", fens::PROMOTIONS, 5),
-        ("middlegame", fens::MIDDLEGAME, 5),
-    ];
-
-    /// Widens the way the engine does when it plays, so the table is warm from
-    /// the previous iteration the way it is in a real search, and totals what
-    /// each iteration visited.
-    fn nodes(fen: &str, depth: u8) -> u64 {
-        let mut engine = AlphaBeta::with_table_bytes(Board::from_fen(fen).unwrap(), TABLE_BYTES);
-        (1..=depth)
-            .map(|d| match engine.search(d) {
-                super::SearchOutcome::Complete(result) => result.nodes,
-                other => panic!("search did not complete: {:?}", other),
-            })
-            .sum()
-    }
-
-    /// Reports how much of the search's use of the transposition table depends
-    /// on the path taken rather than on the position. Not an assertion, it
-    /// prints, which is why it is ignored.
-    ///
-    ///     cargo test -p basic_engine --release ghi_report -- --ignored --nocapture
-    #[test]
-    #[ignore = "prints a measurement, see the doc comment"]
-    fn ghi_report() {
-        println!(
-            "{:<14} {:>10} {:>10} {:>8} {:>10} {:>10} {:>8}",
-            "position", "stores", "tainted", "%", "cutoffs", "tainted", "%"
-        );
-        let mut totals = (0u64, 0u64, 0u64, 0u64);
-        for (name, fen, depth) in POSITIONS {
-            let mut engine =
-                AlphaBeta::with_table_bytes(Board::from_fen(fen).unwrap(), TABLE_BYTES);
-            for d in 1..=depth {
-                match engine.search(d) {
-                    super::SearchOutcome::Complete(_) => (),
-                    other => panic!("search did not complete: {:?}", other),
-                }
-            }
-            let g = engine.ghi;
-            let pct = |a: u64, b: u64| {
-                if b == 0 {
-                    0.0
-                } else {
-                    100.0 * a as f64 / b as f64
-                }
-            };
-            println!(
-                "{:<14} {:>10} {:>10} {:>7.3}% {:>10} {:>10} {:>7.3}%",
-                name,
-                g.stores,
-                g.tainted_stores,
-                pct(g.tainted_stores, g.stores),
-                g.score_cutoffs,
-                g.tainted_score_cutoffs,
-                pct(g.tainted_score_cutoffs, g.score_cutoffs)
-            );
-            totals.0 += g.stores;
-            totals.1 += g.tainted_stores;
-            totals.2 += g.score_cutoffs;
-            totals.3 += g.tainted_score_cutoffs;
-        }
-        let pct = |a: u64, b: u64| {
-            if b == 0 {
-                0.0
-            } else {
-                100.0 * a as f64 / b as f64
-            }
-        };
-        println!(
-            "{:<14} {:>10} {:>10} {:>7.3}% {:>10} {:>10} {:>7.3}%",
-            "TOTAL",
-            totals.0,
-            totals.1,
-            pct(totals.1, totals.0),
-            totals.2,
-            totals.3,
-            pct(totals.3, totals.2)
-        );
-    }
-
-    /// The search is deterministic, so how many nodes it visits is an exact
-    /// figure rather than a timing, and it says the same thing on any machine.
-    /// It moves whenever move ordering, quiescence, the transposition table or
-    /// any pruning changes, including the many such changes that leave the move
-    /// finally played untouched, which is what makes it worth pinning.
-    ///
-    /// A deliberate change to the search is expected to move these. Update them
-    /// in the same commit: the diff is then a statement of how much less, or
-    /// more, of the tree the engine now looks at.
-    #[test]
-    fn node_counts_have_not_moved() {
-        let counted: Vec<(&str, u64)> = POSITIONS
-            .iter()
-            .map(|(name, fen, depth)| (*name, nodes(fen, *depth)))
-            .collect();
-        assert_eq!(
-            counted,
-            vec![
-                ("opening", 151_429),
-                ("kiwipete", 297_693),
-                ("pawn endgame", 184_523),
-                ("promotions", 119_840),
-                ("middlegame", 220_237),
-            ]
-        );
     }
 }

--- a/basic_engine/src/lib.rs
+++ b/basic_engine/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bench;
 mod bitboard;
 mod board;
 mod engine;

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,7 +7,8 @@ cargo build --release
 ```
 
 The binary is written to `target/release/arche` (`arche.exe` on windows). It starts
-in uci mode immediately, it does not take any arguments.
+in uci mode immediately. The one argument it takes is `bench`, which prints the
+bench described below and exits.
 
 The release profile uses link time optimisation and a single codegen unit, so a
 release build is noticeably slower to compile than a debug one but is several
@@ -81,7 +82,7 @@ commit under **Development** whatever its type is:
 
 | scope | covers |
 | --- | --- |
-| `bench` | the criterion benchmarks |
+| `bench` | the criterion benchmarks and the bench |
 | `book` | the opening book generator |
 | `ci` | github workflows and the pre-commit configuration |
 | `deps`, `deps-dev` | dependency bumps, what dependabot uses |
@@ -130,11 +131,27 @@ both on the same runner. It writes the comparison to the job summary. It only
 reports and will not fail a build, for the same reason: even measured back to
 back on one machine, criterion calls single digit differences significant.
 
-What does hold search behaviour still is `node_counts_have_not_moved` in
-`basic_engine/src/engine.rs`. The number of nodes a search visits is exact
-rather than timed, so it says the same thing on any machine. A deliberate change
+What does hold search behaviour still is the bench:
+
+```
+target/release/arche bench
+```
+
+It searches the positions in `basic_engine/bench.epd` to a fixed depth with a
+fixed table and prints what each search counted: nodes, the share of them
+quiescence visited, transposition cutoffs, draw tainted stores, and the speed.
+The number of nodes a search visits is exact rather than timed, so it says the
+same thing on any machine, and `node_counts_have_not_moved` in
+`basic_engine/src/bench.rs` pins it position by position. A deliberate change
 to the search is expected to move it, and the numbers are updated in the same
-commit so the diff shows how much more, or less, of the tree is being looked at.
+commit so the diff shows how much more, or less, of each tree is being looked
+at. The last line, `<nodes> nodes <nps> nps`, is the one the match tools read,
+and `bench` is also a uci command. Both take a depth after the word, as in
+`arche bench 3`, for trying the command cheaply; the number that means
+anything is the one at the default. The suite, depth and table are chosen once:
+changing any of them changes every number the bench has ever printed, which is
+why the depth is expected to be raised exactly once, after the search has
+learned to prune, rather than adjusted as it goes.
 
 ## Playing a match against a previous version
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,40 @@ pub use uci::UCI;
 
 use basic_engine::AlphaBeta;
 use basic_engine::Board;
+use basic_engine::bench;
+use std::process::ExitCode;
 
-fn main() {
-    let game = Board::new();
-    let e = AlphaBeta::new(game);
-    UCI::new_with_engine(e).read_loop();
+fn main() -> ExitCode {
+    // the one argument the binary takes: `arche bench [depth]` prints the
+    // bench and exits, which is how the match tools measure an engine's
+    // speed and how a commit states what its search change did to the tree.
+    // No argument starts the uci loop; anything else is a mistake, and a
+    // mistake that started the uci loop would sit waiting for input in
+    // silence
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(String::as_str) {
+        None => {
+            let game = Board::new();
+            let e = AlphaBeta::new(game);
+            UCI::new_with_engine(e).read_loop();
+            ExitCode::SUCCESS
+        }
+        Some("bench") => match uci::bench_depth(&args.join(" ")) {
+            Ok(depth) => {
+                println!(
+                    "{}",
+                    bench::run_suite(&bench::positions(), depth, bench::TABLE_BYTES)
+                );
+                ExitCode::SUCCESS
+            }
+            Err(word) => {
+                eprintln!("unrecognised bench depth: {}", word);
+                ExitCode::from(2)
+            }
+        },
+        Some(other) => {
+            eprintln!("unrecognised argument: {}", other);
+            ExitCode::from(2)
+        }
+    }
 }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -3,6 +3,7 @@ use basic_engine::Color;
 use basic_engine::Engine;
 use basic_engine::SearchOutcome;
 use basic_engine::SearchParameters;
+use basic_engine::bench;
 use basic_engine::{PvLine, SearchResult};
 use regex::Regex;
 use std::io::{BufRead, Stdout, Write};
@@ -140,6 +141,20 @@ impl<T: Engine, W: Write> UCI<T, W> {
             self.engine.display_board();
         } else if line.starts_with("go") {
             self.parse_go(line);
+        } else if line.starts_with("bench") {
+            // `bench [depth]`, the same as the command line argument: the
+            // depth is for trying the command cheaply, the number that means
+            // anything is the one at the default
+            match bench_depth(line) {
+                Ok(depth) => {
+                    let report = bench::run_suite(&bench::positions(), depth, bench::TABLE_BYTES);
+                    self.say(format_args!("{}", report));
+                }
+                Err(word) => self.say(format_args!(
+                    "info string unrecognised bench depth: {}",
+                    word
+                )),
+            }
         } else if line.starts_with("perft") {
             let depth = perft_depth(line);
             let nodes = self.engine.perft(depth);
@@ -207,6 +222,17 @@ impl<T: Engine, W: Write> UCI<T, W> {
             }
             SearchOutcome::Aborted(None) => self.say(format_args!("bestmove 0000")),
         }
+    }
+}
+
+/// The depth asked of a bench command or argument: the word after `bench`,
+/// or the bench's own depth when there is none. A word that is not a depth
+/// comes back as the error, for the caller to say so; running the default in
+/// its place would take seconds and explain nothing.
+pub(crate) fn bench_depth(line: &str) -> Result<u8, String> {
+    match line.split_whitespace().nth(1) {
+        None => Ok(bench::DEPTH),
+        Some(word) => word.parse().map_err(|_| word.to_string()),
     }
 }
 
@@ -509,6 +535,36 @@ mod tests {
     #[test]
     fn an_oversized_depth_does_not_panic() {
         assert_eq!(capture(&DEPTH_RE, "go depth 999"), Some(999));
+    }
+
+    #[test]
+    fn a_bench_command_ends_with_the_line_the_match_tools_read() {
+        let mut uci = uci();
+        uci.run(Cursor::new("bench 1\n"));
+        let said = said(&uci);
+        assert!(
+            said.starts_with("bench depth 1 hash 16MB positions "),
+            "{}",
+            said
+        );
+        let last = said.lines().last().unwrap();
+        let words: Vec<&str> = last.split(' ').collect();
+        assert_eq!(words.len(), 4, "{}", last);
+        assert_eq!((words[1], words[3]), ("nodes", "nps"), "{}", last);
+        assert!(words[0].parse::<u64>().unwrap() > 0, "{}", last);
+    }
+
+    #[test]
+    fn an_unreadable_bench_depth_is_reported_rather_than_searched() {
+        // running the default in its place would take seconds and say
+        // nothing about why, which is the wrong answer to a typo
+        let mut uci = uci();
+        uci.run(Cursor::new("bench abc\nbench 300\n"));
+        assert_eq!(
+            said(&uci),
+            "info string unrecognised bench depth: abc\n\
+             info string unrecognised bench depth: 300\n"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`arche bench` (and the UCI command `bench`) searches eighteen positions from `basic_engine/bench.epd` to depth 7 with a 16 MB table and prints, per position and in total: nodes, the share quiescence visited, transposition cutoffs, draw-tainted stores and cutoffs, search-only time, and nps. The last line is `<nodes> nodes <nps> nps`, the form OpenBench and fastchess read.

```
bench depth 7 hash 16MB positions 18
position                nodes     qs%   cutoffs  tainted    tcuts     ms        nps
start                 1195758   49.6%     20968      875        0     72   16607750
italian               4426337   68.8%     53317      629        0    449    9858211
ruy lopez             3099801   65.7%     45290      656        0    267   11609741
kiwipete              4641935   63.0%     82281        0        0    374   12411590
perft 4               4069374   64.0%     90168        0        0    330   12331436
promotions            2617360   55.2%     51158       68        0    149   17566174
middlegame            4007180   60.2%    102091      129        0    275   14571563
sharp middlegame     11195520   66.1%    140253     1409        0   1017   11008377
bratko kopec 1         718574   44.7%     17938       11        0     69   10414115
wac 4                 2302115   53.1%     82933      165        0    158   14570348
rook and pawns         173755   45.4%      7263      523        0     10   17375500
tarrasch               434137   49.5%     12135     1989        0     21   20673190
lucena                 523941   58.5%     19453     4312        0     28   18712178
philidor               913576   43.7%     51923     3870        0     46   19860347
minor endgame          142796   43.5%      5797     1263        0      7   20399428
queen endgame         2373132   39.8%    210832    45932        0    157   15115490
king and pawn            9196   38.9%       618       62        0      0    9196000
trebuchet                3264   36.2%       318       44        0      0    3264000
total                42847751   60.7%    994736    61937        0   3435   12473872
42847751 nodes 12473872 nps
```

**Design decisions** (discussed before building): uniform depth rather than per-position depths, so every row shrinks by its own honest factor as pruning lands and the rows stay comparable; depth 7 now with one planned bump after the pruning sprint (the suite is ~3.5 s today and will be a fraction of that); 16 MB, the convention, sensitive to the table being part of the search but not dominated by replacement; search-only timing so nps means what it says; the suite committed once as EPD — changing a line changes every number ever printed, so the file says to append rather than edit.

**What it replaces:** `node_counts_have_not_moved` now lives in `bench.rs` and pins the bench's own counts position by position — one number, one function, so the test and the command cannot disagree. The ignored `ghi_report` test is retired; the bench prints those counters in every run (note the queen endgame's 45,932 tainted stores — the repetition-heavy position the audit's GHI write-up will want).

**Commits:** `feat(bench)` — suite, module, quiescence-node counter, pinned counts; `feat(uci)` — `arche bench [depth]`, UCI `bench [depth]`, README and DEVELOPMENT.md.

**Verification:** release 42 + 103, debug 42 + 104 (57 s, not slower than before — the bench runs alongside the perft tests), fmt and clippy clean. Every existing search test is untouched; the engine's play is unchanged (the only engine-side change is a counter increment in quiescence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
