### PR TITLE
Give the search a SearchConfig and pin the reference search

### DIFF
--- a/basic_engine/src/bench.rs
+++ b/basic_engine/src/bench.rs
@@ -10,7 +10,7 @@
 
 use crate::Game;
 use crate::board::Board;
-use crate::engine::{AlphaBeta, Engine, SearchOutcome, SearchParameters};
+use crate::engine::{AlphaBeta, Engine, SearchConfig, SearchOutcome, SearchParameters};
 use std::fmt;
 use std::time::{Duration, Instant};
 
@@ -75,8 +75,8 @@ pub struct PositionReport {
     pub tt_stores: u64,
     /// Entries stored with a draw tainted score, a part of the stores.
     pub tainted_stores: u64,
-    /// Cutoffs taken from a draw tainted score, which the search refuses, so
-    /// this stays at zero while it does.
+    /// Cutoffs taken from a draw tainted score, which the configuration may
+    /// refuse, and the default does, so this stays at zero while it does.
     pub tainted_cutoffs: u64,
     /// The search alone, not the table's allocation.
     pub elapsed: Duration,
@@ -116,15 +116,22 @@ fn nps(nodes: u64, elapsed: Duration) -> u64 {
 /// and a fresh table, allocated before its clock starts, and is deepened to
 /// the depth the way a game would be, so the table is warm from each
 /// iteration to the next. A depth of zero runs no iteration and counts
-/// nothing, which is no bench at all, so it is searched as one.
-pub fn run_suite(positions: &[Position], depth: u8, table_bytes: usize) -> Report {
+/// nothing, which is no bench at all, so it is searched as one. The bench
+/// the command prints runs the default configuration, the one the engine
+/// plays with; the reference is run the same way to pin its own counts.
+pub fn run_suite(
+    positions: &[Position],
+    depth: u8,
+    table_bytes: usize,
+    config: SearchConfig,
+) -> Report {
     let depth = depth.max(1);
     let positions = positions
         .iter()
         .map(|position| {
             let board = Board::from_fen(&position.fen)
                 .unwrap_or_else(|e| panic!("bench position {} does not parse: {}", position.id, e));
-            let mut engine = AlphaBeta::with_table_bytes(board, table_bytes);
+            let mut engine = AlphaBeta::with_config(board, table_bytes, config);
             let start = Instant::now();
             let outcome = engine
                 .iterative_deepening_search(SearchParameters::new_with_depth(depth), |_, _, _| {});
@@ -282,7 +289,7 @@ mod tests {
     #[test]
     fn the_report_ends_with_the_line_the_match_tools_read() {
         let suite = parse_epd("4k3/8/8/8/8/8/8/4K3 w - - id \"bare kings\";");
-        let report = run_suite(&suite, 2, 1 << 20);
+        let report = run_suite(&suite, 2, 1 << 20, SearchConfig::default());
         let text = report.to_string();
         let last = text.lines().last().unwrap();
         let words: Vec<&str> = last.split(' ').collect();
@@ -300,7 +307,7 @@ mod tests {
             "4k3/8/8/8/8/8/8/4K3 w - - id \"bare kings\";\n\
              rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - id \"start\";",
         );
-        let report = run_suite(&suite, 3, 1 << 16);
+        let report = run_suite(&suite, 3, 1 << 16, SearchConfig::default());
         assert_eq!(report.positions.len(), 2);
         assert!(report.positions.iter().all(|p| p.nodes > 0));
         assert!(report.positions[1].quiescence_nodes <= report.positions[1].nodes);
@@ -322,7 +329,7 @@ mod tests {
         // a depth of zero runs no iteration and finds nothing, which is not
         // a bench: there is nothing to count below one
         let suite = parse_epd("4k3/8/8/8/8/8/8/4K3 w - - id \"bare kings\";");
-        let report = run_suite(&suite, 0, 1 << 20);
+        let report = run_suite(&suite, 0, 1 << 20, SearchConfig::default());
         assert_eq!(report.depth, 1);
         assert!(report.positions[0].nodes > 0);
     }
@@ -340,7 +347,7 @@ mod tests {
     /// at, position by position.
     #[test]
     fn node_counts_have_not_moved() {
-        let report = run_suite(&positions(), DEPTH, TABLE_BYTES);
+        let report = run_suite(&positions(), DEPTH, TABLE_BYTES, SearchConfig::default());
         let counted: Vec<(&str, u64)> = report
             .positions
             .iter()
@@ -367,6 +374,53 @@ mod tests {
                 ("queen endgame", 2_373_132),
                 ("king and pawn", 9_196),
                 ("trebuchet", 3_264),
+            ]
+        );
+    }
+
+    /// The reference search's counts, pinned apart from the default's. The
+    /// two are one tree today and part company at the first shortcut: from
+    /// then on a change that moves both touched the search the two share,
+    /// and one that moves the default's alone is a shortcut. Pinned
+    /// shallower than the bench, which is cheaper and coarser: a twentieth
+    /// of the time, with a table under half full, so a change to what the
+    /// table keeps shows here less than it does at the bench's depth. The
+    /// pin stays where it is when that depth is raised.
+    #[test]
+    fn reference_node_counts_have_not_moved() {
+        const REFERENCE_DEPTH: u8 = 5;
+        let report = run_suite(
+            &positions(),
+            REFERENCE_DEPTH,
+            TABLE_BYTES,
+            SearchConfig::reference(),
+        );
+        let counted: Vec<(&str, u64)> = report
+            .positions
+            .iter()
+            .map(|p| (p.id.as_str(), p.nodes))
+            .collect();
+        assert_eq!(
+            counted,
+            vec![
+                ("start", 29_326),
+                ("italian", 189_082),
+                ("ruy lopez", 158_058),
+                ("kiwipete", 294_415),
+                ("perft 4", 254_459),
+                ("promotions", 119_565),
+                ("middlegame", 215_281),
+                ("sharp middlegame", 333_615),
+                ("bratko kopec 1", 61_500),
+                ("wac 4", 99_422),
+                ("rook and pawns", 19_691),
+                ("tarrasch", 58_191),
+                ("lucena", 34_076),
+                ("philidor", 48_009),
+                ("minor endgame", 13_904),
+                ("queen endgame", 88_220),
+                ("king and pawn", 1_565),
+                ("trebuchet", 627),
             ]
         );
     }

--- a/basic_engine/src/engine.rs
+++ b/basic_engine/src/engine.rs
@@ -109,8 +109,55 @@ impl SearchParameters {
     }
 }
 
+/// The policies a search runs under: the shortcuts it takes and the scores
+/// it trusts. Each one is a fact about the tree searched, so changing one
+/// moves the bench.
+///
+/// Two configurations are named. The reference has every shortcut off and
+/// every refusal on: alpha-beta with a table that only speeds it up, which
+/// is why a position searched warm answers as it does cold, deepened as it
+/// does direct, and with a small table as with a large one. The tests hold
+/// the reference to that and it stays as it is when shortcuts arrive. A
+/// change claiming to be sound keeps those tests green whatever else it
+/// moves; a change that prunes moves the default and leaves the reference
+/// alone; and the two played against each other say what the shortcuts are
+/// worth. The default is what the engine plays with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SearchConfig {
+    /// Whether to refuse a score from a draw tainted entry, trusting only
+    /// its move.
+    ///
+    /// On in the reference and by default. A tainted score describes the
+    /// path that stored it rather than the position, so a search arriving
+    /// another way can read a draw it cannot actually reach. Refusing
+    /// costs, over the five positions the node counts pinned then at their
+    /// depths, nothing at all in kiwipete, promotions and the middlegame,
+    /// which have no tainted cutoffs to refuse, +0.037% in the opening and
+    /// +2.970% in the pawn endgame, for +0.617% overall.
+    pub refuse_tainted_cutoffs: bool,
+}
+
+impl SearchConfig {
+    /// The search with every shortcut off: what the exactness tests hold
+    /// the search to, and the side a shortcut is measured against.
+    pub const fn reference() -> Self {
+        Self {
+            refuse_tainted_cutoffs: true,
+        }
+    }
+}
+
+impl Default for SearchConfig {
+    /// What the engine plays with. The reference, for now: there is no
+    /// shortcut yet to turn on.
+    fn default() -> Self {
+        Self::reference()
+    }
+}
+
 pub struct AlphaBeta {
     pub board: Board,
+    config: SearchConfig,
     nodes: u64,
     moves: HashTable,
     selective_depth: u8,
@@ -140,8 +187,15 @@ pub struct AlphaBeta {
 
 impl AlphaBeta {
     pub fn with_table_bytes(board: Board, bytes: usize) -> Self {
+        Self::with_config(board, bytes, SearchConfig::default())
+    }
+
+    /// An engine searching under the policies given, with a table of the
+    /// size given.
+    pub fn with_config(board: Board, bytes: usize, config: SearchConfig) -> Self {
         Self {
             board,
+            config,
             nodes: 0,
             moves: HashTable::with_capacity_bytes(bytes),
             selective_depth: 0,
@@ -343,7 +397,7 @@ impl AlphaBeta {
                 Bound::Lower => score >= beta,
                 Bound::Ordering => false,
             };
-            if cuts && REFUSE_TAINTED_CUTOFFS && pv.tainted {
+            if cuts && self.config.refuse_tainted_cutoffs && pv.tainted {
                 // the stored draw was reachable by the path that stored it and
                 // may not be reachable by this one, so the move is still worth
                 // ordering by but the score is not worth trusting
@@ -788,16 +842,6 @@ impl Engine for AlphaBeta {
     }
 }
 
-/// Whether to refuse a score from a draw tainted entry, trusting only its move.
-///
-/// On. A tainted score describes the path that stored it rather than the
-/// position, so a search arriving another way can read a draw it cannot
-/// actually reach. Refusing costs, over the five positions the node counts
-/// pinned then at their depths, nothing at all in kiwipete, promotions and
-/// the middlegame, which have no tainted cutoffs to refuse, +0.037% in the
-/// opening and +2.970% in the pawn endgame, for +0.617% overall.
-const REFUSE_TAINTED_CUTOFFS: bool = true;
-
 /// How often the transposition table hands back a score that depended on the
 /// path taken rather than on the position, which is the graph history
 /// interaction error every engine carries and none of them measure.
@@ -996,7 +1040,7 @@ mod search {
     use super::Board;
     use super::Engine;
     use super::Game;
-    use super::{Bound, Play, Pv, SearchOutcome, SearchParameters, SearchResult};
+    use super::{Bound, Play, Pv, SearchConfig, SearchOutcome, SearchParameters, SearchResult};
     use crate::board::{fens, play_named};
     use pretty_assertions::assert_eq;
     use std::time;
@@ -1009,6 +1053,14 @@ mod search {
 
     fn engine(board: Board) -> AlphaBeta {
         AlphaBeta::with_table_bytes(board, TABLE_BYTES)
+    }
+
+    /// The reference search, for the tests that hold it to answering the
+    /// same whatever the table holds. They are the search's exactness
+    /// contract and stay green through every shortcut: a shortcut moves the
+    /// default, which `engine` builds, and not this.
+    fn reference(board: Board) -> AlphaBeta {
+        AlphaBeta::with_config(board, TABLE_BYTES, SearchConfig::reference())
     }
 
     /// A tactical middlegame the cache tests search over and over: sharp
@@ -1171,9 +1223,9 @@ mod search {
             "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
         ];
         for fen in fens {
-            let mut cold = engine(Board::from_fen(fen).unwrap());
+            let mut cold = reference(Board::from_fen(fen).unwrap());
             let expected = completed(cold.search(5));
-            let mut warm = engine(Board::from_fen(fen).unwrap());
+            let mut warm = reference(Board::from_fen(fen).unwrap());
             let result = (1..=5)
                 .map(|depth| completed(warm.search(depth)))
                 .next_back()
@@ -1450,8 +1502,11 @@ mod search {
         // while the hole silently reopens. tainted_score_cutoffs is zero by
         // construction while the refusal holds, so it moving means a probe
         // path that consumes scores without the refusal guard was added.
+        // The refusal is a policy of the reference, so the reference is what
+        // is built: a default told one day to trust those scores is an
+        // experiment to measure, not a hole to find here.
         let fen = "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1";
-        let mut e = engine(Board::from_fen(fen).unwrap());
+        let mut e = reference(Board::from_fen(fen).unwrap());
         for depth in 1..=7 {
             completed(e.search(depth));
         }
@@ -1467,6 +1522,49 @@ mod search {
     }
 
     #[test]
+    fn a_fresh_engine_searches_the_same_tree_every_time() {
+        // the default is what the bench counts and what a match by node
+        // count replays, so it has to follow from the position and the
+        // table alone: no clock, no randomness and no memory of a previous
+        // game in it. The reference is held to more than this; the default
+        // is held to this whatever shortcuts it takes
+        let board = Board::from_fen(SHARP_MIDDLEGAME).unwrap();
+        let mut first = engine(board);
+        let mut second = engine(board);
+        let a = completed(first.search(5));
+        let b = completed(second.search(5));
+        assert_eq!(
+            (a.nodes, a.score, a.best_move.to_string()),
+            (b.nodes, b.score, b.best_move.to_string())
+        );
+    }
+
+    #[test]
+    fn a_search_told_to_trust_tainted_scores_takes_their_cutoffs() {
+        // the refusal is the one policy the config carries so far, and a
+        // search told to trust those scores is the control arm of the graph
+        // history experiments. The switch has to reach the probe: a field
+        // the search never reads would make every comparison against the
+        // reference a comparison of the reference with itself
+        let fen = "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1";
+        // the reference with the one switch flipped, which is what a control
+        // arm is; written that way so it still says so once there are more
+        #[allow(clippy::needless_update)]
+        let trusting = SearchConfig {
+            refuse_tainted_cutoffs: false,
+            ..SearchConfig::reference()
+        };
+        let mut e = AlphaBeta::with_config(Board::from_fen(fen).unwrap(), TABLE_BYTES, trusting);
+        for depth in 1..=7 {
+            completed(e.search(depth));
+        }
+        assert!(
+            e.ghi.tainted_score_cutoffs > 0,
+            "the scores the search was told to trust cut nothing"
+        );
+    }
+
+    #[test]
     fn a_warm_cache_matches_cold_across_draw_context() {
         // The same pieces hash to the same key whatever the fifty move counter
         // says, so a search made a few plies from the draw fills the table
@@ -1475,12 +1573,12 @@ mod search {
         // clock ahead of it.
         let near_draw = "5k2/1p3p1p/p3pK1P/P1P1P3/4bP2/2B5/8/8 w - - 96 112";
         let fresh = "5k2/1p3p1p/p3pK1P/P1P1P3/4bP2/2B5/8/8 w - - 0 1";
-        let mut warm = engine(Board::from_fen(near_draw).unwrap());
+        let mut warm = reference(Board::from_fen(near_draw).unwrap());
         completed(warm.search(6));
         warm.parse_fen(fresh).unwrap();
         let result = completed(warm.search(6));
 
-        let mut cold = engine(Board::from_fen(fresh).unwrap());
+        let mut cold = reference(Board::from_fen(fresh).unwrap());
         let expected = completed(cold.search(6));
         assert_eq!(result.score, expected.score);
         assert_eq!(
@@ -1498,14 +1596,14 @@ mod search {
             "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 10 10",
             "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1",
         ];
-        let mut warm = engine(Board::new());
+        let mut warm = reference(Board::new());
         for fen in fens {
             warm.parse_fen(fen).unwrap();
             completed(warm.search(5));
         }
         for fen in fens {
             let game = Board::from_fen(fen).unwrap();
-            let mut cold = engine(game);
+            let mut cold = reference(game);
             let expected = completed(cold.search(5));
             warm.parse_fen(fen).unwrap();
             let result = completed(warm.search(5));
@@ -1523,9 +1621,13 @@ mod search {
     fn a_small_table_matches_a_large_table() {
         // a table small enough to force constant collisions must not change the result
         let fen = SHARP_MIDDLEGAME;
-        let mut big = engine(Board::from_fen(fen).unwrap());
+        let mut big = reference(Board::from_fen(fen).unwrap());
         let expected = completed(big.search(5));
-        let mut small = AlphaBeta::with_table_bytes(Board::from_fen(fen).unwrap(), 8 * 1024);
+        let mut small = AlphaBeta::with_config(
+            Board::from_fen(fen).unwrap(),
+            8 * 1024,
+            SearchConfig::reference(),
+        );
         let result = completed(small.search(5));
         assert_eq!(result.score, expected.score);
     }
@@ -1679,13 +1781,13 @@ mod search {
     fn a_stopped_search_does_not_poison_the_cache() {
         let fen = SHARP_MIDDLEGAME;
         let game = Board::from_fen(fen).unwrap();
-        let mut cold = engine(game);
+        let mut cold = reference(game);
         let expected = completed(cold.search(6));
 
         // a search with no time budget stops immediately, it must not leave partial results in
         // the hash table which change the outcome of the next search
         let game = Board::from_fen(fen).unwrap();
-        let mut e = engine(game);
+        let mut e = reference(game);
         e.configure(time::Instant::now(), Some(time::Duration::ZERO));
         assert!(matches!(e.search(6), SearchOutcome::Aborted(_)));
 

--- a/basic_engine/src/lib.rs
+++ b/basic_engine/src/lib.rs
@@ -9,7 +9,9 @@ mod psqt;
 mod zobrist;
 
 pub use board::Board;
-pub use engine::{AlphaBeta, Engine, PvLine, SearchOutcome, SearchParameters, SearchResult};
+pub use engine::{
+    AlphaBeta, Engine, PvLine, SearchConfig, SearchOutcome, SearchParameters, SearchResult,
+};
 pub use misc::{Color, Score};
 pub use play::Play;
 use std::fmt;

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -192,6 +192,19 @@ changing any of them changes every number the bench has ever printed, which is
 why the depth is expected to be raised exactly once, after the search has
 learned to prune, rather than adjusted as it goes.
 
+The search runs under a `SearchConfig`, and two configurations are named.
+The reference, `SearchConfig::reference()`, is alpha-beta with every shortcut
+off: its table only speeds it up, so a position searched warm answers as it
+does cold, and the tests in `basic_engine/src/engine.rs` that say so build
+the reference and hold it to that for good. They are the soundness check: a
+change that claims to be sound keeps them green whatever else it moves. The
+default is what the engine plays with and what the bench prints. It is the
+reference today and parts company with it at the first shortcut; from then
+on `reference_node_counts_have_not_moved` pins the reference's tree beside
+the default's, so a commit's diff says which kind of change it carries. One
+that moves both counts touched the search the two share, move ordering or
+the table, say; one that moves the default's alone is a shortcut.
+
 ## Playing a match against a previous version
 
 Benchmarks measure speed, they do not measure whether the engine plays better.

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ pub use uci::UCI;
 
 use basic_engine::AlphaBeta;
 use basic_engine::Board;
+use basic_engine::SearchConfig;
 use basic_engine::bench;
 use std::process::ExitCode;
 
@@ -27,7 +28,12 @@ fn main() -> ExitCode {
             Ok(depth) => {
                 println!(
                     "{}",
-                    bench::run_suite(&bench::positions(), depth, bench::TABLE_BYTES)
+                    bench::run_suite(
+                        &bench::positions(),
+                        depth,
+                        bench::TABLE_BYTES,
+                        SearchConfig::default()
+                    )
                 );
                 ExitCode::SUCCESS
             }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,6 +1,7 @@
 use crate::time_control::TimeControl;
 use basic_engine::Color;
 use basic_engine::Engine;
+use basic_engine::SearchConfig;
 use basic_engine::SearchOutcome;
 use basic_engine::SearchParameters;
 use basic_engine::bench;
@@ -147,7 +148,12 @@ impl<T: Engine, W: Write> UCI<T, W> {
             // anything is the one at the default
             match bench_depth(line) {
                 Ok(depth) => {
-                    let report = bench::run_suite(&bench::positions(), depth, bench::TABLE_BYTES);
+                    let report = bench::run_suite(
+                        &bench::positions(),
+                        depth,
+                        bench::TABLE_BYTES,
+                        SearchConfig::default(),
+                    );
                     self.say(format_args!("{}", report));
                 }
                 Err(word) => self.say(format_args!(


### PR DESCRIPTION
The search has no pruning yet, so a position searched with a warm table answers the same as with a cold one, and four tests say so. The first pruning change will break that on purpose and would have taken those tests with it.

This names the search as it stands before that happens. `SearchConfig::reference()` is alpha-beta with every shortcut off; `SearchConfig::default()` is what the engine plays with. They are the same today. The exactness tests now build the reference and keep holding whatever the default learns later: a sound change (table layout, fail-soft) has to keep them green, and a pruning change moves the default's node counts and not the reference's.

The config carries one switch so far, the refusal of draw tainted scores, which was a const. Turning it off is the control arm for the GHI experiments, and a test checks the switch actually reaches the probe.

The bench pins the reference's counts in a second test at depth 5 (the same tree as the default today; about 3 s in debug). `arche bench` and the `Bench:` trailer are the default's numbers and are unchanged: 42847751.

No UCI option yet; that comes with the first feature there is to flip.
