### PR TITLE
refactor(uci): Read a command's parameters off its words

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,6 @@ name = "arche"
 version = "0.3.10"
 dependencies = [
  "basic_engine",
- "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ name = "arche"
 version = "0.3.10"
 dependencies = [
  "basic_engine",
+ "proptest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ license = "GPL-3.0-or-later"
 [dependencies]
 basic_engine = { path = "./basic_engine" }
 
+[dev-dependencies]
+# already the engine's, so this adds an edge rather than a package
+proptest = "1.7"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ authors = [
 license = "GPL-3.0-or-later"
 
 [dependencies]
-regex = "1"
 basic_engine = { path = "./basic_engine" }
 
 [profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod params;
 mod time_control;
 mod uci;
 
@@ -24,7 +25,7 @@ fn main() -> ExitCode {
             UCI::new_with_engine(e).read_loop();
             ExitCode::SUCCESS
         }
-        Some("bench") => match uci::bench_depth(&args.join(" ")) {
+        Some("bench") => match uci::bench_depth(&params::Params::of(&args.join(" "))) {
             Ok(depth) => {
                 println!(
                     "{}",

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,0 +1,239 @@
+//! Reading the parameters off a UCI command.
+//!
+//! A command is a line of whitespace separated words, and a parameter is a
+//! keyword followed by its value: `go wtime 300000 winc 2000 movestogo 40`.
+//! The words are split once and asked for what the command takes, rather than
+//! the line being searched again for every keyword.
+//!
+//! Whole words throughout. A keyword only counts where it stands as a word of
+//! its own, so `movetime 500` cannot be read as a value for `time`, and a
+//! position whose fen happens to contain a keyword cannot be read as carrying
+//! one.
+
+use std::num::IntErrorKind;
+use std::str::FromStr;
+
+/// The words of one command line.
+pub(crate) struct Params<'a> {
+    words: Vec<&'a str>,
+}
+
+/// What reading one parameter found.
+///
+/// Which of the three is worth acting on differs by parameter, so this says
+/// what happened rather than deciding: an unreadable clock is safest read as a
+/// spent one, since discarding it would leave the search unbounded at the
+/// moment there is least time to spare, while an unreadable depth is better
+/// ignored than obeyed as zero, which would return no move at all.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Param<'a, T> {
+    /// The keyword is not among the words, or is the last of them and so has
+    /// nothing after it to read.
+    Absent,
+    /// The keyword is there and what follows it is not a value. Carries the
+    /// word, for a caller that wants to say which it was.
+    Unreadable(&'a str),
+    Read(T),
+}
+
+impl<'a> Params<'a> {
+    pub(crate) fn of(line: &'a str) -> Self {
+        Self {
+            words: line.split_whitespace().collect(),
+        }
+    }
+
+    /// Whether `keyword` stands among the words on its own.
+    pub(crate) fn flag(&self, keyword: &str) -> bool {
+        self.words.contains(&keyword)
+    }
+
+    /// The word following `keyword`, if the keyword is there and is not last.
+    pub(crate) fn value(&self, keyword: &str) -> Option<&'a str> {
+        let at = self.words.iter().position(|word| *word == keyword)?;
+        self.words.get(at + 1).copied()
+    }
+
+    /// A count of milliseconds or nodes, read the way the protocol's unsigned
+    /// parameters have to be read.
+    ///
+    /// Two values that are not counts are still meant rather than mistyped.
+    /// Below zero is what the match tools send once their time margin has been
+    /// eaten into, and says the clock is spent rather than that the line is
+    /// bad. Too large to hold is a request for everything there is. Both are
+    /// read; only a word that is no kind of number is `Unreadable`.
+    pub(crate) fn count(&self, keyword: &str) -> Param<'a, u64> {
+        let Some(word) = self.value(keyword) else {
+            return Param::Absent;
+        };
+        match word.parse::<u64>() {
+            Ok(count) => Param::Read(count),
+            Err(error) => match error.kind() {
+                IntErrorKind::PosOverflow => Param::Read(u64::MAX),
+                // u64 rejects every negative, so this is the sign test
+                IntErrorKind::InvalidDigit if is_negative(word) => Param::Read(0),
+                _ => Param::Unreadable(word),
+            },
+        }
+    }
+
+    /// A parameter parsed as whatever the caller asks for, with none of the
+    /// leniency `count` applies. What will not parse is `Unreadable`, which is
+    /// what a command wants when the wrong value is worth refusing rather than
+    /// rounding: `bench 300` is a typo for a depth, not a request for one.
+    pub(crate) fn parse<T: FromStr>(&self, keyword: &str) -> Param<'a, T> {
+        match self.value(keyword) {
+            None => Param::Absent,
+            Some(word) => match word.parse() {
+                Ok(value) => Param::Read(value),
+                Err(_) => Param::Unreadable(word),
+            },
+        }
+    }
+}
+
+/// Whether the word is a negative number rather than something that is no
+/// number at all. Anything after the sign has to be digits, and there has to
+/// be at least one, so a bare `-` is not one.
+fn is_negative(word: &str) -> bool {
+    match word.strip_prefix('-') {
+        Some(digits) => !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()),
+        None => false,
+    }
+}
+
+impl<'a, T> Param<'a, T> {
+    /// The value read, with an absent or unreadable parameter alike discarded.
+    pub(crate) fn read(self) -> Option<T> {
+        match self {
+            Param::Read(value) => Some(value),
+            Param::Absent | Param::Unreadable(_) => None,
+        }
+    }
+
+    /// The value read, with an unreadable parameter standing in as `instead`.
+    /// An absent one is still absent: a parameter that was not sent is not the
+    /// same as one that was sent wrong.
+    pub(crate) fn read_or(self, instead: T) -> Option<T> {
+        match self {
+            Param::Read(value) => Some(value),
+            Param::Unreadable(_) => Some(instead),
+            Param::Absent => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Param, Params};
+
+    #[test]
+    fn a_value_is_the_word_after_its_keyword() {
+        let params = Params::of("go wtime 300000 winc 2000");
+        assert_eq!(params.value("wtime"), Some("300000"));
+        assert_eq!(params.value("winc"), Some("2000"));
+        assert_eq!(params.value("btime"), None);
+    }
+
+    #[test]
+    fn a_keyword_only_counts_as_a_whole_word() {
+        // the value belongs to movetime, and nothing here says time
+        let params = Params::of("go movetime 500");
+        assert_eq!(params.value("time"), None);
+        assert_eq!(params.count("time"), Param::Absent);
+        assert_eq!(params.count("movetime"), Param::Read(500));
+        assert!(!params.flag("move"));
+        assert!(params.flag("movetime"));
+    }
+
+    #[test]
+    fn a_keyword_with_nothing_after_it_is_absent() {
+        let params = Params::of("go depth");
+        assert!(params.flag("depth"));
+        assert_eq!(params.count("depth"), Param::Absent);
+    }
+
+    #[test]
+    fn any_amount_of_space_separates_words() {
+        let params = Params::of("  go   wtime\t300000  ");
+        assert_eq!(params.count("wtime"), Param::Read(300_000));
+    }
+
+    #[test]
+    fn a_count_below_zero_is_a_spent_one() {
+        // what the match tools send once their time margin has been eaten into
+        let params = Params::of("go wtime -5 btime -0 winc -99999999999999999999");
+        assert_eq!(params.count("wtime"), Param::Read(0));
+        assert_eq!(params.count("btime"), Param::Read(0));
+        assert_eq!(params.count("winc"), Param::Read(0));
+    }
+
+    #[test]
+    fn a_count_too_large_to_hold_is_the_largest_we_can() {
+        let params = Params::of("go wtime 99999999999999999999999");
+        assert_eq!(params.count("wtime"), Param::Read(u64::MAX));
+    }
+
+    #[test]
+    fn a_word_that_is_no_number_at_all_is_unreadable() {
+        let params = Params::of("go wtime abc btime - winc 1e3 binc +");
+        assert_eq!(params.count("wtime"), Param::Unreadable("abc"));
+        assert_eq!(params.count("btime"), Param::Unreadable("-"));
+        assert_eq!(params.count("winc"), Param::Unreadable("1e3"));
+        assert_eq!(params.count("binc"), Param::Unreadable("+"));
+    }
+
+    #[test]
+    fn a_leading_plus_is_a_count() {
+        // rust's integer parser takes one, and nothing is gained by refusing
+        let params = Params::of("go wtime +300000");
+        assert_eq!(params.count("wtime"), Param::Read(300_000));
+    }
+
+    #[test]
+    fn parse_refuses_what_will_not_fit_rather_than_rounding_it() {
+        let params = Params::of("bench 300");
+        assert_eq!(params.parse::<u8>("bench"), Param::Unreadable("300"));
+        assert_eq!(Params::of("bench 7").parse::<u8>("bench"), Param::Read(7u8));
+        assert_eq!(Params::of("bench").parse::<u8>("bench"), Param::Absent);
+    }
+
+    #[test]
+    fn read_discards_both_kinds_of_missing_value() {
+        assert_eq!(Params::of("go").count("wtime").read(), None);
+        assert_eq!(Params::of("go wtime x").count("wtime").read(), None);
+        assert_eq!(Params::of("go wtime 5").count("wtime").read(), Some(5));
+    }
+
+    #[test]
+    fn read_or_stands_in_for_an_unreadable_value_but_not_an_absent_one() {
+        assert_eq!(Params::of("go").count("wtime").read_or(0), None);
+        assert_eq!(Params::of("go wtime x").count("wtime").read_or(0), Some(0));
+        assert_eq!(Params::of("go wtime 5").count("wtime").read_or(0), Some(5));
+    }
+
+    #[test]
+    fn an_empty_line_has_no_parameters_and_does_not_panic() {
+        let params = Params::of("");
+        assert_eq!(params.value("wtime"), None);
+        assert_eq!(params.count("wtime"), Param::Absent);
+        assert!(!params.flag("infinite"));
+    }
+
+    #[test]
+    fn a_keyword_used_twice_reads_the_first() {
+        // the protocol does not send one twice; reading the first is what a
+        // left to right scan does and is worth pinning either way
+        let params = Params::of("go wtime 100 wtime 200");
+        assert_eq!(params.count("wtime"), Param::Read(100));
+    }
+
+    #[test]
+    fn a_value_may_be_a_keyword_of_its_own() {
+        // nothing stops an interface sending them adjacent, and the scan must
+        // not lose the second one
+        let params = Params::of("go depth infinite");
+        assert_eq!(params.count("depth"), Param::Unreadable("infinite"));
+        assert!(params.flag("infinite"));
+    }
+}

--- a/src/params.rs
+++ b/src/params.rs
@@ -237,3 +237,137 @@ mod tests {
         assert!(params.flag("infinite"));
     }
 }
+
+#[cfg(test)]
+mod properties {
+    use super::{Param, Params};
+    use proptest::prelude::*;
+
+    /// A keyword, in the shape the protocol's are: lower case letters, never a
+    /// number, so it can never be mistaken for a value.
+    fn keyword() -> impl Strategy<Value = String> {
+        "[a-z]{1,10}".prop_map(String::from)
+    }
+
+    /// One word, whatever it is made of, as long as it survives being split on
+    /// whitespace as a single one.
+    fn word() -> impl Strategy<Value = String> {
+        r"[^\s]{1,16}".prop_map(String::from)
+    }
+
+    proptest! {
+        /// The parser is fed whatever an interface sends, which on a bad day is
+        /// anything at all. Nothing it can be given may panic, and this asks
+        /// every accessor with an arbitrary keyword against an arbitrary line.
+        #[test]
+        fn nothing_read_out_of_anything_panics(line in any::<String>(), keyword in any::<String>()) {
+            let params = Params::of(&line);
+            let _ = params.flag(&keyword);
+            let _ = params.value(&keyword);
+            let _ = params.count(&keyword);
+            let _ = params.parse::<u8>(&keyword);
+            let _ = params.parse::<u64>(&keyword);
+            let _ = params.parse::<usize>(&keyword);
+        }
+
+        /// Any count the protocol could send reads back as itself.
+        #[test]
+        fn a_count_reads_back_as_itself(keyword in keyword(), value in any::<u64>()) {
+            let line = format!("{} {}", keyword, value);
+            prop_assert_eq!(Params::of(&line).count(&keyword), Param::Read(value));
+        }
+
+        /// However far below zero, a clock reads as spent rather than as
+        /// something that could not be read.
+        #[test]
+        fn any_negative_count_is_a_spent_one(keyword in keyword(), digits in "[0-9]{1,40}") {
+            let line = format!("{} -{}", keyword, digits);
+            prop_assert_eq!(Params::of(&line).count(&keyword), Param::Read(0));
+        }
+
+        /// However far above what a word holds, a count reads as the largest
+        /// one rather than as unreadable: it is a request for everything there
+        /// is, and discarding it would read as the keyword having been absent.
+        #[test]
+        fn any_count_too_large_is_the_largest_one(keyword in keyword(), digits in "[1-9][0-9]{20,40}") {
+            let line = format!("{} {}", keyword, digits);
+            prop_assert_eq!(Params::of(&line).count(&keyword), Param::Read(u64::MAX));
+        }
+
+        /// Every keyword of a line reads its own value and none of its
+        /// neighbours', which is what a walk one word at a time has to get
+        /// right and an index off by one would not.
+        #[test]
+        fn every_keyword_reads_its_own_value(
+            pairs in prop::collection::vec((keyword(), any::<u32>()), 1..8),
+        ) {
+            let line = pairs
+                .iter()
+                .map(|(keyword, value)| format!("{} {}", keyword, value))
+                .collect::<Vec<_>>()
+                .join(" ");
+            let params = Params::of(&line);
+            // a keyword sent twice reads the first of them, so ask each only
+            // about the first time it appears
+            let mut asked: Vec<&str> = Vec::new();
+            for (keyword, value) in &pairs {
+                if asked.contains(&keyword.as_str()) {
+                    continue;
+                }
+                asked.push(keyword);
+                prop_assert_eq!(params.count(keyword), Param::Read(u64::from(*value)));
+            }
+        }
+
+        /// How much space stands between two words does not change which is
+        /// the value of which.
+        #[test]
+        fn spacing_does_not_change_what_is_read(
+            keyword in keyword(),
+            value in any::<u64>(),
+            before in "[ 	]{1,4}",
+            between in "[ 	]{1,4}",
+            after in "[ 	]{0,4}",
+        ) {
+            let line = format!("{}{}{}{}{}", before, keyword, between, value, after);
+            prop_assert_eq!(Params::of(&line).count(&keyword), Param::Read(value));
+        }
+
+        /// A keyword is a whole word. Buried inside a longer one it is not
+        /// there at all, which is what the regexes this replaced got wrong.
+        #[test]
+        fn a_keyword_inside_a_longer_word_is_absent(
+            keyword in keyword(),
+            prefix in "[a-z]{1,6}",
+            value in any::<u64>(),
+        ) {
+            let line = format!("{}{} {}", prefix, keyword, value);
+            prop_assert_eq!(Params::of(&line).count(&keyword), Param::Absent);
+            prop_assert!(!Params::of(&line).flag(&keyword));
+        }
+
+        /// The strict read is the standard library's, and differs from it only
+        /// in saying which word would not parse.
+        #[test]
+        fn the_strict_read_agrees_with_the_standard_library(
+            keyword in keyword(),
+            word in word(),
+        ) {
+            let line = format!("{} {}", keyword, word);
+            let read: Param<u8> = Params::of(&line).parse(&keyword);
+            match word.parse::<u8>() {
+                Ok(value) => prop_assert_eq!(read, Param::Read(value)),
+                Err(_) => prop_assert_eq!(read, Param::Unreadable(&word)),
+            }
+        }
+
+        /// A parameter is absent exactly when there is no word after its
+        /// keyword, whatever that word turns out to be.
+        #[test]
+        fn absent_means_no_word_followed_the_keyword(line in ".*", keyword in keyword()) {
+            let params = Params::of(&line);
+            let absent = matches!(params.count(&keyword), Param::Absent);
+            prop_assert_eq!(absent, params.value(&keyword).is_none());
+        }
+    }
+}

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,3 +1,4 @@
+use crate::params::{Param, Params};
 use crate::time_control::TimeControl;
 use basic_engine::Color;
 use basic_engine::Engine;
@@ -6,48 +7,31 @@ use basic_engine::SearchOutcome;
 use basic_engine::SearchParameters;
 use basic_engine::bench;
 use basic_engine::{PvLine, SearchResult};
-use regex::Regex;
 use std::io::{BufRead, Stdout, Write};
-use std::sync::LazyLock;
 use std::time::Duration;
 
-static WTIME_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"wtime (-?\d+)").unwrap());
-static BTIME_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"btime (-?\d+)").unwrap());
-static WINC_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"winc (-?\d+)").unwrap());
-static BINC_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"binc (-?\d+)").unwrap());
-static MOVES_TO_GO_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"movestogo (\d+)").unwrap());
-static MOVE_TIME: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"movetime (\d+)").unwrap());
-static DEPTH_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"depth (\d+)").unwrap());
-static NODES_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"nodes (\d+)").unwrap());
-static PERFT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"perft (\d+)").unwrap());
-
-/// Reads the value that follows a keyword. A clock below zero, which the match
-/// tools send once their time margin has been eaten into, reads as an empty
-/// one. Otherwise the value is digits, so the only way it can fail to parse is
-/// by being too large to hold, in which case use the largest value we can.
-/// Discarding either would read as the keyword having been absent, which for
-/// a clock means searching without a limit.
-fn capture(re: &Regex, line: &str) -> Option<u64> {
-    let digits = re.captures(line)?.get(1)?.as_str();
-    if digits.starts_with('-') {
-        return Some(0);
-    }
-    Some(digits.parse().unwrap_or(u64::MAX))
-}
-
-fn time_control_from(line: &str, color: Color) -> TimeControl {
+/// The time part of a `go` command, from the point of view of the side to
+/// move.
+///
+/// A clock or a move time that was sent but cannot be read stands in as spent
+/// rather than being discarded, because discarding it would read as the
+/// keyword having been absent, and a `go` with no time at all searches without
+/// a limit. That trades one bad outcome for a smaller one: an unreadable move
+/// time beside a good clock spends the clock rather than reading it, and moves
+/// almost at once. Playing a weak move is recoverable and thinking for ever is
+/// not. A count of moves is left alone instead: it only divides the clock, and
+/// the time control already treats a missing one as a number to assume.
+fn time_control_from(params: &Params, color: Color) -> TimeControl {
+    let (clock, increment) = match color {
+        Color::White => ("wtime", "winc"),
+        Color::Black => ("btime", "binc"),
+    };
     TimeControl {
-        time: match color {
-            Color::White => capture(&WTIME_RE, line),
-            Color::Black => capture(&BTIME_RE, line),
-        },
-        increment: match color {
-            Color::White => capture(&WINC_RE, line),
-            Color::Black => capture(&BINC_RE, line),
-        },
-        moves_to_go: capture(&MOVES_TO_GO_RE, line),
-        move_time: capture(&MOVE_TIME, line),
-        infinite: line.contains("infinite"),
+        time: params.count(clock).read_or(0),
+        increment: params.count(increment).read_or(0),
+        moves_to_go: params.count("movestogo").read(),
+        move_time: params.count("movetime").read_or(0),
+        infinite: params.flag("infinite"),
     }
 }
 
@@ -144,7 +128,7 @@ impl<T: Engine, W: Write> UCI<T, W> {
             // `bench [depth]`, the same as the command line argument: the
             // depth is for trying the command cheaply, the number that means
             // anything is the one at the default
-            match bench_depth(line) {
+            match bench_depth(&Params::of(line)) {
                 Ok(depth) => {
                     let report = bench::run_suite(
                         &bench::positions(),
@@ -160,7 +144,7 @@ impl<T: Engine, W: Write> UCI<T, W> {
                 )),
             }
         } else if line.starts_with("perft") {
-            let depth = perft_depth(line);
+            let depth = perft_depth(&Params::of(line));
             let nodes = self.engine.perft(depth);
             self.say(format_args!(
                 "info string perft depth {} nodes {}",
@@ -200,10 +184,13 @@ impl<T: Engine, W: Write> UCI<T, W> {
     }
 
     fn parse_go(&mut self, line: &str) {
+        let params = Params::of(line);
         let mut sp = SearchParameters::new();
-        sp.search_duration = time_control_from(line, self.engine.active_color()).budget();
-        sp.depth = go_depth(line);
-        sp.nodes = capture(&NODES_RE, line);
+        sp.search_duration = time_control_from(&params, self.engine.active_color()).budget();
+        sp.depth = go_depth(&params);
+        // an unreadable node limit is ignored rather than obeyed as zero,
+        // which would stop the search before it had a move to report
+        sp.nodes = params.count("nodes").read();
 
         let start = sp.start_time;
         // the closure writes while the engine is borrowed for the search, so
@@ -232,25 +219,33 @@ impl<T: Engine, W: Write> UCI<T, W> {
 /// The depth asked of a go command, if one was. A depth too big for a byte
 /// is a request to go deep, not a reason to refuse the command, so it is
 /// clamped to the most a byte holds rather than rejected.
-fn go_depth(line: &str) -> Option<u8> {
-    capture(&DEPTH_RE, line).map(|depth| depth.try_into().unwrap_or(u8::MAX))
+fn go_depth(params: &Params) -> Option<u8> {
+    params
+        .count("depth")
+        .read()
+        .map(|depth| depth.try_into().unwrap_or(u8::MAX))
 }
 
 /// The depth asked of a bench command or argument: the word after `bench`,
 /// or the bench's own depth when there is none. A word that is not a depth
 /// comes back as the error, for the caller to say so; running the default in
 /// its place would take seconds and explain nothing.
-pub(crate) fn bench_depth(line: &str) -> Result<u8, String> {
-    match line.split_whitespace().nth(1) {
-        None => Ok(bench::DEPTH),
-        Some(word) => word.parse().map_err(|_| word.to_string()),
+pub(crate) fn bench_depth(params: &Params) -> Result<u8, String> {
+    match params.parse::<u8>("bench") {
+        Param::Absent => Ok(bench::DEPTH),
+        Param::Read(depth) => Ok(depth),
+        Param::Unreadable(word) => Err(word.to_string()),
     }
 }
 
 /// The depth asked of a perft command. A bare `perft` counts to depth one,
-/// which is what the command did before it took a depth at all.
-fn perft_depth(line: &str) -> u8 {
-    capture(&PERFT_RE, line)
+/// which is what the command did before it took a depth at all. Unlike the
+/// bench, a depth too big for a byte is clamped rather than refused: perft is
+/// asked for by hand and the answer to too deep is to wait or interrupt.
+fn perft_depth(params: &Params) -> u8 {
+    params
+        .count("perft")
+        .read()
         .map(|depth| depth.try_into().unwrap_or(u8::MAX))
         .unwrap_or(1)
 }
@@ -459,7 +454,7 @@ mod tests {
     fn each_colour_reads_its_own_clock() {
         let line = "go wtime 111 btime 222 winc 333 binc 444 movestogo 5";
         assert_eq!(
-            time_control_from(line, Color::White),
+            time_control_from(&Params::of(line), Color::White),
             TimeControl {
                 time: Some(111),
                 increment: Some(333),
@@ -469,7 +464,7 @@ mod tests {
             }
         );
         assert_eq!(
-            time_control_from(line, Color::Black),
+            time_control_from(&Params::of(line), Color::Black),
             TimeControl {
                 time: Some(222),
                 increment: Some(444),
@@ -482,7 +477,7 @@ mod tests {
 
     #[test]
     fn a_missing_clock_for_our_colour_is_not_taken_from_the_other() {
-        let control = time_control_from("go btime 222 binc 444", Color::White);
+        let control = time_control_from(&Params::of("go btime 222 binc 444"), Color::White);
         assert_eq!(control.time, None);
         assert_eq!(control.increment, None);
     }
@@ -490,18 +485,18 @@ mod tests {
     #[test]
     fn move_time_and_infinite_are_read() {
         assert_eq!(
-            time_control_from("go movetime 500", Color::White).move_time,
+            time_control_from(&Params::of("go movetime 500"), Color::White).move_time,
             Some(500)
         );
-        assert!(time_control_from("go infinite", Color::White).infinite);
-        assert!(!time_control_from("go wtime 1000", Color::White).infinite);
+        assert!(time_control_from(&Params::of("go infinite"), Color::White).infinite);
+        assert!(!time_control_from(&Params::of("go wtime 1000"), Color::White).infinite);
     }
 
     #[test]
     fn a_clock_too_large_to_hold_is_not_read_as_absent() {
         let line = "go wtime 99999999999999999999999";
         assert_eq!(
-            time_control_from(line, Color::White).time,
+            time_control_from(&Params::of(line), Color::White).time,
             Some(u64::MAX),
             "an unreadable clock must not turn into an unlimited search"
         );
@@ -513,17 +508,52 @@ mod tests {
         // margin has been eaten into. Not reading it would leave the budget
         // unset and search without a limit, at the moment there is the least
         // time to spare
-        let control = time_control_from("go wtime -5 btime -5", Color::White);
+        let control = time_control_from(&Params::of("go wtime -5 btime -5"), Color::White);
         assert_eq!(control.time, Some(0));
-        let control = time_control_from("go wtime -5 btime -5 winc -1 binc -1", Color::Black);
+        let control = time_control_from(
+            &Params::of("go wtime -5 btime -5 winc -1 binc -1"),
+            Color::Black,
+        );
         assert_eq!(control.time, Some(0));
         assert_eq!(control.increment, Some(0));
     }
 
     #[test]
+    fn a_clock_that_cannot_be_read_is_a_spent_one_rather_than_no_clock() {
+        // discarding it would read as the keyword having been absent, and a
+        // go with no time at all searches without a limit
+        let control = time_control_from(&Params::of("go wtime abc winc x"), Color::White);
+        assert_eq!(control.time, Some(0));
+        assert_eq!(control.increment, Some(0));
+        assert!(
+            control.budget().is_some(),
+            "an unreadable clock must still bound the search"
+        );
+    }
+
+    #[test]
+    fn an_unreadable_limit_is_ignored_rather_than_obeyed_as_zero() {
+        // zero would be a limit of nothing, and the search would come back
+        // without a move rather than without a limit
+        assert_eq!(go_depth(&Params::of("go depth abc")), None);
+        assert_eq!(Params::of("go nodes abc").count("nodes").read(), None);
+    }
+
+    #[test]
+    fn a_keyword_inside_a_longer_word_is_not_one() {
+        // the regexes this replaced had no word boundary, so a clock could be
+        // read out of the middle of another token
+        let control = time_control_from(&Params::of("go xwtime 300000"), Color::White);
+        assert_eq!(control.time, None);
+    }
+
+    #[test]
     fn a_node_limit_is_read() {
-        assert_eq!(capture(&NODES_RE, "go nodes 1234"), Some(1234));
-        assert_eq!(capture(&NODES_RE, "go depth 3"), None);
+        assert_eq!(
+            Params::of("go nodes 1234").count("nodes").read(),
+            Some(1234)
+        );
+        assert_eq!(Params::of("go depth 3").count("nodes").read(), None);
     }
 
     #[test]
@@ -545,9 +575,9 @@ mod tests {
 
     #[test]
     fn a_depth_too_big_for_a_byte_is_clamped_rather_than_refused() {
-        assert_eq!(go_depth("go depth 5"), Some(5));
-        assert_eq!(go_depth("go depth 999"), Some(u8::MAX));
-        assert_eq!(go_depth("go infinite"), None);
+        assert_eq!(go_depth(&Params::of("go depth 5")), Some(5));
+        assert_eq!(go_depth(&Params::of("go depth 999")), Some(u8::MAX));
+        assert_eq!(go_depth(&Params::of("go infinite")), None);
     }
 
     #[test]
@@ -582,9 +612,13 @@ mod tests {
 
     #[test]
     fn a_perft_command_reads_its_depth() {
-        assert_eq!(perft_depth("perft 3"), 3);
-        assert_eq!(perft_depth("perft"), 1, "a bare perft counts to depth one");
-        assert_eq!(perft_depth("perft 999"), u8::MAX);
+        assert_eq!(perft_depth(&Params::of("perft 3")), 3);
+        assert_eq!(
+            perft_depth(&Params::of("perft")),
+            1,
+            "a bare perft counts to depth one"
+        );
+        assert_eq!(perft_depth(&Params::of("perft 999")), u8::MAX);
     }
 
     #[test]


### PR DESCRIPTION
Eight regexes read one parameter each and each scanned the whole line for its
own keyword. Two things followed. They carried no word boundary, so
`go xwtime 300000` handed white a clock. And the value had to be digits to
match at all, so `go wtime abc` read as no clock and searched without a limit,
which is the outcome the old comment said it was avoiding.

`src/params.rs` splits a line into words once and answers questions about them.
`count` applies the protocol's rules for an unsigned parameter: below zero is a
spent clock, too large is everything there is, and only a word that is no kind
of number is unreadable. `parse` is the strict read for a value worth refusing
rather than rounding, which is what the bench wants — a depth of three hundred
is a typo, not a request.

Reading a parameter can end three ways and which to act on differs by
parameter, so `Param` says what happened rather than deciding. An unreadable
clock stands in as spent, since discarding it reads as absent. An unreadable
depth or node limit is discarded, since zero would be a limit of nothing.

`regex` was the root crate's only dependency and is gone. The release binary
goes from 2,251,096 bytes to 649,240.

Checks: bench 42,847,751, unchanged, and no `Bench:` trailer since `uci` is
outside the engine scopes. fmt and clippy clean. 60 + 104 tests release,
60 + 105 debug, up from 43 with fourteen for the parser and three pinning the
behaviour changes above. Every `go` parameter shape driven end to end through
the built binary.

Reviewed in-session rather than by a second agent, since none was available.

---

Second commit adds property tests that fuzz the parser. The first is that
nothing it can be given panics — an arbitrary keyword asked of an arbitrary
line, through every accessor. The rest state what the parser is for: any count
reads back as itself, a negative one is a spent clock however far below zero,
one too large is the largest there is, every keyword reads its own value and
not a neighbour's, spacing does not matter, a keyword buried in a longer word
is absent, and the strict read agrees with the standard library.

They were checked by breaking the parser three ways rather than by watching
them pass: losing the negative rule fails one property, an off-by-one in the
value scan fails six, and matching a keyword as a substring rather than a word
fails the two written for it.

`proptest` is already the engine's dev dependency, so this adds an edge rather
than a package. 69 + 104 tests release, 69 + 105 debug, and the properties hold
at 8192 cases each.
