### PR TITLE
Build a commit from an export, in one script the five build sites share

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -102,15 +102,9 @@ jobs:
         run: |
           # the checkout is a merge of the pull request into its base: the
           # first parent is the base and the merge is what would land
-          base=$(git rev-parse HEAD^1)
-          head=$(git rev-parse HEAD)
-          echo "BASE_SHA=$base" >> "$GITHUB_ENV"
-          git checkout --quiet --detach "$base"
-          cargo build --release --locked
-          cp target/release/arche base-arche
-          git checkout --quiet --detach "$head"
-          cargo build --release --locked
-          cp target/release/arche pr-arche
+          echo "BASE_SHA=$(git rev-parse HEAD^1)" >> "$GITHUB_ENV"
+          scripts/build_at.sh HEAD^1 base-arche
+          scripts/build_at.sh HEAD pr-arche
       - name: Measure
         id: measure
         shell: bash

--- a/.github/workflows/calibrate.yml
+++ b/.github/workflows/calibrate.yml
@@ -81,25 +81,20 @@ jobs:
 
       - uses: ./.github/actions/match-tools
 
-      # Deliberately not Swatinem/rust-cache, which the workflows that build one
-      # commit do use. This builds whichever commit it was pointed at into the
-      # same target directory, so a cache keyed on the ref would be poisoned by
-      # whatever it was last asked to measure.
+      # the cache keeps the dependencies; the engine is built from an export
+      # of its commit, and the checkout stays on the ref this ran on
+      - uses: Swatinem/rust-cache@v2
+
       - name: Build the engine
         run: |
           if [ -n "$CANDIDATE" ]; then
             sha=$(scripts/resolve_ref.sh "$CANDIDATE") \
               || { echo "::error::cannot resolve candidate ${CANDIDATE}"; exit 1; }
-            git checkout --detach "$sha"
           else
             sha=$GITHUB_SHA
           fi
           echo "CANDIDATE_SHA=${sha}" >> "$GITHUB_ENV"
-          cargo build --release
-          mkdir -p tools
-          cp target/release/arche tools/arche
-          # back to the ref this was run against, the estimate script lives there
-          git checkout --detach "$GITHUB_SHA"
+          scripts/build_at.sh "$sha" tools/arche
 
       # Not cached. Each one is a second of compiling and eighty kilobytes, so
       # fetching a cache costs more than building them does.

--- a/.github/workflows/strength.yml
+++ b/.github/workflows/strength.yml
@@ -169,13 +169,12 @@ jobs:
 
       - uses: ./.github/actions/match-tools
 
-      # Deliberately not Swatinem/rust-cache, which the workflows that build one
-      # commit do use. This builds two arbitrary commits into the same target
-      # directory, so a cache keyed on the ref would be poisoned by whichever
-      # pair it was last asked to compare.
+      # the cache keeps the dependencies; each side's engine is built from an
+      # export of its commit, and the checkout stays on the ref this ran on
+      - uses: Swatinem/rust-cache@v2
+
       - name: Build both versions
         run: |
-          mkdir -p tools
           # a pull request head is not fetched by default and the resolve job
           # ran on a different machine, so fetch anything not already here
           for sha in "$CANDIDATE_SHA" "$BASELINE_SHA"; do
@@ -183,14 +182,8 @@ jobs:
               || git fetch -q origin "$sha" \
               || git fetch -q origin "+refs/pull/*/head:refs/remotes/pull/*"
           done
-          git checkout --detach "$CANDIDATE_SHA"
-          cargo build --release
-          cp target/release/arche tools/new
-          git checkout --detach "$BASELINE_SHA"
-          cargo build --release
-          cp target/release/arche tools/old
-          # back to the ref this was run against, the summary script lives there
-          git checkout --detach "$GITHUB_SHA"
+          scripts/build_at.sh "$CANDIDATE_SHA" tools/new
+          scripts/build_at.sh "$BASELINE_SHA" tools/old
 
       - name: Play the match
         working-directory: tools

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -180,8 +180,9 @@ learned to prune, rather than adjusted as it goes.
 
 Speed is measured against another build, never on its own: a rate says
 nothing across machines, and a single pair of runs says little on one.
-`scripts/speed.sh` builds the commit the tree stands on, runs the bench for
-each side in turn with the side that goes first alternating, and prints the
+`scripts/speed.sh` builds the commit the tree stands on, from an export rather
+than a checkout so the tree is left as it is, runs the bench for each side in
+turn with the side that goes first alternating, and prints the
 change between medians with the spread beside it, which is the `Speed:`
 trailer a perf commit carries. The Bench workflow's speed job does the same
 on every pull request, both sides built and run on one runner, and posts the

--- a/scripts/build_at.sh
+++ b/scripts/build_at.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Build the engine as it was at a commit, and put the binary where asked:
+#
+#     build_at.sh <ref> <binary>
+#
+# The commit is exported with git archive into <target>/at/src, where
+# <target> is CARGO_TARGET_DIR or target/, and built there with <target> as
+# its target directory. The working tree is never checked out: nothing here
+# moves the branch, the index or a file someone is half way through, and a
+# script building one commit to measure against another has nothing to put
+# back afterwards. The source path is the same for every commit and the
+# target directory is shared, so cargo keeps what it built last time, the
+# dependencies always and the engine when the commit left it alone, the way
+# building in a checkout would.
+set -euo pipefail
+
+ref=${1:?usage: build_at.sh <ref> <binary>}
+binary=${2:?usage: build_at.sh <ref> <binary>}
+
+sha=$(git rev-parse --verify --quiet "${ref}^{commit}") \
+    || { echo "build_at.sh: ${ref} is not a commit" >&2; exit 1; }
+# absolute, because the build runs from inside it
+target=$(realpath -m "${CARGO_TARGET_DIR:-target}")
+src="${target}/at/src"
+
+rm -rf "$src"
+mkdir -p "$src"
+git archive "$sha" | tar -x -C "$src"
+(cd "$src" && cargo build --release --quiet --locked --target-dir "$target")
+mkdir -p "$(dirname "$binary")"
+cp "${target}/release/arche" "$binary"

--- a/scripts/speed.sh
+++ b/scripts/speed.sh
@@ -6,24 +6,21 @@
 #                --trailer "$(scripts/speed.sh | tail -n 1)"
 #
 # Run before the commit exists, which is why the base is head and not its
-# parent. The base commit is built once into target/speed/<sha>/ and kept,
-# so measuring again against the same commit costs only the rounds. The
-# tree is built as it stands, not as it is staged. ROUNDS sets how many
-# rounds there are, five by default.
+# parent. The base commit is built once, by build_at.sh, and its binary kept
+# under target/speed/<sha>/, so measuring again against the same commit costs
+# only the rounds. The tree is built as it stands, not as it is staged.
+# ROUNDS sets how many rounds there are, five by default.
 set -euo pipefail
 
 base=$(git rev-parse --verify "${1:-HEAD}^{commit}")
 short=$(git rev-parse --short "$base")
-dir="target/speed/${short}"
+target="${CARGO_TARGET_DIR:-target}"
+kept="${target}/speed/${short}/arche"
 
-if [ ! -x "${dir}/release/arche" ]; then
-    mkdir -p "${dir}/src"
-    git archive "$base" | tar -x -C "${dir}/src"
-    # the target dir is the commit's own, a level up from its source
-    (cd "${dir}/src" && cargo build --release --quiet --target-dir ..)
+if [ ! -x "$kept" ]; then
+    "$(dirname "$0")/build_at.sh" "$base" "$kept"
 fi
 cargo build --release --quiet
 
-python3 scripts/speed.py "${dir}/release/arche" \
-    "${CARGO_TARGET_DIR:-target}/release/arche" \
+python3 scripts/speed.py "$kept" "${target}/release/arche" \
     --base-ref "$short" --rounds "${ROUNDS:-5}"

--- a/scripts/tests/test_build_at.py
+++ b/scripts/tests/test_build_at.py
@@ -1,0 +1,115 @@
+"""Tests for building the engine as it was at a commit.
+
+A repository of two commits whose one file says which commit it is, and a
+cargo that "builds" by writing a fake engine printing that file: what is
+under test is that the binary asked for is the commit's, that the working
+tree is never touched to get it, and that the build lands where cargo is
+told to put things.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "build_at.sh"
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="runs a shell script, which windows cannot"
+)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args):
+        return subprocess.run(
+            ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    git("init", "-q")
+    (repo / "Cargo.toml").write_text('[package]\nname = "arche"\n')
+    (repo / "which.txt").write_text("first\n")
+    git("add", ".")
+    git("commit", "-qm", "first")
+    (repo / "which.txt").write_text("second\n")
+    git("commit", "-aqm", "second")
+
+    shims = tmp_path / "shims"
+    shims.mkdir()
+    cargo = shims / "cargo"
+    # builds wherever --target-dir says, or target/, a fake engine that
+    # prints the file of the tree it was built from
+    cargo.write_text(
+        "#!/usr/bin/env bash\n"
+        "dir=target\n"
+        "while [ $# -gt 0 ]; do\n"
+        '  if [ "$1" = --target-dir ]; then dir=$2; shift; fi\n'
+        "  shift\n"
+        "done\n"
+        'mkdir -p "$dir/release"\n'
+        'printf \'#!/usr/bin/env bash\\ncat %s/which.txt\\n\' "$PWD" > "$dir/release/arche"\n'
+        'chmod +x "$dir/release/arche"\n'
+    )
+    cargo.chmod(0o755)
+    return repo, git, shims
+
+
+def prints(binary):
+    """What the fake engine says, which is the tree it was built from."""
+    return subprocess.run(
+        [str(binary)], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def build(repo, shims, ref, binary, **env):
+    return subprocess.run(
+        [str(SCRIPT), ref, str(binary)],
+        cwd=repo,
+        env={"PATH": f"{shims}:/usr/bin:/bin", **env},
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_the_binary_is_the_commits_and_the_tree_is_untouched(repo, tmp_path):
+    repo, git, shims = repo
+    branch = git("symbolic-ref", "--short", "HEAD")
+    head = git("rev-parse", "HEAD")
+    (repo / "which.txt").write_text("dirty\n")
+
+    result = build(repo, shims, "HEAD~1", tmp_path / "old")
+    assert result.returncode == 0, result.stderr
+    assert prints(tmp_path / "old") == "first\n"
+
+    assert git("rev-parse", "HEAD") == head
+    assert git("symbolic-ref", "--short", "HEAD") == branch
+    assert (repo / "which.txt").read_text() == "dirty\n"
+    assert "checkout" not in git("reflog")
+
+
+def test_the_build_lands_where_cargo_is_told_to_put_it(repo, tmp_path):
+    repo, _git, shims = repo
+    elsewhere = tmp_path / "elsewhere"
+    result = build(
+        repo, shims, "HEAD", tmp_path / "new", CARGO_TARGET_DIR=str(elsewhere)
+    )
+    assert result.returncode == 0, result.stderr
+    assert prints(tmp_path / "new") == "second\n"
+    assert (elsewhere / "release" / "arche").exists()
+    assert not (repo / "target").exists()
+
+
+def test_a_ref_that_is_not_a_commit_fails(repo, tmp_path):
+    repo, _git, shims = repo
+    result = build(repo, shims, "nowhere", tmp_path / "none")
+    assert result.returncode != 0
+    assert not (tmp_path / "none").exists()

--- a/scripts/tests/test_speed.py
+++ b/scripts/tests/test_speed.py
@@ -189,4 +189,6 @@ def test_the_wrapper_builds_the_base_commit_and_measures_against_it(tmp_path):
     assert result.stdout.strip().endswith(
         f"Speed: +0.0% (bench nps, 2 interleaved rounds vs {base}, spread 0.0%)"
     )
-    assert (repo / "target" / "speed" / base / "release" / "arche").exists()
+    # the base binary is kept, so measuring against the same commit again
+    # costs only the rounds
+    assert (repo / "target" / "speed" / base / "arche").exists()

--- a/scripts/tests/test_verify_bench.py
+++ b/scripts/tests/test_verify_bench.py
@@ -44,15 +44,21 @@ def repo(tmp_path):
     shims = tmp_path / "shims"
     shims.mkdir()
     cargo = shims / "cargo"
-    # the fake engine counts whatever the commit's file says, and an engine
-    # told to crash does, the way a broken commit's would
+    # the fake engine counts whatever the file of the tree it was built from
+    # says, and an engine told to crash does, the way a broken commit's
+    # would. Built wherever --target-dir says, or target/
     cargo.write_text(
         "#!/usr/bin/env bash\n"
-        "mkdir -p target/release\n"
-        "printf '#!/usr/bin/env bash\\nn=$(cat bench.txt)\\n"
-        '[ "$n" = crash ] && exit 1\\necho "$n nodes 1 nps"\\n\''
-        " > target/release/arche\n"
-        "chmod +x target/release/arche\n"
+        "dir=target\n"
+        "while [ $# -gt 0 ]; do\n"
+        '  if [ "$1" = --target-dir ]; then dir=$2; shift; fi\n'
+        "  shift\n"
+        "done\n"
+        'mkdir -p "$dir/release"\n'
+        "printf '#!/usr/bin/env bash\\nn=$(cat %s/bench.txt)\\n"
+        '[ "$n" = crash ] && exit 1\\necho "$n nodes 1 nps"\\n\' "$PWD"'
+        ' > "$dir/release/arche"\n'
+        'chmod +x "$dir/release/arche"\n'
     )
     cargo.chmod(0o755)
     return repo, git, commit, shims
@@ -123,12 +129,18 @@ def test_a_bench_line_that_git_does_not_read_as_a_trailer_is_not_one(repo):
     assert "fix(search): One: no bench stated" in result.stdout
 
 
-def test_the_checkout_is_left_where_it_was(repo):
+def test_the_working_tree_is_never_touched(repo):
+    # the commits are built from exports, not checkouts: a developer's
+    # branch, index and half written files are exactly as they were after
     repo, git, commit, shims = repo
     base = commit(1, "docs(docs): Start")
     commit(100, "fix(search): One\n\nBench: 100")
     head = commit(200, "fix(search): Two\n\nBench: 200")
     branch = git("symbolic-ref", "--short", "HEAD")
-    verify(repo, shims, base, head)
+    (repo / "bench.txt").write_text("half written\n")
+    result = verify(repo, shims, base, head)
+    assert result.returncode == 0, result.stderr
     assert git("rev-parse", "HEAD") == head
     assert git("symbolic-ref", "--short", "HEAD") == branch
+    assert (repo / "bench.txt").read_text() == "half written\n"
+    assert "checkout" not in git("reflog")

--- a/scripts/verify_bench.sh
+++ b/scripts/verify_bench.sh
@@ -3,20 +3,19 @@
 #
 #     verify_bench.sh <base> <head>
 #
-# Each commit in base..head with a Bench trailer is checked out and built,
+# Each commit in base..head with a Bench trailer is built by build_at.sh,
+# from an export rather than a checkout, so the working tree is left alone;
 # its bench run, and the count compared with the one stated. The trailer is
 # read the way git reads it, so a line the changelog would not take is not
-# one here either. Every commit is reported, a build or a bench that fails
-# counts as a mismatch and the walk goes on, and the checkout is put back
-# where it started. The count is exact and the same on any machine, which is
-# what lets this gate where a timing could not.
+# one here either. Every commit is reported, and a build or a bench that
+# fails counts as a mismatch and the walk goes on. The count is exact and
+# the same on any machine, which is what lets this gate where a timing
+# could not.
 set -euo pipefail
 
 base=${1:?usage: verify_bench.sh <base> <head>}
 head=${2:?usage: verify_bench.sh <base> <head>}
-bin="${CARGO_TARGET_DIR:-target}/release/arche"
-# a branch to come back to, or the commit when there is none
-start=$(git symbolic-ref -q --short HEAD || git rev-parse HEAD)
+bin="${CARGO_TARGET_DIR:-target}/at/arche"
 
 failed=0
 for sha in $(git rev-list --reverse "${base}..${head}"); do
@@ -28,8 +27,7 @@ for sha in $(git rev-list --reverse "${base}..${head}"); do
         echo "${sha:0:7} ${subject}: no bench stated"
         continue
     fi
-    git checkout -q --detach "$sha"
-    if ! cargo build --release --quiet --locked; then
+    if ! "$(dirname "$0")/build_at.sh" "$sha" "$bin"; then
         echo "${sha:0:7} ${subject}: bench stated ${stated}, build failed"
         failed=1
         continue
@@ -44,5 +42,4 @@ for sha in $(git rev-list --reverse "${base}..${head}"); do
         failed=1
     fi
 done
-git checkout -q "$start"
 exit "$failed"


### PR DESCRIPTION
Five places built the engine at a commit, four of them by checking it out: `speed.sh`, `verify_bench.sh`, and the speed, strength and calibrate workflows, each with its own checkout / build / copy / put-it-back, and `verify_bench.sh` with restore logic and a test for it. The two match workflows also went without rust-cache because two arbitrary commits built in one checkout would leave the cache holding whichever pair came last.

`scripts/build_at.sh <ref> <binary>` is the one way now. It exports the commit with `git archive` and builds it in a target directory of its own under `<target>/at`, so the working tree is never touched (no branch moves, no half-written file overwritten, nothing to put back). The five sites become one line each and the match workflows take rust-cache, which keeps the export's dependencies as a nested target.

Two things keep cargo honest about an export, and the first push of this branch had neither (the review caught it, see the comment below): the export is stamped with extraction time rather than the commit's, and it does not share the tree's target directory. Otherwise cargo judges the export fresh and hands back the previous binary. The engine is built afresh for every commit; the dependencies are what the target directory keeps.

Measured in a clone: the first export build is 11.6 s (dependencies and engine), each differing commit after that 7.9 s, the same as a checkout build; `verify_bench.sh` over three bench-stating commits takes 34 s and leaves the branch where it was rather than on a detached `HEAD`; `speed.sh` measures a real base commit end to end with the same node counts on both sides.

Tested on a fake repository with a cargo that builds whatever it is told to, wherever it is told to (the binary is the commit's, the tree and a half-written file stay as they were, `CARGO_TARGET_DIR` is honoured, a bad ref fails), and once through real cargo: two commits of a crate that prints which one it is, then the changed tree, each binary held to its own source. That test fails on the first version of the script. No `--locked`, which the match workflows never passed; old baselines would refuse to build with it. Nothing here touches the engine.