### PR TITLE
refactor(board): Remove two dead conversions and right the debug print

### DIFF
--- a/basic_engine/src/bitboard.rs
+++ b/basic_engine/src/bitboard.rs
@@ -32,7 +32,9 @@ impl BitBoard for u64 {
     fn debug_print(&self) {
         println!("    a b c d e f g h");
         println!("  -----------------");
-        for rank in 1..9 {
+        // the eighth rank first, the way the board display and a diagram write
+        // it, rather than in index order
+        for rank in (1..=8).rev() {
             print!("{} |", rank);
             for file in File::VARIANTS {
                 if (self & (1u64 << coordinate_to_index(rank, file))) > 0 {

--- a/basic_engine/src/misc.rs
+++ b/basic_engine/src/misc.rs
@@ -188,12 +188,14 @@ mod castle_permissions {
 /// The index of a square, counting a1 as zero. Ranks are one based, the way
 /// a fen and the board display write them.
 pub fn coordinate_to_index(rank: u8, file: File) -> u8 {
+    debug_assert!((1..=8).contains(&rank));
     ((rank - 1) * 8) + (file) as u8
 }
 
 /// The same square in the mailbox indexing, which offsets by a row and a column
 /// of sentinels. See `BaseConversions`.
 pub fn coordinate_to_large_index(rank: u8, file: File) -> u8 {
+    debug_assert!((1..=8).contains(&rank));
     ((rank - 1) * 10) + (file) as u8 + 11
 }
 
@@ -376,24 +378,6 @@ impl fmt::Display for File {
             File::H => write!(f, "h")?,
         }
         Ok(())
-    }
-}
-
-impl TryFrom<&str> for File {
-    type Error = String;
-
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        if s.len() != 1 {
-            return Err(format!("Expected a single character token, got: {}", s));
-        };
-        let c = s.chars().next().unwrap();
-        File::try_from(c)
-    }
-}
-
-impl From<File> for u64 {
-    fn from(file: File) -> Self {
-        file as u64
     }
 }
 


### PR DESCRIPTION
Three small things in the board's helpers.

`TryFrom<&str> for File` and `From<File> for u64` have no callers. The two File
conversions that are used, from `u8` and from `char`, stay. A trait impl is
never reported as dead code, which is how these lasted.

`debug_print` laid a bitboard out with rank one at the top, while the board
display and `attacked_print` both put rank eight there, so a bitboard dumped
beside a board read mirrored against it. Nothing calls it, which is why nobody
noticed rather than a reason to leave it.

`coordinate_to_index` and `coordinate_to_large_index` subtract one from a rank
their doc comments already say is one based. A rank of zero wraps: debug panics
on the overflow, release quietly indexes square 248. Nothing passes zero today,
so the assert states the contract rather than fixing a bug.

Checks: bench 42,847,751, unchanged. fmt and clippy clean. 43 + 104 tests
release, 43 + 105 debug, where the new asserts are live and none fired. Test
count is unchanged against master at 106 functions; the drop against earlier
numbers is master's own 052aa64.

Reviewed in-session rather than by a second agent, since none was available. No
findings: the remaining `File::try_from` calls resolve to the `u8` and `char`
impls, the `u64::from` uses elsewhere are `From<bool>`, and every
`coordinate_to_index` caller takes its rank from a `1..=8` loop, a parsed
`Coordinate`, or `index_to_coordinate`.
