### PR TITLE
refactor(board): Parse the move number once and name the starting position

### DIFF
--- a/basic_engine/benches/benchmark.rs
+++ b/basic_engine/benches/benchmark.rs
@@ -5,9 +5,9 @@ use std::time::{Duration, Instant};
 use basic_engine::{AlphaBeta, Board, Color, Engine, Game, SearchParameters};
 
 const TEST_POSITIONS: [&str; 4] = [
-    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", // initial
+    basic_engine::STARTING_FEN, // initial
     "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1", // Kiwipete
-    "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 10 10",              // position 3
+    "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 10 10", // position 3
     "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1", // position 4
 ];
 

--- a/basic_engine/src/board.rs
+++ b/basic_engine/src/board.rs
@@ -336,7 +336,7 @@ impl Board {
     pub fn new() -> Board {
         // pay for the magic tables at startup rather than on the first search
         LazyLock::force(&MAGIC);
-        Board::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1").unwrap()
+        Board::from_fen(crate::STARTING_FEN).unwrap()
     }
 
     /// Whether this move is one `generate_moves` would produce here.
@@ -1476,6 +1476,9 @@ impl Game for Board {
         let full_move_clock = fen_iter
             .next()
             .ok_or("Error parsing FEN: Could not find full move clock")?;
+        let move_number = full_move_clock
+            .parse::<usize>()
+            .map_err(|e| e.to_string())?;
 
         let mut board = Board {
             pawns: 0,
@@ -1491,14 +1494,9 @@ impl Game for Board {
                 .ok_or("Failed to parse active color from token")?,
             castle: CastlePermissions::from_fen(castle)?,
 
-            ply: (full_move_clock
-                .parse::<usize>()
-                .map_err(|e| e.to_string())?)
-                * 2,
+            ply: move_number * 2,
             line_ply: 0,
-            move_number: full_move_clock
-                .parse::<usize>()
-                .map_err(|e| e.to_string())?,
+            move_number,
             en_passant: Coordinate::from_string(en_passant)?,
             // filled in below, once the pieces are on the board
             checkers: 0,
@@ -1637,7 +1635,7 @@ impl fmt::Display for Board {
 #[cfg(test)]
 pub(crate) mod fens {
     /// The starting position.
-    pub const START: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+    pub const START: &str = crate::STARTING_FEN;
     /// Kiwipete, the standard tactical middlegame: checks, pins, castling and
     /// an en passant square all within a move or two.
     pub const KIWIPETE: &str =
@@ -2112,11 +2110,6 @@ mod fen_parsing {
         fn random_str_doesnt_crash(s in ".*") {
             _ = Board::from_fen(&s);
         }
-
-        //#[test]
-        //fn random_fen_doesnt_crash(s in ("([NBRPKQnbrpkq1-9]{9}/){7}[NBRPKQnbrpkq1-9]{4,} [bw]{1} [kqKQ-]{1,4} [a-hA-H][1-9] [1-9]{1,} [1-9]{1,}").prop_filter("", |v| {println!("{}", v); true})) {
-        //    _ = Board::from_fen(s);
-        //}
     }
 
     #[test]

--- a/basic_engine/src/lib.rs
+++ b/basic_engine/src/lib.rs
@@ -16,6 +16,10 @@ pub use misc::{Color, Score};
 pub use play::Play;
 use std::fmt;
 
+/// The starting position, so that nothing setting a board up from scratch has
+/// to carry its own copy of the fen.
+pub const STARTING_FEN: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
 pub trait Game: fmt::Display {
     fn from_fen(fen: &str) -> Result<Self, String>
     where

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -11,8 +11,6 @@ use std::io::{BufRead, Stdout, Write};
 use std::sync::LazyLock;
 use std::time::Duration;
 
-const START_FEN: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-
 static WTIME_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"wtime (-?\d+)").unwrap());
 static BTIME_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"btime (-?\d+)").unwrap());
 static WINC_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"winc (-?\d+)").unwrap());
@@ -184,7 +182,7 @@ impl<T: Engine, W: Write> UCI<T, W> {
             None => (position_string, None),
         };
         if start.starts_with("startpos") {
-            self.engine.parse_fen(START_FEN)?;
+            self.engine.parse_fen(basic_engine::STARTING_FEN)?;
         } else if let Some(fen) = start.strip_prefix("fen") {
             self.engine.parse_fen(fen.trim())?;
         } else {


### PR DESCRIPTION
The safe half of the DRY pass. Three small duplications and one piece of dead
code, none of which changes what the engine does: the bench counts 42,847,751
before and after.

**The move number was parsed twice.** `from_fen` parsed the full move clock once
for `ply` and once for `move_number`, each with its own error mapping. Parsed
once now.

One observable consequence, stated in the commit: the parse moves ahead of the
colour and the castle rights, so a fen wrong in more than one way reports
whichever error it reaches first. `... x KQkq - 0 zz` said *Failed to parse
active color* before and says *invalid digit found in string* now. Both are
refusals and nothing pins which; I checked both binaries rather than reasoning
about it.

**The starting position was written out four times** — `Board::new`, the test
module's `fens::START`, the uci layer, and the criterion benchmark. It is
`basic_engine::STARTING_FEN` now and the literal appears exactly once. The
benchmark is a separate scope so it is a second commit.

**A commented-out proptest comes out.** Nothing can run it, nothing compiles it,
and a regex inside a comment does not say what it was for.

### What is deliberately not here

Three findings from the original audit that would have lived in this slice were
withdrawn on oracle grounds, and one reversed — merging `material_value` into
`recompute_material`, having `get_piece_and_color_index` call `get_piece_index`,
a `signed_value` helper spanning the oracle boundary, and flattening
`PieceSquareTables`. PR #80 records why in the source.

### Checks

- `bench` 42,847,751, unchanged
- `fmt` and `clippy -D warnings` clean
- 43 + 107 tests in debug, 43 + 106 in release
- `scripts/check_trailers.py` passes on both messages; git's own trailer parser
  reads `Bench: 42847751` on the engine commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Rebased onto master after #85 landed. #85 touched `lib.rs` and `uci.rs` too, but in different regions — its `SearchConfig` export and import against this branch's `STARTING_FEN` const and the removed `START_FEN` — so it merged without conflicts. The `Bench:` trailer was re-measured on top of it and is unchanged at 42,847,751: the `SearchConfig` refactor does not move the default search's tree.
