### PR TITLE
Fix build_at.sh handing back the previous binary

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -227,8 +227,8 @@ versions against each other with
 [8moves_v3](https://github.com/official-stockfish/books).
 
 ```
-git checkout --detach v0.3.7 && cargo build --release && cp target/release/arche /tmp/old
-git checkout - && cargo build --release && cp target/release/arche /tmp/new
+scripts/build_at.sh v0.3.7 /tmp/old
+cargo build --release && cp target/release/arche /tmp/new
 
 fastchess \
   -engine name=new cmd=/tmp/new \

--- a/scripts/build_at.sh
+++ b/scripts/build_at.sh
@@ -4,28 +4,39 @@
 #     build_at.sh <ref> <binary>
 #
 # The commit is exported with git archive into <target>/at/src, where
-# <target> is CARGO_TARGET_DIR or target/, and built there with <target> as
-# its target directory. The working tree is never checked out: nothing here
+# <target> is CARGO_TARGET_DIR or target/, and built with <target>/at as its
+# target directory. The working tree is never checked out: nothing here
 # moves the branch, the index or a file someone is half way through, and a
 # script building one commit to measure against another has nothing to put
-# back afterwards. The source path is the same for every commit and the
-# target directory is shared, so cargo keeps what it built last time, the
-# dependencies always and the engine when the commit left it alone, the way
-# building in a checkout would.
+# back afterwards.
+#
+# The export has a target directory of its own, and its files are stamped
+# with the time they were extracted rather than the commit's. Both are what
+# keep cargo honest. Cargo tells a crate fresh by its sources being older
+# than its last build, and names a workspace crate's build by the crate and
+# not by where it was built from: so an export stamped with the commit's
+# time looks older than whatever was built last and is handed that binary
+# back, and an export sharing the tree's target directory is taken for the
+# tree. The engine is built afresh for every commit; what the target
+# directory keeps across calls is the dependencies.
+#
+# No --locked: a baseline old enough that its lock file predates a registry
+# change would refuse to build, and the pull request's own tree is held to
+# its lock file by the Rust workflow.
 set -euo pipefail
 
 ref=${1:?usage: build_at.sh <ref> <binary>}
 binary=${2:?usage: build_at.sh <ref> <binary>}
 
-sha=$(git rev-parse --verify --quiet "${ref}^{commit}") \
+sha=$(git rev-parse --verify "${ref}^{commit}") \
     || { echo "build_at.sh: ${ref} is not a commit" >&2; exit 1; }
 # absolute, because the build runs from inside it
-target=$(realpath -m "${CARGO_TARGET_DIR:-target}")
-src="${target}/at/src"
+target=$(realpath -m "${CARGO_TARGET_DIR:-target}")/at
+src="${target}/src"
 
 rm -rf "$src"
 mkdir -p "$src"
-git archive "$sha" | tar -x -C "$src"
-(cd "$src" && cargo build --release --quiet --locked --target-dir "$target")
+git archive "$sha" | tar -xm -C "$src"
+(cd "$src" && cargo build --release --quiet --target-dir "$target")
 mkdir -p "$(dirname "$binary")"
 cp "${target}/release/arche" "$binary"

--- a/scripts/tests/test_build_at.py
+++ b/scripts/tests/test_build_at.py
@@ -7,6 +7,8 @@ tree is never touched to get it, and that the build lands where cargo is
 told to put things.
 """
 
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -104,8 +106,70 @@ def test_the_build_lands_where_cargo_is_told_to_put_it(repo, tmp_path):
     )
     assert result.returncode == 0, result.stderr
     assert prints(tmp_path / "new") == "second\n"
-    assert (elsewhere / "release" / "arche").exists()
+    assert (elsewhere / "at" / "release" / "arche").exists()
     assert not (repo / "target").exists()
+
+
+@pytest.mark.skipif(shutil.which("cargo") is None, reason="needs cargo")
+def test_a_commit_that_changed_the_source_is_built_afresh(tmp_path):
+    # the one test through real cargo, because the failure it guards
+    # against is cargo's: an export stamped with the commit's time looks
+    # older than the last build and is handed that binary back, and an
+    # export sharing the tree's target directory is taken for the tree.
+    # Two commits of a crate that prints which one it is, then the tree
+    # changed again: each build has to say what its own source says
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+
+    def git(*args):
+        return subprocess.run(
+            ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def says(word):
+        (repo / "src" / "main.rs").write_text(f'fn main() {{ println!("{word}"); }}\n')
+
+    git("init", "-q")
+    (repo / "Cargo.toml").write_text(
+        '[package]\nname = "arche"\nversion = "0.0.0"\nedition = "2021"\n'
+    )
+    says("first")
+    git("add", ".")
+    git("commit", "-qm", "first")
+    says("second")
+    git("commit", "-aqm", "second")
+    says("tree")
+
+    # cargo's own configuration comes through, rustup's home among it; the
+    # target directory does not, or the build would land in the caller's
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("CARGO_TARGET_DIR", "CARGO_BUILD_TARGET")
+    }
+    env.setdefault("HOME", str(tmp_path))
+    for ref, word in [("HEAD~1", "first"), ("HEAD", "second")]:
+        result = subprocess.run(
+            [str(SCRIPT), ref, str(tmp_path / word)],
+            cwd=repo,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert prints(tmp_path / word) == f"{word}\n"
+    subprocess.run(
+        ["cargo", "build", "--release", "--quiet"],
+        cwd=repo,
+        env=env,
+        check=True,
+    )
+    assert prints(repo / "target" / "release" / "arche") == "tree\n"
 
 
 def test_a_ref_that_is_not_a_commit_fails(repo, tmp_path):


### PR DESCRIPTION
`build_at.sh` as merged in #90 hands back the previous binary for any commit that only changed Rust source, so until this lands the `speed` job compares a binary with itself, a strength match plays the engine against itself, and `verify_bench` counts every commit after the first on the first's binary. The #90 review caught it and I reproduced it: two commits differing in `engine.rs` built to byte-identical binaries in 0.03 s.

Why: `git archive` stamps files with the commit's time; cargo judges a crate fresh by its sources being older than its last build; and cargo names a workspace crate's build by the crate, not by the path it was built from. So the second export looks older than the first build and gets its binary, and a working-tree build after an export is taken for the export too.

Fix: the export is stamped with extraction time (`tar -m`) and built in a target directory of its own, `<target>/at`. The engine is built afresh for every commit (about 8 s); the target directory keeps the dependencies. `--locked` is dropped: the match workflows never passed it and a baseline older than v0.3.6 refuses to build with it; the Rust workflow still holds the PR's own tree to its lock file.

A test through real cargo builds two commits of a crate that prints which one it is, then the changed tree, and holds each binary to its own source. It fails on the merged script with `'first' == 'second'` — the staleness itself, not incidentally. The manual old-vs-new recipe in `DEVELOPMENT.md` now uses the script.