### PR TITLE
docs(docs): Split the readme up and add AI disclaimer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,9 @@ jobs:
           zip: windows
           checksum: "sha256"
           archive: $bin-$tag-$target
-          include: LICENSE,README.md
+          # The readme links to the changelog and to docs/, so they travel
+          # with it; a relative link in the archive is dead otherwise.
+          include: LICENSE,README.md,CHANGELOG.md,docs
           # (required) GitHub token for uploading assets to GitHub Releases.
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ perf.data*
 callgrind.out*
 dhat.out*
 flamegraph.svg*
+
+# agent instructions for one machine, kept out of the repository
+/AGENTS.local.md
+/CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Working on Arche
+
+Arche is a small chess engine. The code is short enough to read, so this file
+is only for what reading it will not tell you.
+
+## Before you commit
+
+Read [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md). It has the build, the two test
+runs, the lints, the commit scopes and the trailers an engine commit carries. A
+commit-msg hook checks the scope, so a guess at one is rejected rather than
+quietly accepted.
+
+[docs/ROADMAP.md](docs/ROADMAP.md) has what is not implemented, what is known to
+be wrong, and which experiments have already been measured and rejected.
+
+## House rules
+
+- Design and planning documents stay out of the repository unless one has been
+  asked for. Keep them in a scratch directory.
+- Review fixes are folded into the commits they fix rather than added on top.
+  Rebuild the branch and push with `--force-with-lease`.
+- Pull request descriptions are short, plain and self-contained.
+- For a change that is not trivial, have a second agent review it if one is
+  available, and check its findings against the code before acting on them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -3,20 +3,44 @@ Andrew's Rust Chess Engine
 
 ## About
 
-This project is mostly intended for self-edification. The engine is not intended to be particularly novel or powerful.
+This project is mostly intended for self-edification. The engine is not intended to be
+particularly novel or powerful, and most of the effort goes into being able to tell whether a
+change to it helped. Every change to the engine states in its commit message how much of the
+tree the search looks at afterwards, and a change that claims to be faster states how much
+faster it measured.
 
-The board is currently represented using only bitboards (with magic bitboards for move generation of sliding pieces).
+Since 2026 most of the changes in this repo are written by AI. I had abandoned this project
+for want of time, but AI has changed that. AI allows me to explore new ideas — be they my own,
+AI generated or borrowed from other engines. I still decide on the roadmap, but I can no longer
+call the engine all my own work. It remains first and foremost a fun project that helps me
+learn about how chess engines work and performance tuning in Rust.
+
+The board is currently represented using only bitboards (with magic bitboards for move
+generation of sliding pieces).
 
 The search is alpha beta with a transposition table, iterative deepening, quiescence search and
 MVV-LVA move ordering. Evaluation is material plus piece square tables.
 
+None of this is meant as a reference implementation, and it is not especially idiomatic Rust.
+The engine is something to experiment on rather than an example to copy.
+
+## Documentation
+
+- [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) — building, the tests, the benchmarks and the
+  bench, playing a match against a previous version, placing the engine on the ccrl scale, and
+  cutting a release
+- [docs/ROADMAP.md](docs/ROADMAP.md) — what is not implemented yet, and the limitations of what is
+- [docs/LICHESS.md](docs/LICHESS.md) — running the engine as a bot account on lichess
+- [CHANGELOG.md](CHANGELOG.md) — what changed in each release
+
 ## Usage
 
-The engine does not ship with any GUI. It currently implements a subset of the UCI protocol, you can use it with an open source GUI such as [Arena](http://www.playwitharena.de/).
+The engine does not ship with any GUI. It currently implements a subset of the UCI protocol,
+you can use it with an open source GUI such as [Arena](http://www.playwitharena.de/).
 
-The program starts in UCI mode immediately. The one argument it takes is `bench`, which
+The program starts in UCI mode immediately. The one argument it takes is `bench [depth]`, which
 searches a fixed set of positions and prints what each search counted, for measuring a
-change to the search or the speed of a machine.
+change to the search or the speed of a machine. It is a UCI command as well as an argument.
 
 Binaries for linux, macos and windows are attached to each
 [release](https://github.com/aywrite/arche/releases). To build from source:
@@ -30,78 +54,31 @@ transposition table on startup and that the size is not yet configurable over UC
 
 ## Strength
 
-Each release plays a short match against its predecessor and the result is added to the
-release notes. The estimate is only as good as the number of games behind it, which is why
-the error bar is published alongside it.
+Each release plays a short match against its predecessor, and a gauntlet against old releases
+of [Stash](https://github.com/mhouppin/stash-bot) which are ranked on the
+[ccrl](https://computerchess.org.uk/) blitz list. Both results are added to the release notes.
+The estimate is only as good as the number of games behind it, which is why the error bar is
+published alongside it.
 
-Each release also plays a gauntlet against old releases of
-[Stash](https://github.com/mhouppin/stash-bot), which are ranked on the
-[ccrl](https://computerchess.org.uk/) blitz list, and the rating that implies is added
-alongside. The engine has not been entered into any rating list itself, and the gauntlet
-is played faster and on different hardware than the list it borrows its opponents from,
-so read that figure as a placement to within about a hundred points rather than a rating.
-
-## Development
-
-See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for how to run the tests and benchmarks,
-play a match against a previous version, and cut a release.
+The engine has not been entered into any rating list itself, and the gauntlet is played faster
+and on different hardware than the list it borrows its opponents from, so read the figure it
+implies as a placement to within about a hundred points rather than a rating.
+[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) has the method, and what a match of a given size can
+and cannot settle.
 
 ## Lichess
 
 `docker/Dockerfile` builds an image containing
 [lichess-bot](https://github.com/lichess-bot-devs/lichess-bot), the engine and an opening book,
 which is enough to run the engine as a bot account on [lichess.org](https://lichess.org).
-Images are published to `ghcr.io/aywrite/arche-lichess-bot`, tagged `master` on every push to
-master. A release is tagged `latest`, `<major>.<minor>`, `<version>` and `v<version>`, the last
-of which matches the git tag and is the one quoted in the release notes along with its digest.
+Images are published to `ghcr.io/aywrite/arche-lichess-bot`.
 
 ```
 docker run -e LICHESS_BOT_TOKEN=<token> ghcr.io/aywrite/arche-lichess-bot:master
 ```
 
-The token is a lichess API token for a bot account with the `bot:play` scope. The engine
-allocates a 256MB transposition table, so give the container at least 512MB of memory. To change
-any other setting, mount a replacement over `/lichess-bot/config.yml`; the defaults are in
-`docker/config.yml`.
-
-The book is generated at build time by `docker/build_book.py` from
-[lichess-org/chess-openings](https://github.com/lichess-org/chess-openings) (CC0). Each move is
-weighted by the number of named openings that play it, so common theory is chosen far more often
-than novelties.
-
-To build and check an image locally:
-
-```
-docker build -f docker/Dockerfile -t arche-lichess-bot .
-docker/smoke_test.sh arche-lichess-bot
-```
-
-## TODO
-
-- null move pruning
-- killer moves
-- better evaluation
-  - mobility in evaluation
-  - evaluate drawn positions
-  - special cases (bishop pair, open files etc)
-- read an opening book in the engine, only the lichess-bot image has one at the moment and it is
-  lichess-bot that reads it rather than the engine
-- the rest of the uci protocol
-  - `setoption` is not handled and no options are advertised, so the 256MB transposition table
-    can only be changed in code
-  - `stop` is not handled, which rules out pondering and `go infinite`
-  - `ponderhit`, `debug` and `register` are not handled either
-- winboard
-- known issues
-  - fail low nodes (upper bounds) are never stored in the transposition table, only exact
-    scores and fail highs
-  - a transposition score that came from a repetition or fifty move draw is refused rather than
-    trusted, so the search cannot read a draw down a path that could not reach it. The reverse
-    direction is still open: a score stored with the draw out of reach can be read by a path
-    with the draw in reach, say a fifty move counter about to run out, and be trusted
-  - a fen is only validated as far as what the search cannot survive, a king a side and the side
-    not to move being out of check. A position which is illegal in other ways, such as one with
-    nine pawns or castling rights without a rook, is accepted and played from
+See [docs/LICHESS.md](docs/LICHESS.md) for the tags, the token the container needs, how the
+book is built, and how to build and check an image locally.
 
 ## Acknowledgements
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,8 +7,8 @@ cargo build --release
 ```
 
 The binary is written to `target/release/arche` (`arche.exe` on windows). It starts
-in uci mode immediately. The one argument it takes is `bench`, which prints the
-bench described below and exits.
+in uci mode immediately. The one argument it takes is `bench [depth]`, which
+prints the bench described below and exits.
 
 The release profile uses link time optimisation and a single codegen unit, so a
 release build is noticeably slower to compile than a debug one but is several
@@ -55,9 +55,10 @@ cargo fmt --all --check
 cargo clippy --workspace --all-targets -- -D warnings
 ```
 
-The pre-commit configuration runs them too, along with a check that the commit
-message is a conventional commit, which is what the changelog is generated from,
-and carries the trailers its kind requires, which are described below:
+The pre-commit configuration runs the formatter, and `cargo check` in place of
+clippy, along with a check that the commit message is a conventional commit,
+which is what the changelog is generated from, and carries the trailers its
+kind requires, which are described below:
 
 ```
 pip install pre-commit
@@ -88,7 +89,7 @@ commit under **Development** whatever its type is:
 | `ci` | github workflows and the pre-commit configuration |
 | `deps`, `deps-dev` | dependency bumps, what dependabot uses |
 | `docker` | the lichess-bot image |
-| `docs` | the readme and this file, when the change spans more than one area |
+| `docs` | the readme and the files in `docs/`, when the change spans more than one area |
 | `lint` | fmt and clippy fallout |
 | `release` | cargo-release, git-cliff and the release workflows |
 

--- a/docs/LICHESS.md
+++ b/docs/LICHESS.md
@@ -1,0 +1,34 @@
+# Running the engine on lichess
+
+`docker/Dockerfile` builds an image containing
+[lichess-bot](https://github.com/lichess-bot-devs/lichess-bot), the engine and an opening book,
+which is enough to run the engine as a bot account on [lichess.org](https://lichess.org).
+
+```
+docker run -e LICHESS_BOT_TOKEN=<token> ghcr.io/aywrite/arche-lichess-bot:master
+```
+
+The token is a lichess API token for a bot account with the `bot:play` scope. The engine
+allocates a 256MB transposition table, so give the container at least 512MB of memory. To change
+any other setting, mount a replacement over `/lichess-bot/config.yml`; the defaults are in
+`docker/config.yml`.
+
+## Tags
+
+Images are published to `ghcr.io/aywrite/arche-lichess-bot`, tagged `master` on every push to
+master. A release is tagged `latest`, `<major>.<minor>`, `<version>` and `v<version>`, the last
+of which matches the git tag and is the one quoted in the release notes along with its digest.
+
+## The book
+
+The book is generated at build time by `docker/build_book.py` from
+[lichess-org/chess-openings](https://github.com/lichess-org/chess-openings) (CC0). Each move is
+weighted by the number of named openings that play it, so common theory is chosen far more often
+than novelties.
+
+## Building and checking an image locally
+
+```
+docker build -f docker/Dockerfile -t arche-lichess-bot .
+docker/smoke_test.sh arche-lichess-bot
+```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,7 +5,10 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for how to measure whether one of these hel
 
 ## Not implemented yet
 
-Roughly in the order they look worth doing.
+The measurement spine — the bench, the commit trailers, a reference search to
+compare against — lands before the first change to the search, so that every
+later commit carries its numbers and the series has no gap in it. Roughly in
+the order they look worth doing after that.
 
 - null move pruning
 - killer moves
@@ -31,3 +34,25 @@ Roughly in the order they look worth doing.
 - a fen is only validated as far as what the search cannot survive, a king a side and the side
   not to move being out of check. A position which is illegal in other ways, such as one with
   nine pawns or castling rights without a rook, is accepted and played from
+
+## Measured and rejected
+
+Ideas that look right on paper and have already been tried. Do not propose one
+of these again without saying what is different this time.
+
+- Carrying the moving piece in `Play`, to save the `get_piece_index` walks in
+  make, unmake and MVV-LVA. Implemented correctly, node counts identical, and
+  4-6% slower: the struct grows from six bytes to seven, which takes the inline
+  `MoveList` from 384 bytes to 448. It would only pay bit-packed into the spare
+  bits of `from` and `to`, which is a different change to measure.
+- A `MoveList` inline capacity other than 64. Thirty-two and forty-eight are
+  4.2% and 3.4% slower, ninety-six and 128 marginally slower. The list is a
+  stack local at every recursion frame, so inline bytes multiply by depth and
+  trade against a 48KB L1D. Spilling is already negligible; there is nothing
+  there to fix.
+- Prefetching a child's transposition slot straight after `make_move`, 6.7%
+  slower over six interleaved rounds. The prefetch sits immediately before the
+  recursive call and the child probes the table almost first, so there is no
+  latency to hide and all that is added is an index multiply on every made
+  move. Inside `make_move`, after the key is finalised, is the only placement
+  that could pay, and it needs the key folded up front first.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,33 @@
+# Roadmap
+
+What the engine does not do yet, and what it does badly enough to be worth writing down.
+See [DEVELOPMENT.md](DEVELOPMENT.md) for how to measure whether one of these helped.
+
+## Not implemented yet
+
+Roughly in the order they look worth doing.
+
+- null move pruning
+- killer moves
+- evaluate drawn positions
+- the rest of evaluation: mobility, and special cases such as the bishop pair and open files
+- the rest of the uci protocol
+  - `setoption` is not handled and no options are advertised, so the 256MB transposition table
+    can only be changed in code
+  - `stop` is not handled, which rules out pondering and `go infinite`
+  - `ponderhit`, `debug` and `register` are not handled either
+- read an opening book in the engine, only the lichess-bot image has one at the moment and it is
+  lichess-bot that reads it rather than the engine
+- winboard
+
+## Known limitations
+
+- fail low nodes (upper bounds) are never stored in the transposition table, only exact
+  scores and fail highs
+- a transposition score that came from a repetition or fifty move draw is refused rather than
+  trusted, so the search cannot read a draw down a path that could not reach it. The reverse
+  direction is still open: a score stored with the draw out of reach can be read by a path
+  with the draw in reach, say a fifty move counter about to run out, and be trusted
+- a fen is only validated as far as what the search cannot survive, a king a side and the side
+  not to move being out of check. A position which is illegal in other ways, such as one with
+  nine pawns or castling rights without a rook, is accepted and played from


### PR DESCRIPTION
Splits the readme, states the use of AI, and corrects what had drifted.

- `docs/LICHESS.md` takes the image's operational detail: tags, the token, memory, the config override, the book, and building an image locally. The readme keeps the two sentences and the `docker run` line.
- `docs/ROADMAP.md` takes the todo list, reordered by what looks worth doing next, with the known issues under a heading of their own. Same items as before; nothing added.
- A **Documentation** section links both of those, the development guide and the changelog. The changelog was not linked from anywhere before.
- The release archive now ships `CHANGELOG.md` and `docs/` beside the binary, so those relative links resolve inside a downloaded release rather than dangling.
- The about section says that most changes since 2026 are written by AI, what that changed, and what is still mine to decide, and that the engine is something to experiment on rather than a reference to copy.
- Corrections in the development guide: pre-commit runs `cargo check` rather than clippy, the bench takes a depth, and the `docs` scope covers more than one file now.

