### PR TITLE
SPRT verdict in the Elo trailer, a scope drift test, and two workflow cadence fixes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,16 +1,21 @@
 name: Docker
 
+# A pull request, and a push to master, build the image and smoke test it, so
+# a Dockerfile that no longer builds is found before a release rather than on
+# the day. Neither publishes: the image that runs is a release's, published
+# when the release workflow calls this one, so that it is only built once the
+# tests have passed and the release exists. The master build is also what
+# keeps the layer cache warm: a pull request can read master's cache and a
+# tag can, and neither can read the other's.
 on:
   push:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
-  # a tag is published by the release workflow calling this one, so that the
-  # image is only built once the tests have passed and the release exists
   workflow_call:
     inputs:
       release:
-        description: Add the published image to the release notes for this tag
+        description: Publish the image for this tag, and add it to the release notes
         type: boolean
         default: false
 
@@ -18,7 +23,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}-lichess-bot
 
-# Two pushes in quick succession would otherwise race to publish the same tags.
+# a new push to the same ref makes the build in progress redundant
 concurrency:
   group: docker-${{ github.ref }}
   cancel-in-progress: true
@@ -61,10 +66,10 @@ jobs:
         run: docker/smoke_test.sh arche-lichess-bot:test
 
       - uses: docker/setup-qemu-action@v4
-        if: github.event_name != 'pull_request'
+        if: inputs.release
 
       - name: Log in to the container registry
-        if: github.event_name != 'pull_request'
+        if: inputs.release
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -72,20 +77,19 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Collect image metadata
-        if: github.event_name != 'pull_request'
+        if: inputs.release
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
             type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
 
       - name: Build and push
-        if: github.event_name != 'pull_request'
+        if: inputs.release
         id: push
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ permissions:
 # a new push to a pull request makes the run in progress redundant
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -17,7 +17,7 @@ permissions:
 # a new push to a pull request makes the run in progress redundant
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:
@@ -27,5 +27,5 @@ jobs:
       - uses: actions/checkout@v7
       - name: Run the script tests
         run: |
-          python3 -m pip install --quiet pytest
+          python3 -m pip install --quiet pytest pyyaml
           python3 -m pytest scripts/tests -q

--- a/.github/workflows/strength.yml
+++ b/.github/workflows/strength.yml
@@ -253,7 +253,7 @@ jobs:
             echo '```'
             echo
             if [ "$SPRT" = "true" ]; then
-              echo "SPRT stops when the games settle the question at a five percent error rate each way: H1 accepted means stronger by about ${ELO1} elo or more, H0 accepted means not, and inconclusive means the cap of ${GAMES} games or ${MAX_MATCH_MINUTES} minutes arrived first."
+              echo "SPRT stops when the games settle the question at a five percent error rate each way: passed (H1 accepted) means stronger by about ${ELO1} elo or more, failed (H0 accepted) means not, and inconclusive means the cap of ${GAMES} games or ${MAX_MATCH_MINUTES} minutes arrived first."
             else
               echo "At ${GAMES} games only a difference of about $(python3 -c "print(int(800/(${GAMES}**0.5)))") elo can be told from none."
             fi

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ which is enough to run the engine as a bot account on [lichess.org](https://lich
 Images are published to `ghcr.io/aywrite/arche-lichess-bot`.
 
 ```
-docker run -e LICHESS_BOT_TOKEN=<token> ghcr.io/aywrite/arche-lichess-bot:master
+docker run -e LICHESS_BOT_TOKEN=<token> ghcr.io/aywrite/arche-lichess-bot:latest
 ```
 
 See [docs/LICHESS.md](docs/LICHESS.md) for the tags, the token the container needs, how the

--- a/cliff.toml
+++ b/cliff.toml
@@ -56,8 +56,9 @@ commit_parsers = [
     { message = "^chore\\(release\\): prepare for ", skip = true},
     # Scopes that name part of the build rather than part of the engine, matched
     # ahead of the types so that a feat(docker) or a perf(bench) does not read
-    # as a change to how the engine plays.
-    { message = "^\\w+\\((bench|book|ci|deps(-dev)?|docker|lint|release)\\)!?:", group = "<!-- 6 -->Development"},
+    # as a change to how the engine plays. The list is the build table in
+    # docs/DEVELOPMENT.md, and scripts/tests/test_scopes.py holds them to it.
+    { message = "^\\w+\\((bench|book|ci|deps(-dev)?|docker|docs|lint|release)\\)!?:", group = "<!-- 6 -->Development"},
     { message = "^feat", group = "<!-- 0 -->Features"},
     { message = "^fix", group = "<!-- 1 -->Bug Fixes"},
     { message = "^perf", group = "<!-- 2 -->Performance"},

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -128,7 +128,7 @@ git keeps at the end of a message, and the commit-msg hook checks them:
 | --- | --- | --- |
 | `Bench: 42847751` | `feat`, `fix`, `perf` and `refactor` to `board`, `eval`, `magic`, `search` or `zobrist` | `scripts/bench_trailer.sh` |
 | `Speed: +3.1% (bench nps, 5 interleaved rounds vs a1b2c3d, spread 2.4%)` | `perf` to one of those scopes | `scripts/speed.sh` |
-| `Elo: +12 ±8 (sprt [0, 10], 1240 games, 10+0.1, vs v0.3.10)` | nothing, checked when present | the Strength workflow's summary |
+| `Elo: +12 ±8 (sprt [0, 10] passed, 1240 games, 10+0.1, vs v0.3.10)` | nothing, checked when present | the Strength workflow's summary |
 
 So an engine commit is made as
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -111,7 +111,9 @@ The engine ones are grouped by type instead:
 The commit-msg hook rejects a scope that is not on the list, which is the point:
 a mistyped `perf(benchmark)` would otherwise be published as if the engine had
 got faster. Adding a scope means adding it to the hook arguments in
-`.pre-commit-config.yaml`, and to `cliff.toml` as well if it is a build one.
+`.pre-commit-config.yaml`, to the table above it belongs in, and to
+`cliff.toml` if it is a build one or to `scripts/check_trailers.py` if it is
+an engine one; `scripts/tests/test_scopes.py` fails until the four agree.
 Merge commits are exempt.
 
 `git-cliff --unreleased` prints what the next release would say, which is the

--- a/docs/LICHESS.md
+++ b/docs/LICHESS.md
@@ -5,7 +5,7 @@
 which is enough to run the engine as a bot account on [lichess.org](https://lichess.org).
 
 ```
-docker run -e LICHESS_BOT_TOKEN=<token> ghcr.io/aywrite/arche-lichess-bot:master
+docker run -e LICHESS_BOT_TOKEN=<token> ghcr.io/aywrite/arche-lichess-bot:latest
 ```
 
 The token is a lichess API token for a bot account with the `bot:play` scope. The engine
@@ -15,9 +15,11 @@ any other setting, mount a replacement over `/lichess-bot/config.yml`; the defau
 
 ## Tags
 
-Images are published to `ghcr.io/aywrite/arche-lichess-bot`, tagged `master` on every push to
-master. A release is tagged `latest`, `<major>.<minor>`, `<version>` and `v<version>`, the last
-of which matches the git tag and is the one quoted in the release notes along with its digest.
+Images are published to `ghcr.io/aywrite/arche-lichess-bot` on release only. A release is tagged
+`latest`, `<major>.<minor>`, `<version>` and `v<version>`, the last of which matches the git tag
+and is the one quoted in the release notes along with its digest. A pull request or a push to
+master builds and smoke tests the image without publishing it. The `master` tag that earlier
+versions published is no longer updated; a bot still running it is on whatever master was then.
 
 ## The book
 

--- a/scripts/check_trailers.py
+++ b/scripts/check_trailers.py
@@ -32,9 +32,12 @@ SPEED = re.compile(
     r"^[+-]\d+(\.\d+)?% \(bench nps, ([2-9]|\d{2,}) interleaved rounds "
     r"vs [0-9a-f]{7,40}, spread \d+(\.\d+)?%\)$"
 )
+# an sprt names its verdict: bounds alone would leave a passed test and a
+# failed one telling the same story
 ELO = re.compile(
     r"^(not measured"
-    r"|[+-]\d+ ±\d+ \((sprt \[-?\d+(\.\d+)?, -?\d+(\.\d+)?\], )?"
+    r"|[+-]\d+ ±\d+ \((sprt \[-?\d+(\.\d+)?, -?\d+(\.\d+)?\] "
+    r"(passed|failed|inconclusive), )?"
     r"\d+ games, [^,()]+, vs [^()]+\))$"
 )
 

--- a/scripts/match_summary.py
+++ b/scripts/match_summary.py
@@ -44,10 +44,13 @@ def verdict(text: str) -> str:
 
 def trailer(text: str, tc: str, baseline: str) -> str:
     """The result as the Elo trailer a commit carries, in the one shape the
-    commit-msg hook accepts: the estimate, the sprt bounds when there were
-    any, the games, the time control and what was played. A sweep has no
-    estimate, fastchess prints inf, and a trailer claiming a number it never
-    gave would be a lie the hook could not catch."""
+    commit-msg hook accepts: the estimate, the sprt bounds and verdict when
+    there were any, the games, the time control and what was played. The
+    verdict is the point of an sprt, an estimate of +58 with the test
+    failed and one with it passed are not the same claim, so it is named,
+    and a match a cap stopped is inconclusive. A sweep has no estimate,
+    fastchess prints inf, and a trailer claiming a number it never gave
+    would be a lie the hook could not catch."""
     found = ELO.findall(text)
     if not found:
         return "Elo: not measured"
@@ -56,7 +59,13 @@ def trailer(text: str, tc: str, baseline: str) -> str:
     sprt = ""
     if bounds := LLR.findall(text):
         low, high = (float(bound) for bound in bounds[-1].strip("[]").split(","))
-        sprt = f"sprt [{low:g}, {high:g}], "
+        accepted = VERDICT.findall(text)
+        verdict = (
+            "inconclusive"
+            if not accepted
+            else ("passed" if accepted[-1] == "H1" else "failed")
+        )
+        sprt = f"sprt [{low:g}, {high:g}] {verdict}, "
     estimate = f"{round(float(elo)):+d} ±{round(float(margin))}"
     return f"Elo: {estimate} ({sprt}{games} games, {tc}, vs {baseline})"
 

--- a/scripts/tests/test_check_trailers.py
+++ b/scripts/tests/test_check_trailers.py
@@ -92,15 +92,21 @@ def test_the_speed_format_is_fixed():
 
 def test_the_elo_format_is_fixed_when_present():
     for value in [
-        "+12 ±8 (sprt [0, 10], 1240 games, 10+0.1, vs v0.3.10)",
-        "+12 ±8 (sprt [-1.5, 2.5], 100 games, 10+0.1, vs master)",
+        "+12 ±8 (sprt [0, 10] passed, 1240 games, 10+0.1, vs v0.3.10)",
+        "-2 ±9 (sprt [0, 10] failed, 1240 games, 10+0.1, vs v0.3.10)",
+        "+12 ±8 (sprt [-1.5, 2.5] inconclusive, 100 games, 10+0.1, vs master)",
         "-3 ±11 (500 games, 10+0.1, vs master)",
         "not measured",
     ]:
         assert problems(f"{ENGINE}\n\nBench: 1\nElo: {value}\n") == [], value
-    assert problems(f"{ENGINE}\n\nBench: 1\nElo: about ten\n") == [
-        "Elo: is not in the shape the strength workflow prints, got about ten"
-    ]
+    for value in [
+        "about ten",
+        # sprt bounds with no verdict: the estimate alone is not the result
+        "+12 ±8 (sprt [0, 10], 1240 games, 10+0.1, vs v0.3.10)",
+    ]:
+        assert problems(f"{ENGINE}\n\nBench: 1\nElo: {value}\n") == [
+            f"Elo: is not in the shape the strength workflow prints, got {value}"
+        ], value
 
 
 def test_merges_fixups_and_the_release_bump_are_exempt():

--- a/scripts/tests/test_match_summary.py
+++ b/scripts/tests/test_match_summary.py
@@ -149,9 +149,24 @@ def test_a_fixed_match_gives_the_elo_trailer(tmp_path):
     assert result.stdout == "Elo: +7 ±45 (50 games, 10+0.1, vs v0.3.10)\n"
 
 
-def test_an_sprt_match_names_its_bounds_in_the_trailer(tmp_path):
-    result = trailer(tmp_path, SPRT_CAPPED, tc="1+0.01", baseline="master")
-    assert result.stdout == "Elo: +58 ±81 (sprt [0, 10], 60 games, 1+0.01, vs master)\n"
+def test_an_sprt_match_names_its_bounds_and_verdict_in_the_trailer(tmp_path):
+    # the verdict is the point of an sprt: an estimate of +58 with the
+    # test failed and one with it passed are not the same claim, and the
+    # history has to be able to tell them apart without the log
+    interrupted = (
+        "Tournament was interrupted. To resume the tournament, "
+        "run: ./fastchess -config file=config.json"
+    )
+    for ending, verdict in [
+        (interrupted, "inconclusive"),
+        ("SPRT ([0.00, 10.00]) completed - H1 was accepted", "passed"),
+        ("SPRT ([0.00, 10.00]) completed - H0 was accepted", "failed"),
+    ]:
+        text = SPRT_CAPPED.replace(interrupted, ending)
+        result = trailer(tmp_path, text, tc="1+0.01", baseline="master")
+        assert result.stdout == (
+            f"Elo: +58 ±81 (sprt [0, 10] {verdict}, 60 games, 1+0.01, vs master)\n"
+        ), verdict
 
 
 def test_a_sweep_has_no_elo_to_state(tmp_path):

--- a/scripts/tests/test_scopes.py
+++ b/scripts/tests/test_scopes.py
@@ -1,0 +1,81 @@
+"""The commit scope list is kept in four places, and they have to agree.
+
+The commit-msg hook holds the scopes it accepts. cliff.toml names the build
+scopes, which go under Development whatever their type. The trailer check
+names the engine scopes, which need a bench. And DEVELOPMENT.md has a table
+of each kind. A scope added to the hook and not the others lands a commit in
+the wrong changelog section, or lets an engine commit through with no bench
+stated, and nothing else would notice. The hook is the gate, so that is the
+direction checked: a scope the others name and the hook does not is one no
+commit can carry.
+"""
+
+import re
+from pathlib import Path
+
+import check_trailers
+import tomllib
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+# listed by type like an engine scope, but needing no bench: the protocol
+# layer never changes what the search counts
+NEITHER = {"uci"}
+
+
+def hook_scopes() -> set[str]:
+    config = yaml.safe_load((ROOT / ".pre-commit-config.yaml").read_text("utf-8"))
+    for repo in config["repos"]:
+        for hook in repo["hooks"]:
+            if hook["id"] == "conventional-pre-commit":
+                args = hook["args"]
+                return set(args[args.index("--scopes") + 1].split(","))
+    raise AssertionError("the conventional-pre-commit hook is not configured")
+
+
+def cliff_build_pattern() -> re.Pattern:
+    """The alternation cliff.toml matches build scopes with, as a pattern a
+    scope either matches whole or does not."""
+    config = tomllib.loads((ROOT / "cliff.toml").read_text("utf-8"))
+    for parser in config["git"]["commit_parsers"]:
+        if match := re.fullmatch(r"\^\\w\+\\\((.+)\\\)!\?:", parser.get("message", "")):
+            return re.compile(match.group(1))
+    raise AssertionError("cliff.toml has no parser for the build scopes")
+
+
+def documented_scopes() -> tuple[set[str], set[str]]:
+    """The build table and the engine table of DEVELOPMENT.md, as the
+    scopes named in their first columns."""
+    text = (ROOT / "docs" / "DEVELOPMENT.md").read_text("utf-8")
+    section = text.split("## Commit messages")[1].split("## Commit trailers")[0]
+    tables = []
+    for table in re.findall(
+        r"\| scope \| covers \|\n\| --- \| --- \|\n((?:\|.*\|\n)+)", section
+    ):
+        first_cells = [row.split("|")[1] for row in table.strip().splitlines()]
+        tables.append(
+            {name for cell in first_cells for name in re.findall(r"`([\w-]+)`", cell)}
+        )
+    assert len(tables) == 2, "expected a build table and an engine table"
+    return tables[0], tables[1]
+
+
+def test_every_scope_the_hook_accepts_is_a_build_scope_or_an_engine_scope():
+    hook = hook_scopes()
+    build = {scope for scope in hook if cliff_build_pattern().fullmatch(scope)}
+    engine = check_trailers.ENGINE_SCOPES
+    assert engine <= hook, "an engine scope the hook would refuse"
+    assert not build & engine, "a scope is both build and engine"
+    unplaced = hook - build - engine - NEITHER
+    assert not unplaced, (
+        f"the hook accepts {sorted(unplaced)}, which cliff.toml and the trailer check do not place"
+    )
+
+
+def test_the_development_notes_list_the_same_scopes():
+    hook = hook_scopes()
+    build = {scope for scope in hook if cliff_build_pattern().fullmatch(scope)}
+    documented_build, documented_engine = documented_scopes()
+    assert documented_build == build
+    assert documented_engine == check_trailers.ENGINE_SCOPES | NEITHER


### PR DESCRIPTION
Four small tooling changes from the CI audit, each its own commit.

- **The `Elo:` trailer names the SPRT verdict.** It carried the bounds but not what the test decided, so a failed SPRT with a noisy +3 read the same as a passed one with +12. Now `sprt [0, 10] passed`, `failed`, or `inconclusive` for a match a cap stopped; the hook refuses bounds without a verdict. No commit on master carries an Elo trailer yet, so the shape changes once, before the first one does.
- **A test that the four scope lists agree** (the commit-msg hook, `cliff.toml`, `check_trailers.py`, the tables in `DEVELOPMENT.md`). It failed on first run: the notes list `docs` as a build scope but `cliff.toml` didn't, so a `feat(docs)` went under Features. Fixed in its own commit; a throwaway `feat(docs)` now renders under Development.
- **Master runs finish.** The Rust and Scripts workflows cancelled the run in progress on any push to the same ref, so two quick merges left the first with a cancelled status. Only pull request runs cancel now.
- **The Docker image publishes on release only.** Every master push built and published the multi-arch image (6 min, arm64 under QEMU) for a `master` tag nothing runs from. Pull requests still build and smoke test it without publishing. The notes run the bot from `latest`.

Nothing here touches the engine.