### PR TITLE
Carry the bench, speed and elo as commit trailers, and check them

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,76 @@
+name: Bench
+
+# Two checks on what a pull request's commits say about themselves.
+#
+# The trailers job runs the pre-commit hooks over the tree and the commit-msg
+# hooks over every commit, so a scope the changelog does not know, or an
+# engine commit with no bench stated, fails here rather than slipping past a
+# clone that never installed the hooks.
+#
+# The bench job builds each commit that states a bench and counts it. The
+# count is exact and the same on any machine, so unlike the benchmark
+# workflow this one gates: a commit whose stated bench is not the bench is
+# wrong, and a history whose numbers cannot be trusted is worse than one
+# with none.
+
+on:
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  trailers:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/cache@v6
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Install pre-commit
+        run: python3 -m pip install --quiet pre-commit
+      - name: Run the hooks over the tree
+        run: pre-commit run --all-files --show-diff-on-failure
+      - name: Run the commit-msg hooks over every commit
+        # reported even when the tree failed, so a pull request with both
+        # kinds of problem hears of both at once
+        if: success() || failure()
+        shell: bash
+        run: |
+          # the checkout is a merge of the pull request into its base: the
+          # first parent is the base and the second is the pull request's head
+          failed=0
+          for sha in $(git rev-list --reverse "$(git rev-parse HEAD^1)..$(git rev-parse HEAD^2)"); do
+            git log -1 --format=%B "$sha" > commit-msg.txt
+            echo "::group::$(git log -1 --format='%h %s' "$sha")"
+            if ! pre-commit run --hook-stage commit-msg --commit-msg-filename commit-msg.txt; then
+              failed=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "$failed"
+
+  bench:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: Swatinem/rust-cache@v2
+      - name: Count the bench of every commit that states one
+        shell: bash
+        run: scripts/verify_bench.sh "$(git rev-parse HEAD^1)" "$(git rev-parse HEAD^2)"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,6 +56,10 @@ jobs:
         run: |
           git checkout --detach "$BASE_SHA"
           cargo bench -p basic_engine --bench benchmark -- --noplot --save-baseline pr-base
+          # the engine's own bench as well, for a rate over a real search
+          # rather than a microbenchmark's
+          cargo build --release --locked
+          target/release/arche bench | tee base-bench.txt
 
       - name: Measure the pull request
         # Naming the shell is what turns on pipefail, without it a failing
@@ -68,6 +72,8 @@ jobs:
           cargo bench -p basic_engine --bench benchmark -- \
             --noplot --baseline-lenient pr-base --noise-threshold 0.1 \
             | tee benchmark-output.txt
+          cargo build --release --locked
+          target/release/arche bench | tee pr-bench.txt
 
       - name: Summarise
         if: always()
@@ -78,7 +84,8 @@ jobs:
             echo "<!-- benchmark-summary -->"
             echo "## Benchmark against \`${BASE_SHA:0:8}\`"
             echo
-            python3 scripts/benchmark_summary.py < benchmark-output.txt
+            python3 scripts/benchmark_summary.py --bench base-bench.txt pr-bench.txt \
+              < benchmark-output.txt
           } > benchmark-summary.md
           cat benchmark-summary.md >> "$GITHUB_STEP_SUMMARY"
 
@@ -112,5 +119,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-output
-          path: benchmark-output.txt
+          path: |
+            benchmark-output.txt
+            base-bench.txt
+            pr-bench.txt
           if-no-files-found: warn

--- a/.github/workflows/strength.yml
+++ b/.github/workflows/strength.yml
@@ -238,10 +238,19 @@ jobs:
           line="Performance compared to ${PREVIOUS} | $(python3 scripts/match_summary.py tools/result.txt)"
           echo "::notice::$line"
           echo "line=${line}" >> "$GITHUB_OUTPUT"
+          # the same result as the trailer a commit carries, ready to paste
+          trailer=$(python3 scripts/match_summary.py tools/result.txt \
+            --trailer --tc "$TIME_CONTROL" --baseline "$PREVIOUS")
           {
             echo "${CANDIDATE} (\`${CANDIDATE_SHA:0:8}\`) against ${PREVIOUS} (\`${BASELINE_SHA:0:8}\`)"
             echo
             echo "$line"
+            echo
+            echo "As the trailer for the commit that made the difference:"
+            echo
+            echo '```'
+            echo "$trailer"
+            echo '```'
             echo
             if [ "$SPRT" = "true" ]; then
               echo "SPRT stops when the games settle the question at a five percent error rate each way: H1 accepted means stronger by about ${ELO1} elo or more, H0 accepted means not, and inconclusive means the cap of ${GAMES} games or ${MAX_MATCH_MINUTES} minutes arrived first."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,16 @@ repos:
         language: system
         types: [rust]
         pass_filenames: false
+      # An engine commit states its bench, a perf commit its speed, and an elo
+      # claim comes in one shape. What each is and how to produce it is in
+      # docs/DEVELOPMENT.md under commit trailers.
+      # Its own python rather than the system's, which on windows is a stub
+      # that only offers to install one.
+      - id: check-trailers
+        name: check the commit trailers
+        entry: python scripts/check_trailers.py
+        language: python
+        stages: [commit-msg]
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0
     hooks:

--- a/cliff.toml
+++ b/cliff.toml
@@ -21,6 +21,12 @@ body = """
         - {% if commit.breaking %}[**breaking**] {% endif %}\
 {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
 {{ commit.message | upper_first }}\
+{% for footer in commit.footers %}\
+{% if footer.token == "Bench" %} [bench {{ footer.value }}]\
+{% elif footer.token == "Speed" %} [speed {{ footer.value | split(pat=" ") | first }}]\
+{% elif footer.token == "Elo" %} [elo {{ footer.value }}]\
+{% endif %}\
+{% endfor %}\
     {% endfor %}
 {% endfor %}\n
 """

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -56,7 +56,8 @@ cargo clippy --workspace --all-targets -- -D warnings
 ```
 
 The pre-commit configuration runs them too, along with a check that the commit
-message is a conventional commit, which is what the changelog is generated from:
+message is a conventional commit, which is what the changelog is generated from,
+and carries the trailers its kind requires, which are described below:
 
 ```
 pip install pre-commit
@@ -114,6 +115,43 @@ Merge commits are exempt.
 `git-cliff --unreleased` prints what the next release would say, which is the
 quickest way to check a scope landed where it should.
 
+## Commit trailers
+
+A commit that changes the engine carries the bench after it, so the history
+says how much of the tree each change looks at, and a commit that claims
+speed carries how much it measured. Both are trailers, the `Key: value` lines
+git keeps at the end of a message, and the commit-msg hook checks them:
+
+| trailer | required on | produced by |
+| --- | --- | --- |
+| `Bench: 42847751` | `feat`, `fix`, `perf` and `refactor` to `board`, `eval`, `magic`, `search` or `zobrist` | `scripts/bench_trailer.sh` |
+| `Speed: +3.1% (bench nps, 5 interleaved rounds vs a1b2c3d, spread 2.4%)` | `perf` to one of those scopes | `scripts/speed.sh` |
+| `Elo: +12 ±8 (sprt [0, 10], 1240 games, 10+0.1, vs v0.3.10)` | nothing, checked when present | the Strength workflow's summary |
+
+So an engine commit is made as
+
+```
+git commit --trailer "$(scripts/bench_trailer.sh)"
+```
+
+and a perf commit adds `--trailer "$(scripts/speed.sh | tail -n 1)"`, which
+builds the commit the tree stands on once, keeps it under `target/speed/`,
+and runs the bench for each side in turn with the side that goes first
+alternating, so the spread it prints beside the change is what the change has
+to be read against: a plus three with a six percent spread is not a claim.
+Both scripts build the tree as it stands rather than as it is staged, so
+stage everything first. A refactor that moves nothing still states the bench,
+since unchanged is a claim worth making, and the Bench workflow builds every
+commit that states one and counts it, so a wrong number fails the pull
+request. The trailers are the final paragraph of the message and nothing
+else, which is how git reads them, and the bench has to be the last bench
+number anywhere in the message, because that is the one openbench reads, so
+a sentence that names one goes above them.
+
+The Elo line is pasted from the Strength workflow's summary, which prints it
+ready to use, and `Elo: not measured` is the honest alternative on a change
+that was not played. The changelog prints all three after the entry.
+
 ## Benchmarks
 
 ```
@@ -145,7 +183,7 @@ same thing on any machine, and `node_counts_have_not_moved` in
 `basic_engine/src/bench.rs` pins it position by position. A deliberate change
 to the search is expected to move it, and the numbers are updated in the same
 commit so the diff shows how much more, or less, of each tree is being looked
-at. The last line, `<nodes> nodes <nps> nps`, is the one the match tools read,
+at, with the new total stated in the commit's `Bench:` trailer. The last line, `<nodes> nodes <nps> nps`, is the one the match tools read,
 and `bench` is also a uci command. Both take a depth after the word, as in
 `arche bench 3`, for trying the command cheaply; the number that means
 anything is the one at the default. The suite, depth and table are chosen once:

--- a/scripts/bench_trailer.sh
+++ b/scripts/bench_trailer.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Print the Bench trailer for the tree as it stands, for an engine commit:
+#
+#     git commit --trailer "$(scripts/bench_trailer.sh)"
+#
+# Builds the release binary first, unless ARCHE names one already built, from
+# the tree as it stands rather than as it is staged. The number is the
+# bench's last line, which is the count the hook checks and the one openbench
+# reads.
+set -euo pipefail
+
+if [ -z "${ARCHE:-}" ]; then
+    cargo build --release --quiet
+    # where cargo put it, which CARGO_TARGET_DIR moves
+    ARCHE="${CARGO_TARGET_DIR:-target}/release/arche"
+fi
+
+nodes=$("$ARCHE" bench | tail -n 1 | cut -d' ' -f1)
+if ! [ "$nodes" -gt 0 ] 2>/dev/null; then
+    echo "bench_trailer.sh: no node count in the output of $ARCHE bench" >&2
+    exit 1
+fi
+echo "Bench: ${nodes}"

--- a/scripts/benchmark_summary.py
+++ b/scripts/benchmark_summary.py
@@ -67,15 +67,83 @@ def percent(change):
         return 0.0
 
 
+def bench_last_line(text):
+    """The nodes and rate from a bench's output, or None when there is none."""
+    for line in reversed(text.strip().splitlines()):
+        words = line.split()
+        if len(words) == 4 and words[1] == "nodes" and words[3] == "nps":
+            return int(words[0]), int(words[2])
+    return None
+
+
+def bench_table(base_text, pr_text):
+    """The engine's own bench on each side of the pull request, as markdown.
+
+    The node count is compared for being the same, not for size: a search
+    change moves it and that is the commit's Bench trailer's business. The
+    rate is the speed figure over a real search rather than a microbenchmark,
+    read against the same noise as the rows above it.
+    """
+    base, pr = bench_last_line(base_text), bench_last_line(pr_text)
+    lines = [
+        "## Bench",
+        "",
+        "The engine's own bench on each side, on the same runner.",
+        "",
+        "| | base | pull request | change |",
+        "| --- | --- | --- | --- |",
+    ]
+    if base is None or pr is None:
+        missing = "not measured"
+        lines.append(
+            f"| nodes | {base[0] if base else missing} | {pr[0] if pr else missing} | |"
+        )
+        return "\n".join(lines) + "\n"
+    moved = base[0] != pr[0]
+    lines.append(f"| nodes | {base[0]} | {pr[0]} | {'moved' if moved else 'same'} |")
+    change = 100.0 * (pr[1] - base[1]) / base[1]
+    lines.append(f"| nps | {base[1]} | {pr[1]} | {change:+.1f}% |")
+    if moved:
+        lines += [
+            "",
+            (
+                "The node counts moved, so this is a search change as well as "
+                "whatever it does to the speed; the commit's Bench trailer says "
+                "by how much."
+            ),
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def bench_files(argv):
+    """The two bench outputs named after --bench, or nothing."""
+    if "--bench" not in argv:
+        return None
+    at = argv.index("--bench")
+    return argv[at + 1], argv[at + 2]
+
+
+def read_or_empty(path):
+    try:
+        with open(path, encoding="utf-8") as file:
+            return file.read()
+    except OSError:
+        return ""
+
+
 def main():
     # criterion writes utf-8, a minus sign and a micro sign among it, whatever
     # the console's own encoding is. Read and write the same way, so a windows
     # clone parses the sign rather than a mangled one and prints the table
     sys.stdin.reconfigure(encoding="utf-8")
     sys.stdout.reconfigure(encoding="utf-8")
+    bench = bench_files(sys.argv[1:])
     results = list(parse(sys.stdin))
     if not results:
         print("No benchmark comparison was produced.")
+        if bench:
+            print()
+            print(bench_table(read_or_empty(bench[0]), read_or_empty(bench[1])))
         return 1
 
     moved = [r for r in results if r[3] == "Performance has regressed"]
@@ -94,6 +162,9 @@ def main():
     ):
         label = LABEL.get(verdict, verdict)
         print(f"| `{name}` | {time or ''} | {change or 'no baseline'} | {label} |")
+    if bench:
+        print()
+        print(bench_table(read_or_empty(bench[0]), read_or_empty(bench[1])))
     return 0
 
 

--- a/scripts/check_trailers.py
+++ b/scripts/check_trailers.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Check the trailers a commit message carries against what its kind requires.
+
+A commit that changes the engine says what the bench counts after it, so the
+history states how much of the tree each change looks at; a commit that
+claims speed says how much it measured; and an elo claim is in the one shape
+the changelog and the release notes read. Runs as a commit-msg hook, given
+the file holding the message, and in ci over every commit of a pull request.
+
+Trailers are read the way git reads them: the `Key: value` lines of the
+final paragraph, and nothing else. A Bench line with prose after it is body
+text to git, to the changelog and to the ci check, so it is body text here.
+
+The scopes and types are the engine half of the table in docs/DEVELOPMENT.md.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ENGINE_SCOPES = {"board", "eval", "magic", "search", "zobrist"}
+MEASURED_TYPES = {"feat", "fix", "perf", "refactor", "revert"}
+SUBJECT = re.compile(r"^(?P<type>\w+)(\((?P<scope>[\w-]+)\))?!?: ")
+EXEMPT = ("Merge ", "fixup! ", "squash! ", "chore(release): prepare for ")
+TRAILER_LINE = re.compile(r"^[A-Za-z][\w-]*: ")
+TRAILER = re.compile(r"^(Bench|Speed|Elo): (.*)$")
+# what openbench's server reads the expected bench from: the last of these
+# anywhere in the message, so the trailer has to be it
+OPENBENCH = re.compile(r"(?:bench|nodes)[ :=]+([0-9,]+)", re.IGNORECASE)
+# one round shows no spread, so it is no measurement
+SPEED = re.compile(
+    r"^[+-]\d+(\.\d+)?% \(bench nps, ([2-9]|\d{2,}) interleaved rounds "
+    r"vs [0-9a-f]{7,40}, spread \d+(\.\d+)?%\)$"
+)
+ELO = re.compile(
+    r"^(not measured"
+    r"|[+-]\d+ ±\d+ \((sprt \[-?\d+(\.\d+)?, -?\d+(\.\d+)?\], )?"
+    r"\d+ games, [^,()]+, vs [^()]+\))$"
+)
+
+
+def trailers_of(lines: list[str]) -> dict[str, str]:
+    """The trailers of a message, from its final paragraph, as git keeps
+    them. A final paragraph with anything else in it holds none."""
+    body = "\n".join(lines[1:]).strip("\n")
+    paragraphs = re.split(r"\n\s*\n", body) if body else []
+    last = (
+        [line for line in paragraphs[-1].splitlines() if line.strip()]
+        if paragraphs
+        else []
+    )
+    if not last or not all(TRAILER_LINE.match(line) for line in last):
+        return {}
+    found = {}
+    for line in last:
+        if match := TRAILER.match(line):
+            found[match.group(1)] = match.group(2)
+    return found
+
+
+def problems(message: str) -> list[str]:
+    """Everything wrong with the message's trailers, in the order found."""
+    lines = [line for line in message.splitlines() if not line.startswith("#")]
+    if not lines or lines[0].startswith(EXEMPT):
+        return []
+    match = SUBJECT.match(lines[0])
+    kind = match.group("type") if match else ""
+    scope = match.group("scope") if match else ""
+    trailers = trailers_of(lines)
+
+    engine = scope in ENGINE_SCOPES and kind in MEASURED_TYPES
+    found = []
+    if engine and "Bench" not in trailers:
+        found.append("an engine commit needs a Bench: trailer")
+    if "Bench" in trailers:
+        value = trailers["Bench"]
+        # exactly digits: the ci check reads the line with git's trailer
+        # parser and compares the value as printed
+        if not re.fullmatch(r"\d+", value):
+            found.append(f"Bench: must be a plain number, got {value}")
+        else:
+            read = OPENBENCH.findall("\n".join(lines))
+            last = read[-1] if read else None
+            if last != value:
+                found.append(
+                    f"Bench: {value} is not the last bench number in the message, "
+                    f"which openbench reads: {last}"
+                )
+    if engine and kind == "perf" and "Speed" not in trailers:
+        found.append("a perf commit needs a Speed: trailer")
+    if "Speed" in trailers and not SPEED.match(trailers["Speed"]):
+        found.append(
+            "Speed: is not in the shape scripts/speed.sh prints, "
+            f"got {trailers['Speed']}"
+        )
+    if "Elo" in trailers and not ELO.match(trailers["Elo"]):
+        found.append(
+            "Elo: is not in the shape the strength workflow prints, "
+            f"got {trailers['Elo']}"
+        )
+    return found
+
+
+def main(argv: list[str]) -> int:
+    message = Path(argv[0]).read_text(encoding="utf-8", errors="replace")
+    found = problems(message)
+    for problem in found:
+        print(f"commit message: {problem}", file=sys.stderr)
+    return 1 if found else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/match_summary.py
+++ b/scripts/match_summary.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Print the elo estimate, and any sprt verdict, from a fastchess result file."""
 
+import argparse
 import re
-import sys
 from pathlib import Path
 
 # the lookbehind keeps this from matching the nElo figure on the same line
@@ -42,9 +42,41 @@ def verdict(text: str) -> str:
     return f", SPRT {bounds[-1]} accepted {hypothesis}: {reading}"
 
 
+def trailer(text: str, tc: str, baseline: str) -> str:
+    """The result as the Elo trailer a commit carries, in the one shape the
+    commit-msg hook accepts: the estimate, the sprt bounds when there were
+    any, the games, the time control and what was played. A sweep has no
+    estimate, fastchess prints inf, and a trailer claiming a number it never
+    gave would be a lie the hook could not catch."""
+    found = ELO.findall(text)
+    if not found:
+        return "Elo: not measured"
+    elo, margin = found[-1]
+    games = GAMES.findall(text)[-1]
+    sprt = ""
+    if bounds := LLR.findall(text):
+        low, high = (float(bound) for bound in bounds[-1].strip("[]").split(","))
+        sprt = f"sprt [{low:g}, {high:g}], "
+    estimate = f"{round(float(elo)):+d} ±{round(float(margin))}"
+    return f"Elo: {estimate} ({sprt}{games} games, {tc}, vs {baseline})"
+
+
 def main() -> None:
-    text = Path(sys.argv[1]).read_text()
-    print(f"{estimate(text)}{verdict(text)}")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("result", help="a fastchess result file")
+    parser.add_argument(
+        "--trailer",
+        action="store_true",
+        help="print the Elo trailer for a commit instead of the summary line",
+    )
+    parser.add_argument("--tc", default="", help="the time control played")
+    parser.add_argument("--baseline", default="", help="what was played against")
+    args = parser.parse_args()
+    text = Path(args.result).read_text()
+    if args.trailer:
+        print(trailer(text, args.tc, args.baseline))
+    else:
+        print(f"{estimate(text)}{verdict(text)}")
 
 
 if __name__ == "__main__":

--- a/scripts/speed.py
+++ b/scripts/speed.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Measure one engine's bench against another's and print the Speed trailer.
+
+A rate on its own says nothing across machines, and a single pair of runs
+says nothing on one: this box swings ten percent between runs. So the two
+binaries take turns, which side goes first alternating each round, the
+medians are compared, and the spread of the rounds is printed beside the
+change so a reader can tell a claim from noise. The node counts are printed
+too, since a search change moves them and a speed change must not.
+
+    speed.py <base binary> <candidate binary> [--rounds N] [--depth D]
+             [--base-ref SHA]
+
+scripts/speed.sh builds the base commit and calls this.
+"""
+
+import argparse
+import statistics
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Measured:
+    base_nps: list[int] = field(default_factory=list)
+    candidate_nps: list[int] = field(default_factory=list)
+    base_nodes: int = 0
+    candidate_nodes: int = 0
+
+
+def last_line(text: str) -> tuple[int, int] | None:
+    """The nodes and the rate from the bench's last line, `N nodes M nps`,
+    or nothing when the output does not end that way."""
+    lines = text.strip().splitlines()
+    words = lines[-1].split() if lines else []
+    if len(words) != 4 or words[1] != "nodes" or words[3] != "nps":
+        return None
+    return int(words[0]), int(words[2])
+
+
+def bench(binary: str, depth: int | None) -> tuple[int, int]:
+    command = [binary, "bench"] + ([str(depth)] if depth is not None else [])
+    # stdin closed, so a binary from before the bench existed, which would
+    # start its uci loop and wait, ends instead
+    output = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+    if (read := last_line(output.stdout)) is None:
+        raise SystemExit(
+            f"{binary}: no bench in its output, which ended: {output.stdout[-200:]!r}"
+        )
+    return read
+
+
+def measure(base: str, candidate: str, rounds: int, depth: int | None) -> Measured:
+    measured = Measured()
+    for round_ in range(rounds):
+        # which side runs first alternates, so a machine warming up or
+        # cooling down through the rounds leans on neither
+        order = [(base, measured.base_nps), (candidate, measured.candidate_nps)]
+        if round_ % 2:
+            order.reverse()
+        for binary, rates in order:
+            nodes, nps = bench(binary, depth)
+            rates.append(nps)
+            if binary == base:
+                measured.base_nodes = nodes
+            else:
+                measured.candidate_nodes = nodes
+    return measured
+
+
+def spread(rates: list[int]) -> float:
+    """How far the rounds ranged, as a share of the median."""
+    return 100.0 * (max(rates) - min(rates)) / statistics.median(rates)
+
+
+def trailer(base: list[int], candidate: list[int], base_ref: str) -> str:
+    """The Speed trailer: the change between medians, and the wider of the
+    two sides' spreads, which is what the change has to be read against."""
+    change = 100.0 * (statistics.median(candidate) - statistics.median(base))
+    change /= statistics.median(base)
+    widest = max(spread(base), spread(candidate))
+    return (
+        f"Speed: {change:+.1f}% (bench nps, {len(base)} interleaved rounds "
+        f"vs {base_ref}, spread {widest:.1f}%)"
+    )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("base")
+    parser.add_argument("candidate")
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--depth", type=int, default=None)
+    parser.add_argument("--base-ref", default="base")
+    args = parser.parse_args(argv)
+    if args.rounds < 2:
+        parser.error(
+            "at least two rounds: one shows no spread, so it is no measurement"
+        )
+
+    measured = measure(args.base, args.candidate, args.rounds, args.depth)
+    print(f"{'round':>5} {'base nps':>12} {'candidate nps':>14}")
+    for i, (b, c) in enumerate(zip(measured.base_nps, measured.candidate_nps), 1):
+        print(f"{i:>5} {b:>12} {c:>14}")
+    print(
+        f"base: {measured.base_nodes} nodes, candidate: {measured.candidate_nodes} nodes"
+    )
+    if measured.base_nodes != measured.candidate_nodes:
+        print("the node counts differ: this is a search change as well as a speed one")
+    print(trailer(measured.base_nps, measured.candidate_nps, args.base_ref))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/speed.sh
+++ b/scripts/speed.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Measure the tree as it stands against the commit it will be made on top
+# of, head by default, and print the Speed trailer for a perf commit:
+#
+#     git commit --trailer "$(scripts/bench_trailer.sh)" \
+#                --trailer "$(scripts/speed.sh | tail -n 1)"
+#
+# Run before the commit exists, which is why the base is head and not its
+# parent. The base commit is built once into target/speed/<sha>/ and kept,
+# so measuring again against the same commit costs only the rounds. The
+# tree is built as it stands, not as it is staged. ROUNDS sets how many
+# rounds there are, five by default.
+set -euo pipefail
+
+base=$(git rev-parse --verify "${1:-HEAD}^{commit}")
+short=$(git rev-parse --short "$base")
+dir="target/speed/${short}"
+
+if [ ! -x "${dir}/release/arche" ]; then
+    mkdir -p "${dir}/src"
+    git archive "$base" | tar -x -C "${dir}/src"
+    # the target dir is the commit's own, a level up from its source
+    (cd "${dir}/src" && cargo build --release --quiet --target-dir ..)
+fi
+cargo build --release --quiet
+
+python3 scripts/speed.py "${dir}/release/arche" \
+    "${CARGO_TARGET_DIR:-target}/release/arche" \
+    --base-ref "$short" --rounds "${ROUNDS:-5}"

--- a/scripts/tests/test_bench_trailer.py
+++ b/scripts/tests/test_bench_trailer.py
@@ -1,0 +1,113 @@
+"""Tests for the bench trailer script.
+
+A cargo shim stands in for the build and writes a fake engine where the real
+one would go, so what is under test is that the script builds when it has to,
+reads the bench's last line, and prints the trailer in the shape the hook
+accepts.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import check_trailers
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "bench_trailer.sh"
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="runs a shell script, which windows cannot"
+)
+
+
+def fake_engine(path, nodes):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo 'bench depth 7 hash 16MB positions 18'\n"
+        "echo 'total 1 2 3'\n"
+        f"echo '{nodes} nodes 12345678 nps'\n"
+    )
+    path.chmod(0o755)
+
+
+def run(cwd, env):
+    return subprocess.run(
+        [str(SCRIPT)],
+        cwd=cwd,
+        env={"PATH": env.get("PATH", "/usr/bin:/bin"), **env},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_it_builds_and_prints_the_trailer(tmp_path):
+    shims = tmp_path / "shims"
+    shims.mkdir()
+    cargo = shims / "cargo"
+    cargo.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo built >> cargo.log\n"
+        "mkdir -p target/release\n"
+        "printf '#!/usr/bin/env bash\\necho 42847751 nodes 1 nps\\n' > target/release/arche\n"
+        "chmod +x target/release/arche\n"
+    )
+    cargo.chmod(0o755)
+    result = run(tmp_path, {"PATH": f"{shims}:/usr/bin:/bin"})
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "Bench: 42847751\n"
+    assert (tmp_path / "cargo.log").read_text() == "built\n"
+
+
+def test_the_build_is_read_from_where_cargo_was_told_to_put_it(tmp_path):
+    # CARGO_TARGET_DIR moves the build; reading target/ regardless would
+    # bench whatever stale binary sat there
+    shims = tmp_path / "shims"
+    shims.mkdir()
+    cargo = shims / "cargo"
+    cargo.write_text(
+        "#!/usr/bin/env bash\n"
+        'mkdir -p "$CARGO_TARGET_DIR/release"\n'
+        "printf '#!/usr/bin/env bash\\necho 777 nodes 1 nps\\n'"
+        ' > "$CARGO_TARGET_DIR/release/arche"\n'
+        'chmod +x "$CARGO_TARGET_DIR/release/arche"\n'
+    )
+    cargo.chmod(0o755)
+    fake_engine(tmp_path / "target" / "release" / "arche", 1)
+    result = run(
+        tmp_path,
+        {
+            "PATH": f"{shims}:/usr/bin:/bin",
+            "CARGO_TARGET_DIR": str(tmp_path / "elsewhere"),
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "Bench: 777\n"
+
+
+def test_a_binary_named_in_the_environment_is_used_without_building(tmp_path):
+    engine = tmp_path / "elsewhere" / "arche"
+    fake_engine(engine, 777)
+    result = run(tmp_path, {"ARCHE": str(engine), "PATH": "/usr/bin:/bin"})
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "Bench: 777\n"
+    assert not (tmp_path / "target").exists()
+
+
+def test_the_trailer_passes_the_hook(tmp_path):
+    engine = tmp_path / "arche"
+    fake_engine(engine, 42847751)
+    result = run(tmp_path, {"ARCHE": str(engine), "PATH": "/usr/bin:/bin"})
+    message = f"fix(search): Do a thing\n\n{result.stdout}"
+    assert check_trailers.problems(message) == []
+
+
+def test_a_missing_engine_fails_rather_than_printing_an_empty_trailer(tmp_path):
+    result = run(
+        tmp_path, {"ARCHE": str(tmp_path / "nowhere"), "PATH": "/usr/bin:/bin"}
+    )
+    assert result.returncode != 0
+    assert "Bench:" not in result.stdout
+    assert os.path.basename(SCRIPT) in result.stderr or result.stderr

--- a/scripts/tests/test_benchmark_bench.py
+++ b/scripts/tests/test_benchmark_bench.py
@@ -1,0 +1,31 @@
+"""Tests for the bench rows the benchmark summary adds: the engine's own
+bench on each side of a pull request, measured on the one runner."""
+
+import benchmark_summary
+
+BASE = "bench depth 7 hash 16MB positions 18\n...\n42847751 nodes 12473872 nps\n"
+SAME = "bench depth 7 hash 16MB positions 18\n...\n42847751 nodes 12600000 nps\n"
+MOVED = "bench depth 7 hash 16MB positions 18\n...\n4571056 nodes 12000000 nps\n"
+
+
+def test_the_rows_carry_both_sides_and_the_change_in_rate():
+    text = benchmark_summary.bench_table(BASE, SAME)
+    assert "| nodes | 42847751 | 42847751 | same |" in text
+    assert "| nps | 12473872 | 12600000 | +1.0% |" in text
+
+
+def test_a_moved_node_count_is_named_rather_than_compared_as_speed():
+    text = benchmark_summary.bench_table(BASE, MOVED)
+    assert "| nodes | 42847751 | 4571056 | moved |" in text
+    assert "search change" in text
+
+
+def test_a_slower_rate_carries_its_sign():
+    slower = "x\n42847751 nodes 12000000 nps\n"
+    text = benchmark_summary.bench_table(BASE, slower)
+    assert "| nps | 12473872 | 12000000 | -3.8% |" in text
+
+
+def test_a_side_that_did_not_run_says_so():
+    text = benchmark_summary.bench_table(BASE, "")
+    assert "not measured" in text

--- a/scripts/tests/test_check_trailers.py
+++ b/scripts/tests/test_check_trailers.py
@@ -1,0 +1,159 @@
+"""Tests for the commit message trailer check.
+
+A commit that changes the engine has to say what the bench counts after it,
+a commit that claims speed has to say how much it measured, and an elo claim
+has to be in the one shape the changelog and the release notes read. The
+check runs as a commit-msg hook, so what is under test is which messages it
+lets through and what it says about the ones it does not.
+"""
+
+import check_trailers
+
+ENGINE = "fix(search): Finish depth one before the clock can stop the search"
+BUILD = "feat(ci): Require a bench on engine commits"
+
+
+def problems(message):
+    return check_trailers.problems(message)
+
+
+def test_an_engine_commit_needs_a_bench():
+    found = problems(f"{ENGINE}\n\nA body.\n")
+    assert found == ["an engine commit needs a Bench: trailer"]
+
+
+def test_a_bench_trailer_satisfies_an_engine_commit():
+    assert problems(f"{ENGINE}\n\nA body.\n\nBench: 42847751\n") == []
+
+
+def test_a_build_commit_needs_nothing():
+    assert problems(f"{BUILD}\n\nA body.\n") == []
+
+
+def test_every_engine_scope_and_type_is_covered():
+    for scope in ["board", "eval", "magic", "search", "zobrist"]:
+        for kind in ["feat", "fix", "perf", "refactor"]:
+            message = f"{kind}({scope}): Do a thing\n"
+            assert problems(message), f"{kind}({scope}) was let through"
+    for kind in ["docs", "test", "chore", "style"]:
+        assert problems(f"{kind}(search): Do a thing\n") == []
+
+
+def test_a_bench_must_be_digits():
+    found = problems(f"{ENGINE}\n\nBench: 42,847,751\n")
+    assert found == ["Bench: must be a plain number, got 42,847,751"]
+
+
+def test_the_bench_trailer_must_be_the_last_bench_number_in_the_message():
+    # openbench reads the last `bench <number>` anywhere in the message, so
+    # a later trailer with one in it would be read in place of the bench
+    message = f"{ENGINE}\n\nBench: 42847751\nNote: the old bench 9 positions are gone\n"
+    found = problems(message)
+    assert found == [
+        (
+            "Bench: 42847751 is not the last bench number in the message, "
+            "which openbench reads: 9"
+        )
+    ]
+
+
+def test_a_node_count_in_the_body_is_read_the_same_way():
+    message = f"{ENGINE}\n\nThe search visits 4571056 nodes.\n\nBench: 42847751\n"
+    assert problems(message) == []
+    message = f"{ENGINE}\n\nBench: 42847751\n\nNow nodes 4571056 are visited.\n"
+    assert problems(message)
+
+
+def test_a_perf_commit_needs_a_speed_as_well():
+    message = "perf(search): Sort less\n\nBench: 42847751\n"
+    assert problems(message) == ["a perf commit needs a Speed: trailer"]
+
+
+def test_a_perf_commit_on_the_build_needs_neither():
+    assert problems("perf(bench): Stop timing the memset\n") == []
+
+
+def test_the_speed_format_is_fixed():
+    good = (
+        "perf(search): Sort less\n\nBench: 42847751\n"
+        "Speed: +3.1% (bench nps, 5 interleaved rounds vs a1b2c3d, spread 2.4%)\n"
+    )
+    assert problems(good) == []
+    bad = "perf(search): Sort less\n\nBench: 42847751\nSpeed: faster\n"
+    assert problems(bad) == [
+        "Speed: is not in the shape scripts/speed.sh prints, got faster"
+    ]
+
+
+def test_the_elo_format_is_fixed_when_present():
+    for value in [
+        "+12 ±8 (sprt [0, 10], 1240 games, 10+0.1, vs v0.3.10)",
+        "-3 ±11 (500 games, 10+0.1, vs master)",
+        "not measured",
+    ]:
+        assert problems(f"{ENGINE}\n\nBench: 1\nElo: {value}\n") == [], value
+    assert problems(f"{ENGINE}\n\nBench: 1\nElo: about ten\n") == [
+        "Elo: is not in the shape the strength workflow prints, got about ten"
+    ]
+
+
+def test_merges_fixups_and_the_release_bump_are_exempt():
+    for message in [
+        "Merge branch 'feature'\n",
+        "fixup! fix(search): Finish depth one\n",
+        "squash! perf(search): Sort less\n",
+        "chore(release): prepare for 0.4.0\n",
+    ]:
+        assert problems(message) == [], message
+
+
+def test_only_the_final_paragraph_holds_trailers_as_git_reads_it():
+    # a Bench line followed by more prose is not a trailer to git, git-cliff
+    # or the ci check, so it must not be one to the hook either
+    message = f"{ENGINE}\n\nBench: 5\n\nMore prose after.\n"
+    assert problems(message) == ["an engine commit needs a Bench: trailer"]
+    # and other trailers in the same final paragraph are fine
+    message = f"{ENGINE}\n\nA body.\n\nBench: 5\nCo-Authored-By: Someone <s@x>\n"
+    assert problems(message) == []
+
+
+def test_the_bench_value_is_exactly_digits_with_no_stray_whitespace():
+    # the ci check reads the line with git's trailer parser and compares the
+    # value as printed, so the hook refuses what that would not match
+    for value in ["5 ", " 5", "5\t"]:
+        assert problems(f"{ENGINE}\n\nBench: {value}\n") == [
+            f"Bench: must be a plain number, got {value}"
+        ], repr(value)
+
+
+def test_sprt_bounds_may_carry_decimals():
+    line = "Elo: +12 ±8 (sprt [-1.5, 2.5], 100 games, 10+0.1, vs master)"
+    assert problems(f"{ENGINE}\n\nBench: 1\n{line}\n") == []
+
+
+def test_a_speed_of_one_round_is_not_a_measurement():
+    line = "Speed: +3.1% (bench nps, 1 interleaved rounds vs a1b2c3d, spread 0.0%)"
+    assert problems(f"perf(search): x\n\nBench: 1\n{line}\n") == [
+        f"Speed: is not in the shape scripts/speed.sh prints, got {line[7:]}"
+    ]
+
+
+def test_a_revert_of_an_engine_change_needs_a_bench():
+    assert problems("revert(search): Undo the sort\n") == [
+        "an engine commit needs a Bench: trailer"
+    ]
+
+
+def test_comment_lines_are_ignored():
+    # git hands the hook the message with its commented instructions still in
+    message = f"{ENGINE}\n\nBench: 1\n# Please enter the commit message\n# bench 99\n"
+    assert problems(message) == []
+
+
+def test_the_hook_reads_the_file_and_exits_nonzero_on_a_problem(tmp_path, capsys):
+    path = tmp_path / "COMMIT_EDITMSG"
+    path.write_text(f"{ENGINE}\n\nA body.\n")
+    assert check_trailers.main([str(path)]) == 1
+    assert "needs a Bench: trailer" in capsys.readouterr().err
+    path.write_text(f"{ENGINE}\n\nBench: 1\n")
+    assert check_trailers.main([str(path)]) == 0

--- a/scripts/tests/test_match_summary.py
+++ b/scripts/tests/test_match_summary.py
@@ -124,6 +124,54 @@ def test_a_capped_sprt_match_is_inconclusive(tmp_path):
     )
 
 
+def trailer(tmp_path, text, tc="10+0.1", baseline="v0.3.10"):
+    result_file = tmp_path / "result.txt"
+    result_file.write_text(text)
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            str(result_file),
+            "--trailer",
+            "--tc",
+            tc,
+            "--baseline",
+            baseline,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_a_fixed_match_gives_the_elo_trailer(tmp_path):
+    result = trailer(tmp_path, RESULT)
+    assert result.stdout == "Elo: +7 ±45 (50 games, 10+0.1, vs v0.3.10)\n"
+
+
+def test_an_sprt_match_names_its_bounds_in_the_trailer(tmp_path):
+    result = trailer(tmp_path, SPRT_CAPPED, tc="1+0.01", baseline="master")
+    assert result.stdout == "Elo: +58 ±81 (sprt [0, 10], 60 games, 1+0.01, vs master)\n"
+
+
+def test_a_sweep_has_no_elo_to_state(tmp_path):
+    # fastchess prints inf, and a trailer claiming a number it never gave
+    # would be a lie the hook could not catch
+    result = trailer(tmp_path, SPRT_H0)
+    assert result.stdout == "Elo: not measured\n"
+
+
+def test_the_trailer_passes_the_hook(tmp_path):
+    import check_trailers
+
+    # the bounds are workflow inputs and need not be whole
+    decimals = SPRT_CAPPED.replace("[0.00, 10.00]", "[-1.50, 2.50]")
+    for text in [RESULT, SPRT_CAPPED, SPRT_H0, decimals]:
+        line = trailer(tmp_path, text).stdout
+        message = f"perf(search): Sort less\n\nBench: 1\nSpeed: +1.0% (bench nps, 5 interleaved rounds vs a1b2c3d, spread 1.0%)\n{line}"
+        assert check_trailers.problems(message) == [], line
+
+
 def test_a_fixed_match_gets_no_sprt_annotation(tmp_path):
     # the LLR line is the marker of an sprt run, a plain match must not grow
     # a verdict

--- a/scripts/tests/test_speed.py
+++ b/scripts/tests/test_speed.py
@@ -1,0 +1,184 @@
+"""Tests for the speed comparison.
+
+Two binaries stand in for the tree as it stands and the commit it is measured
+against. They print a bench whose rate is whatever the test wants, and log
+every call, so what is under test is the arithmetic, the shape of the trailer
+and that the rounds really alternate.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import speed
+
+SCRIPT = Path(__file__).resolve().parent.parent / "speed.sh"
+
+
+def fake_engine(directory, name, nps_by_call, nodes=100):
+    """An engine that prints a bench whose rate is the next of nps_by_call on
+    every run, and appends its name to a log beside it."""
+    log = directory / "calls.log"
+    rates = directory / f"{name}.rates"
+    rates.write_text("\n".join(str(n) for n in nps_by_call) + "\n")
+    body = (
+        "import pathlib, sys\n"
+        f"log = pathlib.Path({str(log)!r})\n"
+        f"rates = pathlib.Path({str(rates)!r})\n"
+        "left = rates.read_text().split()\n"
+        "rates.write_text('\\n'.join(left[1:]) + '\\n')\n"
+        f"log.open('a').write({name!r} + '\\n')\n"
+        "print('bench depth 1 hash 16MB positions 1')\n"
+        f"print('{nodes} nodes ' + left[0] + ' nps')\n"
+    )
+    script = directory / f"{name}.py"
+    script.write_text(body)
+    if sys.platform == "win32":
+        runner = directory / f"{name}.cmd"
+        runner.write_text(f'@"{sys.executable}" "{script}" %*\r\n')
+    else:
+        runner = directory / name
+        runner.write_text(f"#!{sys.executable}\n{body}")
+        runner.chmod(0o755)
+    return runner
+
+
+def test_the_last_line_is_read_for_nodes_and_rate():
+    text = "bench depth 7 hash 16MB positions 18\n...\n42847751 nodes 12473872 nps\n"
+    assert speed.last_line(text) == (42847751, 12473872)
+
+
+def test_the_change_is_between_medians_and_the_spread_is_the_wider_side():
+    base = [100, 102, 98, 101, 99]
+    candidate = [103, 105, 101, 104, 102]
+    assert speed.trailer(base, candidate, "a1b2c3d") == (
+        "Speed: +3.0% (bench nps, 5 interleaved rounds vs a1b2c3d, spread 4.0%)"
+    )
+
+
+def test_a_slowdown_carries_its_sign():
+    assert speed.trailer([200, 200, 200], [195, 195, 195], "a1b2c3d") == (
+        "Speed: -2.5% (bench nps, 3 interleaved rounds vs a1b2c3d, spread 0.0%)"
+    )
+
+
+def test_the_rounds_alternate_which_side_runs_first(tmp_path):
+    base = fake_engine(tmp_path, "base", [100] * 3)
+    candidate = fake_engine(tmp_path, "candidate", [110] * 3)
+    measured = speed.measure(str(base), str(candidate), rounds=3, depth=1)
+    assert measured.base_nps == [100, 100, 100]
+    assert measured.candidate_nps == [110, 110, 110]
+    assert (measured.base_nodes, measured.candidate_nodes) == (100, 100)
+    calls = (tmp_path / "calls.log").read_text().split()
+    assert calls == ["base", "candidate", "candidate", "base", "base", "candidate"]
+
+
+def test_the_report_names_differing_node_counts(tmp_path, capsys):
+    base = fake_engine(tmp_path, "base", [100] * 2, nodes=100)
+    candidate = fake_engine(tmp_path, "candidate", [100] * 2, nodes=90)
+    assert (
+        speed.main(
+            [str(base), str(candidate), "--rounds", "2", "--base-ref", "abc1234"]
+        )
+        == 0
+    )
+    out = capsys.readouterr().out
+    assert "100 nodes" in out and "90 nodes" in out
+    assert out.strip().endswith(
+        "Speed: +0.0% (bench nps, 2 interleaved rounds vs abc1234, spread 0.0%)"
+    )
+
+
+def test_fewer_than_two_rounds_is_refused(tmp_path, capsys):
+    base = fake_engine(tmp_path, "base", [100])
+    candidate = fake_engine(tmp_path, "candidate", [100])
+    with pytest.raises(SystemExit) as left:
+        speed.main([str(base), str(candidate), "--rounds", "1"])
+    assert left.value.code == 2
+    assert "rounds" in capsys.readouterr().err
+
+
+def test_an_engine_that_prints_no_bench_is_named_rather_than_a_traceback(tmp_path):
+    quiet = tmp_path / ("quiet.cmd" if sys.platform == "win32" else "quiet")
+    quiet.write_text("@echo off\r\n" if sys.platform == "win32" else "#!/bin/sh\n")
+    quiet.chmod(0o755)
+    with pytest.raises(SystemExit) as left:
+        speed.measure(str(quiet), str(quiet), rounds=2, depth=1)
+    assert "no bench" in str(left.value)
+
+
+def test_the_trailer_passes_the_hook():
+    import check_trailers
+
+    line = speed.trailer([100, 101, 99], [104, 103, 105], "a1b2c3d")
+    message = f"perf(search): Sort less\n\nBench: 1\n{line}\n"
+    assert check_trailers.problems(message) == []
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="runs a shell script, which windows cannot"
+)
+def test_the_wrapper_builds_the_base_commit_and_measures_against_it(tmp_path):
+    # a repository of two commits, a cargo that "builds" by writing a fake
+    # engine wherever it is told to, and the wrapper measuring the second
+    # commit against the first
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args):
+        return subprocess.run(
+            ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    git("init", "-q")
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "speed.py").write_text(
+        speed.__file__ and Path(speed.__file__).read_text()
+    )
+    (repo / "Cargo.toml").write_text('[package]\nname = "arche"\n')
+    git("add", ".")
+    git("commit", "-qm", "first")
+    (repo / "Cargo.toml").write_text('[package]\nname = "arche"\nversion = "2"\n')
+    git("commit", "-aqm", "second")
+    # the tree is measured against the commit it will be made on top of,
+    # which is head: the trailer is produced before the commit exists
+    base = git("rev-parse", "--short", "HEAD")
+
+    shims = tmp_path / "shims"
+    shims.mkdir()
+    cargo = shims / "cargo"
+    cargo.write_text(
+        "#!/usr/bin/env bash\n"
+        "# writes a fake engine under the target dir asked for, or target/\n"
+        "dir=target\n"
+        "while [ $# -gt 0 ]; do\n"
+        '  if [ "$1" = --target-dir ]; then dir=$2; shift; fi\n'
+        "  shift\n"
+        "done\n"
+        'mkdir -p "$dir/release"\n'
+        "printf '#!/usr/bin/env bash\\necho 100 nodes 1000 nps\\n' > \"$dir/release/arche\"\n"
+        'chmod +x "$dir/release/arche"\n'
+    )
+    cargo.chmod(0o755)
+
+    result = subprocess.run(
+        [str(SCRIPT)],
+        cwd=repo,
+        env={
+            "PATH": f"{shims}:{Path(sys.executable).parent}:/usr/bin:/bin",
+            "ROUNDS": "2",
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith(
+        f"Speed: +0.0% (bench nps, 2 interleaved rounds vs {base}, spread 0.0%)"
+    )
+    assert (repo / "target" / "speed" / base / "release" / "arche").exists()

--- a/scripts/tests/test_verify_bench.py
+++ b/scripts/tests/test_verify_bench.py
@@ -1,0 +1,134 @@
+"""Tests for the per commit bench check.
+
+A repository whose every commit carries a file saying what its engine would
+count, a cargo that builds a fake engine reading that file, and the check
+walking the commits: what is under test is that a stated bench is compared
+with a counted one for each commit, that a commit stating none is passed
+over with a word, and that one mismatch fails the lot.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "verify_bench.sh"
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="runs a shell script, which windows cannot"
+)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args):
+        return subprocess.run(
+            ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def commit(counted, message):
+        (repo / "bench.txt").write_text(f"{counted}\n")
+        git("add", ".")
+        git("commit", "-qm", message)
+        return git("rev-parse", "HEAD")
+
+    git("init", "-q")
+    shims = tmp_path / "shims"
+    shims.mkdir()
+    cargo = shims / "cargo"
+    # the fake engine counts whatever the commit's file says, and an engine
+    # told to crash does, the way a broken commit's would
+    cargo.write_text(
+        "#!/usr/bin/env bash\n"
+        "mkdir -p target/release\n"
+        "printf '#!/usr/bin/env bash\\nn=$(cat bench.txt)\\n"
+        '[ "$n" = crash ] && exit 1\\necho "$n nodes 1 nps"\\n\''
+        " > target/release/arche\n"
+        "chmod +x target/release/arche\n"
+    )
+    cargo.chmod(0o755)
+    return repo, git, commit, shims
+
+
+def verify(repo, shims, base, head):
+    return subprocess.run(
+        [str(SCRIPT), base, head],
+        cwd=repo,
+        env={"PATH": f"{shims}:/usr/bin:/bin"},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_every_stated_bench_is_counted_and_a_match_passes(repo):
+    repo, _git, commit, shims = repo
+    base = commit(1, "docs(docs): Start")
+    commit(100, "fix(search): One\n\nBench: 100")
+    head = commit(200, "fix(search): Two\n\nBench: 200")
+    result = verify(repo, shims, base, head)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "fix(search): One: bench 100 ok" in result.stdout
+    assert "fix(search): Two: bench 200 ok" in result.stdout
+
+
+def test_a_commit_stating_no_bench_is_passed_over(repo):
+    repo, _git, commit, shims = repo
+    base = commit(1, "docs(docs): Start")
+    head = commit(5, "docs(docs): Words only")
+    result = verify(repo, shims, base, head)
+    assert result.returncode == 0
+    assert "docs(docs): Words only: no bench stated" in result.stdout
+
+
+def test_one_mismatch_fails_the_lot_but_every_commit_is_still_reported(repo):
+    repo, _git, commit, shims = repo
+    base = commit(1, "docs(docs): Start")
+    commit(100, "fix(search): One\n\nBench: 100")
+    commit(200, "fix(search): Two\n\nBench: 250")
+    head = commit(300, "fix(search): Three\n\nBench: 300")
+    result = verify(repo, shims, base, head)
+    assert result.returncode == 1
+    assert "fix(search): Two: bench stated 250, counted 200" in result.stdout
+    assert "fix(search): Three: bench 300 ok" in result.stdout
+
+
+def test_a_bench_that_crashes_is_reported_and_the_rest_still_counted(repo):
+    repo, _git, commit, shims = repo
+    base = commit(1, "docs(docs): Start")
+    commit("crash", "fix(search): One\n\nBench: 100")
+    head = commit(200, "fix(search): Two\n\nBench: 200")
+    result = verify(repo, shims, base, head)
+    assert result.returncode == 1
+    assert "fix(search): One: bench stated 100, counted nothing" in result.stdout
+    assert "fix(search): Two: bench 200 ok" in result.stdout
+
+
+def test_a_bench_line_that_git_does_not_read_as_a_trailer_is_not_one(repo):
+    # a Bench line with prose after it is body text to git, and the check
+    # reads trailers the way git does
+    repo, _git, commit, shims = repo
+    base = commit(1, "docs(docs): Start")
+    head = commit(100, "fix(search): One\n\nBench: 999\n\nMore prose after.")
+    result = verify(repo, shims, base, head)
+    assert result.returncode == 0
+    assert "fix(search): One: no bench stated" in result.stdout
+
+
+def test_the_checkout_is_left_where_it_was(repo):
+    repo, git, commit, shims = repo
+    base = commit(1, "docs(docs): Start")
+    commit(100, "fix(search): One\n\nBench: 100")
+    head = commit(200, "fix(search): Two\n\nBench: 200")
+    branch = git("symbolic-ref", "--short", "HEAD")
+    verify(repo, shims, base, head)
+    assert git("rev-parse", "HEAD") == head
+    assert git("symbolic-ref", "--short", "HEAD") == branch

--- a/scripts/verify_bench.sh
+++ b/scripts/verify_bench.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Count the bench of every commit between two that states one, and compare.
+#
+#     verify_bench.sh <base> <head>
+#
+# Each commit in base..head with a Bench trailer is checked out and built,
+# its bench run, and the count compared with the one stated. The trailer is
+# read the way git reads it, so a line the changelog would not take is not
+# one here either. Every commit is reported, a build or a bench that fails
+# counts as a mismatch and the walk goes on, and the checkout is put back
+# where it started. The count is exact and the same on any machine, which is
+# what lets this gate where a timing could not.
+set -euo pipefail
+
+base=${1:?usage: verify_bench.sh <base> <head>}
+head=${2:?usage: verify_bench.sh <base> <head>}
+bin="${CARGO_TARGET_DIR:-target}/release/arche"
+# a branch to come back to, or the commit when there is none
+start=$(git symbolic-ref -q --short HEAD || git rev-parse HEAD)
+
+failed=0
+for sha in $(git rev-list --reverse "${base}..${head}"); do
+    subject=$(git log -1 --format=%s "$sha")
+    # git prints the values and a blank line after them, so the last value
+    # is the last line with anything on it
+    stated=$(git log -1 --format='%(trailers:key=Bench,valueonly)' "$sha" | awk 'NF { value = $0 } END { print value }')
+    if [ -z "$stated" ]; then
+        echo "${sha:0:7} ${subject}: no bench stated"
+        continue
+    fi
+    git checkout -q --detach "$sha"
+    if ! cargo build --release --quiet --locked; then
+        echo "${sha:0:7} ${subject}: bench stated ${stated}, build failed"
+        failed=1
+        continue
+    fi
+    if ! counted=$("$bin" bench | tail -n 1 | cut -d' ' -f1) || [ -z "$counted" ]; then
+        counted=nothing
+    fi
+    if [ "$counted" = "$stated" ]; then
+        echo "${sha:0:7} ${subject}: bench ${stated} ok"
+    else
+        echo "${sha:0:7} ${subject}: bench stated ${stated}, counted ${counted}"
+        failed=1
+    fi
+done
+git checkout -q "$start"
+exit "$failed"


### PR DESCRIPTION
Every commit that changes the engine now states its bench, a commit that claims a speed-up states what it measured, and an Elo result has one fixed shape. They are git trailers, checked by a commit-msg hook and by CI.

## The trailers

```
Bench: 42847751
Speed: +3.1% (bench nps, 5 interleaved rounds vs a1b2c3d, spread 2.4%)
Elo: +12 ±8 (sprt [0, 10], 1240 games, 10+0.1, vs v0.3.10)
```

`Bench` is required on `feat`, `fix`, `perf`, `refactor` and `revert` commits scoped `board`, `eval`, `magic`, `search` or `zobrist`. `Speed` is required on `perf` commits to those scopes. `Elo` is optional and checked when present; `Elo: not measured` is fine. Trailers are the final paragraph of the message, read the way git reads them. `Bench` also has to be the last `bench <number>` anywhere in the message, because that is the one OpenBench's server reads.

## Producing them

```
git commit --trailer "$(scripts/bench_trailer.sh)"
git commit --trailer "$(scripts/bench_trailer.sh)" --trailer "$(scripts/speed.sh | tail -n 1)"
```

`bench_trailer.sh` builds the tree and prints the bench's last line as a trailer. `speed.sh` builds the commit the tree stands on once, keeps it under `target/speed/`, and runs the bench for both sides with the first side alternating each round. The spread is printed next to the change because the machine swings a few percent between runs: two identical engines here measured +0.5% with a 2.6% spread and then +1.6% with a 0.6% spread. Both scripts build the working tree, not the index. The Strength workflow prints the Elo line ready to paste.

## Checks

A new Bench workflow runs on pull requests. One job runs pre-commit over the tree and the commit-msg hooks over every commit in the PR, which the scope hook had never had done for it before. The other rebuilds each commit that states a bench, runs `arche bench`, and fails on a mismatch. Node counts are deterministic, so this gates; the timing benchmark still only reports, though its comment now also shows the engine's own bench on both sides.

The changelog prints the trailers after each entry. `docs/DEVELOPMENT.md` has the details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
